### PR TITLE
fix: enables chain switching from a dapp with walletconnect 

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -11,7 +11,7 @@
     "@rainbow-me/kit-utils": "workspace:*",
     "@vanilla-extract/next-plugin": "^1.0.1",
     "@web3-react/injected-connector": "^6.0.7",
-    "@web3-react/walletconnect-connector": "^6.2.8",
+    "@web3-react/walletconnect-connector": "6.2.4",
     "@web3-react/walletlink-connector": "^6.2.8",
     "next": "^12.0.4",
     "react": "^17.0.2",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -47,7 +47,7 @@
   "optionalDependencies": {
     "@web3-react/frame-connector": "^6.0.9",
     "@web3-react/injected-connector": "^6.0.7",
-    "@web3-react/walletconnect-connector": "^6.2.8",
+    "@web3-react/walletconnect-connector": "6.2.4",
     "@web3-react/walletlink-connector": "^6.2.8"
   },
   "repository": {


### PR DESCRIPTION
web3-react's `walletconnect-connector` seems borked for at least last three versions. [See thread here](https://github.com/NoahZinsmeister/web3-react/issues/310). Downgrading fixes this issue.

I was seeing sometimes multiple requests for the same chain switch, i.e. two prompts for switching to the same chain. That needs to be validated/resolved before merging. We also might be missing or have incorrect RPC urls for certain chains, need to validate that, saw some errors there. 