### PR TITLE
chore: fix pnpm warnings when package-lock = false

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,4 @@ shamefully-hoist = false
 shared-workspace-shrinkwrap = true
 access = public
 enable-pre-post-scripts = true
+package-lock = true


### PR DESCRIPTION
I kept getting the "WARN  A pnpm-lock.yaml file exists. The current configuration prohibits to read or write a lockfile" warning with pnpm and it was because I had this set to false at the profile level (I work mostly on modules, and keep it off by default). As long as we are using lock files in this repo, let's keep this setting pinned down correctly.