### PR TITLE
RNBW-2443: chain changed event error when disconnecting from metamask

### DIFF
--- a/packages/rainbowkit/src/components/Network/Network.tsx
+++ b/packages/rainbowkit/src/components/Network/Network.tsx
@@ -32,7 +32,7 @@ export function Network() {
     provider.on('chainChanged', stopSwitching);
 
     return () => {
-      provider.off('chainChanged', stopSwitching);
+      provider.removeListener('chainChanged', stopSwitching);
     };
   }, [connectData.connector, setIsSwitching]);
 


### PR DESCRIPTION
Fixes RNBW-2443

It seems that to stop listening to a provider event, we can use `removeListener`, instead of off 

It's not something that's documented, but I found some [example](https://github.com/tmm/wagmi/blob/f05b0310f7f7e6447e9b6c81cedbb27dcf2f3649/packages/testing/src/connectors/mockConnector.ts#L54) use cases by looking into the `wagmi` source code 

Since there's no documentation, I a bit on the fence about this, but thought I'd raise a PR to kick it off.