### PR TITLE
refactor: configure TypeScript to use strict mode

### DIFF
--- a/packages/hooks/src/useENSWithAvatar.ts
+++ b/packages/hooks/src/useENSWithAvatar.ts
@@ -16,7 +16,9 @@ export const useENSWithAvatar = <T extends BaseProvider = Web3Provider>({
       const getENSInfo = async () => {
         const domain = await provider.lookupAddress(address)
 
+        // @ts-expect-error domain could be null?
         setEnsDomain(domain)
+        // @ts-expect-error domain could be null?
         const resolver = await provider.getResolver(domain)
         if (resolver) {
           const avatar = await resolver.getText('avatar')

--- a/packages/hooks/src/useExplorerTxHistory.ts
+++ b/packages/hooks/src/useExplorerTxHistory.ts
@@ -22,7 +22,7 @@ export const useExplorerTxHistory = <Tx = any, P extends BaseProvider = Web3Prov
   options?: any
 }) => {
   const [loading, setLoading] = useState(true)
-  const [data, setData] = useState<Tx[]>()
+  const [data, setData] = useState<Tx[]>([])
   const [error, setError] = useState<Error & { data?: { message: string; code: string } }>()
 
   useEffect(() => {

--- a/packages/hooks/src/useTxHistory.ts
+++ b/packages/hooks/src/useTxHistory.ts
@@ -84,7 +84,8 @@ export const useTxHistory = ({
 
   useEffect(() => {
     if (rememberHistory) {
-      const txes = safeJSONParse(localStorage.getItem('rk-tx-history')) || []
+      const txHistory = localStorage.getItem('rk-tx-history')
+      const txes = txHistory ? safeJSONParse(txHistory) ?? [] : []
 
       set(txes)
     }

--- a/packages/modal/src/components/Modal.tsx
+++ b/packages/modal/src/components/Modal.tsx
@@ -85,7 +85,13 @@ const WalletIcon = ({ wallet, connect }: { wallet: Wallet } & Partial<Pick<Modal
 
   return (
     <li className={styles.WalletOption} key={name}>
-      <button onClick={() => void connect(wallet)} className={styles.ButtonOption}>
+      <button
+        onClick={() => {
+          // @ts-expect-error connect could be undefined?
+          connect(wallet)
+        }}
+        className={styles.ButtonOption}
+      >
         <WalletLabel>
           <Icon {...{ name, logoURI }} className={styles.OptionIcon} />
           {name}

--- a/packages/modal/src/useWalletModal.tsx
+++ b/packages/modal/src/useWalletModal.tsx
@@ -48,9 +48,9 @@ export const useWalletModal = ({ modal: ModalComponent, wallets, terms }: UseWal
       try {
         await activate(connector, undefined, true)
       } catch (error) {
-        setError(error)
+        setError(error as Error)
 
-        if (error.name === 'UserRejectedRequestError') {
+        if (error instanceof Error && error.name === 'UserRejectedRequestError') {
           isRejected.current = true
           localStorage.removeItem('rk-last-wallet')
         }

--- a/packages/ui/src/components/EmojiIcon/EmojiIcon.tsx
+++ b/packages/ui/src/components/EmojiIcon/EmojiIcon.tsx
@@ -12,7 +12,7 @@ export const EmojiIcon = ({ address, className, ...props }: EmojiIconProps) => {
   const { emoji, color } = useMemo(() => {
     return {
       emoji: addressHashedEmoji(address),
-      color: colors[addressHashedColorIndex(address)]
+      color: colors[addressHashedColorIndex(address) ?? 0]
     }
   }, [address])
 

--- a/packages/ui/src/components/NetworkSelect/NetworkSelect.tsx
+++ b/packages/ui/src/components/NetworkSelect/NetworkSelect.tsx
@@ -45,7 +45,7 @@ export const NetworkSelect = ({
     return tmp
   }, [selectedChains])
 
-  const node = useRef<HTMLDivElement>()
+  const node = useRef<HTMLDivElement | null>(null)
   useOnClickOutside(node, open ? toggle : undefined)
 
   return (
@@ -108,6 +108,7 @@ export const NetworkSelect = ({
               chain={ch}
               key={ch.name}
               onClick={() => {
+                // @ts-expect-error provider could be undefined?
                 if (!isCurrentChain) switchNetwork(provider, ch)
               }}
               className={clsx([SelectOptionStyles, { CurrentChainOptionStyles: isCurrentChain }, classNames.option])}

--- a/packages/ui/src/components/Profile/Profile.tsx
+++ b/packages/ui/src/components/Profile/Profile.tsx
@@ -47,12 +47,13 @@ export const Profile = ({
     chainId
   } = useWalletModal(modalOptions)
 
+  // @ts-expect-error accountAddress and ENSProvider could be undefined?
   const ens = useENSWithAvatar({ address: accountAddress, provider: ENSProvider })
   const address = useMemo(() => ens?.domain || accountAddress, [ens?.domain, accountAddress])
 
   const [open, toggle] = useToggle(false)
 
-  const node = useRef<HTMLDivElement>()
+  const node = useRef<HTMLDivElement | null>(null)
   useOnClickOutside(node, open ? toggle : undefined)
 
   return (
@@ -60,6 +61,7 @@ export const Profile = ({
       {isConnected ? (
         <>
           <div ref={node}>
+            {/* @ts-expect-error address could be undefined? */}
             <Badge
               {...{ ipfsGatewayUrl, address, provider }}
               onClick={toggle}
@@ -69,6 +71,7 @@ export const Profile = ({
               <DropdownIcon />
             </Badge>
 
+            {/* @ts-expect-error address could be undefined? */}
             <DropdownComponent
               {...{ address, accountAddress, chainId, provider, isExpanded: open }}
               copyAddress={CopyAddressComponent}

--- a/packages/ui/src/components/Tx/Tx.tsx
+++ b/packages/ui/src/components/Tx/Tx.tsx
@@ -44,6 +44,7 @@ export const Tx = ({ status, title: initialTitle, classNames, chainId, data, val
       }
 
       if (!initialTitle) {
+        // @ts-expect-error 'from' and 'to' could be undefined?
         const guessedTitle = guessTitle({ data, from, to, chainId, value })
         if (guessedTitle) setTitle(guessedTitle)
       }
@@ -51,7 +52,7 @@ export const Tx = ({ status, title: initialTitle, classNames, chainId, data, val
   }, [props.hash, props.explorerUrl, chainId])
 
   return (
-    <div className={clsx(TxContainerClassName, classNames.container)}>
+    <div className={clsx(TxContainerClassName, classNames?.container)}>
       {link === '' ? (
         <span>{title || 'Contract call'}</span>
       ) : (

--- a/packages/utils/src/colors.ts
+++ b/packages/utils/src/colors.ts
@@ -91,17 +91,17 @@ export function hashCode(text: string) {
   return hash
 }
 
-export function addressHashedIndex(address: string) {
+export function addressHashedIndex(address: string | null) {
   if (address == null) return null
   return Math.abs(hashCode(address.toLowerCase()) % emojiCount)
 }
 
-export function addressHashedColorIndex(address: string) {
+export function addressHashedColorIndex(address: string | null) {
   if (address == null) return null
   return emojiColorIndexes[Math.abs(hashCode(address.toLowerCase()) % emojiCount)]
 }
 
-export function addressHashedEmoji(address: string) {
+export function addressHashedEmoji(address: string | null) {
   const index = addressHashedIndex(address)
   if (index == null) return null
   return popularEmojis[index]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "declarationDir": "dist",
     "jsx": "preserve",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": true
   }
 }


### PR DESCRIPTION
I ran into some issues with type checking of vanilla-extract themes and it turns out it's because TypeScript wasn't in strict mode. This PR enables strict mode and fixes the more straightforward errors, but I've added `@ts-expect-error` directives where the solution wasn't clear because it requires either a change in types or a change in runtime behaviour, both of which were outside the scope of this PR. Ideally we eventually get rid of these, though.