### PR TITLE
chore: fix NetworkSelect prop spreading error in example

### DIFF
--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -23,7 +23,7 @@ const themes = { darkTheme, dimTheme, lightTheme } as const;
 const darkModeThemes = { darkTheme, dimTheme, none: undefined } as const;
 
 const Example = () => {
-  const { chainId, provider } = useWeb3State();
+  const { chainId } = useWeb3State();
   const [themeName, setThemeName] = useState<keyof typeof themes>('lightTheme');
   const [darkModeThemeName, setDarkModeThemeName] =
     useState<keyof typeof darkModeThemes>('none');
@@ -101,7 +101,6 @@ const Example = () => {
           <Profile ENSProvider={ENSProvider} modalOptions={{ wallets }} />
           <NetworkSelect
             chains={['ethereum', 'arbitrum', 'polygon', 'ropsten']}
-            {...{ chainId, provider }}
           />
         </nav>
         <TxHistory


### PR DESCRIPTION
These props are not supported by `NetworkSelect` and get spread onto the underlying DOM element which results in a runtime error. Not sure why, but this wasn't picked up because spreading props like this isn't being type checked properly.