### PR TITLE
fix: handle addresses without ENS domains

### DIFF
--- a/packages/rainbowkit/src/components/Profile/Profile.tsx
+++ b/packages/rainbowkit/src/components/Profile/Profile.tsx
@@ -74,12 +74,15 @@ export const Profile = ({
       {isConnected ? (
         <>
           <div ref={node}>
-            {/* @ts-expect-error address could be undefined? */}
             <Badge
-              {...{ address, ipfsGatewayUrl, provider }}
+              // @ts-expect-error address could be undefined?
+              address={address}
+              avatar={ens.avatar}
               className={classNames?.pill || ''}
+              ipfsGatewayUrl={ipfsGatewayUrl}
               onClick={toggle}
-              {...ens}
+              // @ts-expect-error provider could be undefined?
+              provider={provider}
             >
               <DropdownIcon />
             </Badge>

--- a/packages/rainbowkit/src/hooks/useENSWithAvatar.ts
+++ b/packages/rainbowkit/src/hooks/useENSWithAvatar.ts
@@ -10,19 +10,29 @@ export const useENSWithAvatar = <T extends BaseProvider = Web3Provider>({
 }) => {
   const [avatar, setAvatar] = useState<string>();
   const [domain, setEnsDomain] = useState(address);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (provider && address) {
       const getENSInfo = async () => {
-        const domain = await provider.lookupAddress(address);
+        const ensDomain = await provider.lookupAddress(address);
 
-        // @ts-expect-error domain could be null?
-        setEnsDomain(domain);
-        // @ts-expect-error domain could be null?
-        const resolver = await provider.getResolver(domain);
+        if (!ensDomain) {
+          setLoading(false);
+          return;
+        }
+
+        setEnsDomain(ensDomain);
+
+        const resolver = await provider.getResolver(ensDomain);
         if (resolver) {
           const avatar = await resolver.getText('avatar');
-          setAvatar(avatar);
+
+          if (avatar) {
+            setAvatar(avatar);
+          }
+
+          setLoading(false);
         }
       };
 
@@ -30,5 +40,5 @@ export const useENSWithAvatar = <T extends BaseProvider = Web3Provider>({
     }
   }, [provider, address]);
 
-  return { avatar, domain };
+  return { avatar, domain, loading };
 };

--- a/tests/hooks/useENSWithAvatar.test.ts
+++ b/tests/hooks/useENSWithAvatar.test.ts
@@ -30,6 +30,13 @@ t('resolves avatar and domain', async ({ provider }) => {
       provider,
     })
   );
+
+  assert.equal(result.current, {
+    avatar: undefined,
+    domain: '0xD3B282e9880cDcB1142830731cD83f7ac0e1043f',
+    loading: true,
+  });
+
   await waitForNextUpdate({ timeout: 5000 });
   await waitForNextUpdate({ timeout: 5000 });
 
@@ -37,6 +44,32 @@ t('resolves avatar and domain', async ({ provider }) => {
     avatar:
       'ipfs://bafkreia4t7isswz3fpqzwc7rokd5m7rd3dom7aavcbthxk5fggixncngru',
     domain: 'v1rtl.eth',
+    loading: false,
+  });
+});
+
+const mockAddress = '0xde7f309de0f69c49e7c065bb4ae6dffe0f5e32f4';
+
+t('gracefully handles missing ENS reverse record', async ({ provider }) => {
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useENSWithAvatar({
+      address: mockAddress,
+      provider,
+    })
+  );
+
+  assert.equal(result.current, {
+    avatar: undefined,
+    domain: mockAddress,
+    loading: true,
+  });
+
+  await waitForNextUpdate({ timeout: 5000 });
+
+  assert.equal(result.current, {
+    avatar: undefined,
+    domain: mockAddress,
+    loading: false,
   });
 });
 


### PR DESCRIPTION
This also adds a `loading` flag to the object returned from `useENSWithAvatar` so that we know when loading is complete, otherwise the test would have to wait an arbitrary amount of time before checking the result.