### PR TITLE
chore: run tsc during lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "postinstall": "husky install",
-    "lint": "eslint . --ext=js,mjs,ts,cjs,tsx",
+    "lint": "eslint . --ext=js,mjs,ts,cjs,tsx && pnpm typecheck -r",
     "format": "prettier --check \"./**/*.{ts,js,mjs,cjs,md,tsx}\"",
     "format:fix": "prettier --write \"./**/*.{ts,js,mjs,cjs,md,tsx}\"",
     "test:run": "tsm --experimental-specifier-resolution=node node_modules/uvu/bin.js tests",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
     "build": "node build.js",
     "prepare": "pnpm build",
     "prebuild": "pnpm typegen",
+    "typecheck": "pnpm tsc --noEmit",
     "typegen": "tsc --emitDeclarationOnly || true"
   },
   "repository": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -18,7 +18,8 @@
     "react-dom": "^17.0.2"
   },
   "scripts": {
-    "dev": "next"
+    "dev": "next",
+    "typecheck": "pnpm tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -18,6 +18,7 @@
     "build": "node build.js",
     "prepare": "pnpm build",
     "prebuild": "pnpm typegen",
+    "typecheck": "pnpm tsc --noEmit",
     "typegen": "tsc --emitDeclarationOnly || true"
   },
   "description": "React hooks for RainbowKit",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -19,6 +19,7 @@
     "build:watch": "node build.js --watch",
     "prepare": "pnpm build",
     "prebuild": "pnpm typegen",
+    "typecheck": "pnpm tsc --noEmit",
     "typegen": "tsc --emitDeclarationOnly || true"
   },
   "keywords": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,6 +19,7 @@
     "build:watch": "node build.js --watch",
     "prepare": "pnpm build",
     "prebuild": "pnpm typegen",
+    "typecheck": "pnpm tsc --noEmit",
     "typegen": "tsc --emitDeclarationOnly || true"
   },
   "keywords": [

--- a/packages/use-ens/package.json
+++ b/packages/use-ens/package.json
@@ -15,6 +15,7 @@
     "build": "node build.js",
     "prepare": "pnpm build",
     "prebuild": "pnpm typegen",
+    "typecheck": "pnpm tsc --noEmit",
     "typegen": "tsc --emitDeclarationOnly || true"
   },
   "keywords": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,6 +8,7 @@
     "build": "node build.js",
     "prepare": "pnpm build",
     "prebuild": "pnpm typegen",
+    "typecheck": "pnpm tsc --noEmit",
     "typegen": "tsc --emitDeclarationOnly || true"
   },
   "description": "A collection of utilities for RainbowKit",


### PR DESCRIPTION
Noticed type errors don't fail the build. This adds a `typecheck` script to each package which is then run from the root-level `lint` script.