### PR TITLE
fix: fixes clsx spelling error which caused error to be thrown

### DIFF
--- a/packages/ui/src/components/NetworkSelect/NetworkSelect.tsx
+++ b/packages/ui/src/components/NetworkSelect/NetworkSelect.tsx
@@ -82,7 +82,7 @@ export const NetworkSelect = ({
           <ChainOption
             aria-selected={true}
             chain={currentChain}
-            className={cslx(ButtonStyles, classNames.current)}
+            className={clsx(ButtonStyles, classNames.current)}
             onClick={toggle}
             iconClassName={clsx(classNames.icon)}
             padding="6"


### PR DESCRIPTION
`cslx` -> `clsx`