### PR TITLE
feat: allow themes to extend other themes, use for `darkModeTheme`

### DIFF
--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -159,7 +159,7 @@ const Example = () => {
 
           @media (prefers-color-scheme: dark) {
             :root {
-              ${cssStringFromTheme(darkModeTheme)}
+              ${cssStringFromTheme(darkModeTheme, { extends: theme })}
             }
           }
         `}

--- a/packages/rainbowkit/src/components/RainbowkitThemeProvider/RainbowkitThemeProvider.tsx
+++ b/packages/rainbowkit/src/components/RainbowkitThemeProvider/RainbowkitThemeProvider.tsx
@@ -20,7 +20,8 @@ export function RainbowkitThemeProvider({
   const themeCss = `${selector}{${cssStringFromTheme(theme)}}`;
   const darkModeThemeCss = darkModeTheme
     ? `@media(prefers-color-scheme:dark){${selector}{${cssStringFromTheme(
-        darkModeTheme
+        darkModeTheme,
+        { extends: theme }
       )}}}`
     : null;
 

--- a/packages/rainbowkit/src/css/cssObjectFromTheme.ts
+++ b/packages/rainbowkit/src/css/cssObjectFromTheme.ts
@@ -1,15 +1,35 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import { Theme, themeVars } from './sprinkles.css';
 
-export function cssObjectFromTheme(theme: Theme | (() => Theme)) {
-  return {
+const resolveTheme = (theme: Theme | (() => Theme)) =>
+  typeof theme === 'function' ? theme() : theme;
+
+export function cssObjectFromTheme(
+  theme: Theme | (() => Theme),
+  { extends: baseTheme }: { extends?: Theme | (() => Theme) } = {}
+) {
+  const resolvedThemeVars = {
     // We use an object spread here to ensure it's a plain object since vanilla-extract's
     // var objects have a custom 'toString' method that returns a CSS string, but we don't
     // want to leak this to our consumers since they're unaware we're using vanilla-extract.
     // Instead, we want them to handle this explicitly via our 'cssStringFromTheme' function.
-    ...assignInlineVars(
-      themeVars,
-      typeof theme === 'function' ? theme() : theme
-    ),
+    ...assignInlineVars(themeVars, resolveTheme(theme)),
   };
+
+  if (!baseTheme) {
+    return resolvedThemeVars;
+  }
+
+  const resolvedBaseThemeVars = assignInlineVars(
+    themeVars,
+    resolveTheme(baseTheme)
+  );
+
+  const filteredVars = Object.fromEntries(
+    Object.entries(resolvedThemeVars).filter(
+      ([varName, value]) => value !== resolvedBaseThemeVars[varName]
+    )
+  );
+
+  return filteredVars;
 }

--- a/packages/rainbowkit/src/css/cssStringFromTheme.ts
+++ b/packages/rainbowkit/src/css/cssStringFromTheme.ts
@@ -1,8 +1,11 @@
 import { cssObjectFromTheme } from './cssObjectFromTheme';
 import { Theme } from './sprinkles.css';
 
-export function cssStringFromTheme(theme: Theme | (() => Theme)) {
-  return Object.entries(cssObjectFromTheme(theme))
+export function cssStringFromTheme(
+  theme: Theme | (() => Theme),
+  options: { extends?: Theme | (() => Theme) } = {}
+) {
+  return Object.entries(cssObjectFromTheme(theme, options))
     .map(([key, value]) => `${key}:${value};`)
     .join('');
 }


### PR DESCRIPTION
Our low-level `cssStringFromTheme` / `cssObjectFromTheme` functions now accept an options object as the 2nd argument which lets you specify a base theme via the `extends` option. This has also been hooked up to the high-level `RainbowkitThemeProvider` component so that it's handled for you automatically.

This is used to filter out any theme values that are the same as the base theme, meaning that the resulting HTML/CSS and resolved styles are much leaner. This also makes for a much nicer debugging experience because you can clearly see which theme variables actually needed to be overridden in dark mode (or whatever other modes you have), as opposed to seeing literally every theme value defined again.

### Before:

<img width="809" alt="Before" src="https://user-images.githubusercontent.com/696693/150446608-3c87d4fc-3f86-42a7-87cb-8bc7c8fde047.png">

### After:

<img width="812" alt="After" src="https://user-images.githubusercontent.com/696693/150446632-bc03d999-0b78-421b-bae8-fca2fec6d3f7.png">

