### PR TITLE
Remove outline on menu

### DIFF
--- a/packages/ui/src/components/Profile.tsx
+++ b/packages/ui/src/components/Profile.tsx
@@ -34,7 +34,6 @@ const Pill = styled.div`
 
 const Menu = styled.ul`
   background: #17181c;
-  outline: 4px solid #17181c;
   box-shadow: 0px 10px 30px rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(20px);
   border-radius: 16px;


### PR DESCRIPTION
This outline looked out of place

Before:
<img width="378" alt="Screen Shot 2021-09-20 at 12 18 22 PM" src="https://user-images.githubusercontent.com/166301/134053748-1149b34d-5b25-4685-ba02-6d5039a33cb4.png">

After:

<img width="316" alt="Screen Shot 2021-09-20 at 12 19 24 PM" src="https://user-images.githubusercontent.com/166301/134053846-628d1acf-4810-45bf-aabb-e81b8a600e64.png">

