### PR TITLE
fix: minify CSS identifiers in production builds

### DIFF
--- a/esbuild/plugins.js
+++ b/esbuild/plugins.js
@@ -10,9 +10,11 @@ async function processCss(css) {
   return result.css
 }
 
-export const vanillaExtract = vanillaExtractPlugin({
-  processCss
-})
+export const vanillaExtract = ({ identifiers = 'debug' } = {}) =>
+  vanillaExtractPlugin({
+    processCss,
+    identifiers
+  })
 
 export const externals = {
   name: 'make-all-packages-external',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "chgset:version": "changeset version",
     "chgset": "pnpm chgset:run && pnpm chgset:version",
     "release": "changeset publish",
-    "prerelease": "pnpm build -r"
+    "prerelease": "MINIFY_CSS=true pnpm build -r"
   },
   "repository": {
     "type": "git",

--- a/packages/rainbowkit/build.js
+++ b/packages/rainbowkit/build.js
@@ -3,6 +3,7 @@ import readdir from 'recursive-readdir-files'
 import { externals, vanillaExtract } from '../../esbuild/plugins.js'
 
 const isWatching = process.argv.includes('--watch')
+const isCssMinified = process.env.MINIFY_CSS === 'true'
 
 const getRecursivePaths = async (rootPath) =>
   (await readdir(rootPath)).map((x) => x.path).filter((x) => !x.endsWith('.css.ts'))
@@ -25,7 +26,12 @@ esbuild
     format: 'esm',
     platform: 'browser',
     splitting: true, // Required for tree shaking
-    plugins: [vanillaExtract, externals],
+    plugins: [
+      vanillaExtract({
+        identifiers: isCssMinified ? 'short' : 'debug'
+      }),
+      externals
+    ],
     watch: isWatching
       ? {
           onRebuild(error, result) {


### PR DESCRIPTION
This cuts a lot of bloat from the generated CSS file by turning this:

```css
.sprinkles_flexDirection_row__ju367vk
```

into this:

```css
.ju367vk
```

You can also test this during development by running the following command: `MINIFY_CSS=true pnpm dev`