### PR TITLE
fix: dialog accessibility improvements

### DIFF
--- a/packages/rainbowkit/src/components/ConnectButton/Connect.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/Connect.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { Box } from '../Box/Box';
 import ConnectOptions from '../ConnectOptions/ConnectOptions';
 import { Dialog } from '../Dialog/Dialog';
@@ -6,7 +6,7 @@ import { DialogContent } from '../Dialog/DialogContent';
 
 export function Connect() {
   const [open, setOpen] = useState(false);
-  const initialFocusRef = useRef<HTMLHeadingElement | null>(null);
+
   const titleId = 'rk_connect_title';
 
   return (
@@ -35,14 +35,9 @@ export function Connect() {
         </Box>
       </div>
 
-      <Dialog
-        initialFocusRef={initialFocusRef}
-        onClose={() => setOpen(false)}
-        open={open}
-        titleId={titleId}
-      >
+      <Dialog onClose={() => setOpen(false)} open={open} titleId={titleId}>
         <DialogContent>
-          <ConnectOptions initialFocusRef={initialFocusRef} />
+          <ConnectOptions />
         </DialogContent>
       </Dialog>
     </>

--- a/packages/rainbowkit/src/components/ConnectOptions/ConnectOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/ConnectOptions.tsx
@@ -3,26 +3,13 @@ import { Box } from '../Box/Box';
 import { useWallets } from '../RainbowKitProvider/useWallets';
 import { Text } from '../Text/Text';
 
-interface ConnectOptionsProps {
-  initialFocusRef: React.MutableRefObject<HTMLHeadingElement | null>;
-}
-
-export default function ConnectOptions({
-  initialFocusRef,
-}: ConnectOptionsProps) {
+export default function ConnectOptions() {
   const wallets = useWallets();
   const titleId = 'rk_connect_title';
 
   return (
     <Box display="flex" flexDirection="column" gap="24">
-      <Text
-        as="h1"
-        color="modalText"
-        id={titleId}
-        ref={initialFocusRef}
-        size="23"
-        tabIndex={-1}
-      >
+      <Text as="h1" color="modalText" id={titleId} size="23">
         Connect Wallet
       </Text>
       <Box display="flex" flexDirection="column" gap="18">

--- a/packages/rainbowkit/src/components/Dialog/Dialog.tsx
+++ b/packages/rainbowkit/src/components/Dialog/Dialog.tsx
@@ -1,7 +1,6 @@
 import React, {
   MouseEventHandler,
   ReactNode,
-  RefObject,
   useCallback,
   useEffect,
 } from 'react';
@@ -18,27 +17,11 @@ interface DialogProps {
   open: boolean;
   onClose: () => void;
   titleId: string;
-  initialFocusRef: RefObject<HTMLElement | null>;
+  onMountAutoFocus?: (event: Event) => void;
   children: ReactNode;
 }
 
-export function Dialog({
-  children,
-  initialFocusRef,
-  onClose,
-  open,
-  titleId,
-}: DialogProps) {
-  useEffect(() => {
-    const previouslyActiveElement = document.activeElement;
-
-    initialFocusRef?.current?.focus();
-
-    return () => {
-      (previouslyActiveElement as HTMLElement).focus?.();
-    };
-  }, [initialFocusRef]);
-
+export function Dialog({ children, onClose, open, titleId }: DialogProps) {
   useEffect(() => {
     const handleEscape = (event: KeyboardEvent) =>
       open && event.key === 'Escape' && onClose();

--- a/packages/rainbowkit/src/components/Dialog/FocusTrap.tsx
+++ b/packages/rainbowkit/src/components/Dialog/FocusTrap.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
 const moveFocusWithin = (element: HTMLElement, position: 'start' | 'end') => {
   const focusableElements = element.querySelectorAll(
-    'button, a[href]'
+    'button:not(:disabled), a[href]'
   ) as NodeListOf<HTMLButtonElement | HTMLAnchorElement>;
 
   if (focusableElements.length === 0) return;
@@ -15,6 +15,26 @@ const moveFocusWithin = (element: HTMLElement, position: 'start' | 'end') => {
 export function FocusTrap(props: JSX.IntrinsicElements['div']) {
   const contentRef = useRef<HTMLDivElement>(null);
 
+  useEffect(() => {
+    const previouslyActiveElement = document.activeElement;
+
+    return () => {
+      (previouslyActiveElement as HTMLElement).focus?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (contentRef.current) {
+      const elementToFocus =
+        contentRef.current.querySelector('[data-auto-focus]');
+      if (elementToFocus) {
+        (elementToFocus as HTMLElement).focus();
+      } else {
+        contentRef.current.focus();
+      }
+    }
+  }, [contentRef]);
+
   return (
     <>
       <div
@@ -25,7 +45,12 @@ export function FocusTrap(props: JSX.IntrinsicElements['div']) {
         )}
         tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
       />
-      <div ref={contentRef} {...props} />
+      <div
+        ref={contentRef}
+        style={{ outline: 'none' }}
+        tabIndex={-1}
+        {...props}
+      />
       <div
         onFocus={useCallback(
           () =>

--- a/packages/rainbowkit/src/components/Network/Network.tsx
+++ b/packages/rainbowkit/src/components/Network/Network.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useConnect, useNetwork } from 'wagmi';
 import { Box } from '../Box/Box';
 import { Dialog } from '../Dialog/Dialog';
@@ -12,7 +12,6 @@ export function Network() {
   const [isSwitching, setIsSwitching] = useState(false);
   const [{ data: connectData }] = useConnect();
   const [{ data: networkData }, switchNetwork] = useNetwork();
-  const initialFocusRef = useRef<HTMLHeadingElement | null>(null);
   const titleId = 'rk_network_title';
 
   const chainIconUrlsById = useChainIconUrlsById();
@@ -78,22 +77,10 @@ export function Network() {
         </Box>
       </div>
 
-      <Dialog
-        initialFocusRef={initialFocusRef}
-        onClose={() => setOpen(false)}
-        open={open}
-        titleId={titleId}
-      >
+      <Dialog onClose={() => setOpen(false)} open={open} titleId={titleId}>
         <DialogContent>
           <Box display="flex" flexDirection="column" gap="24">
-            <Text
-              as="h1"
-              color="modalText"
-              id={titleId}
-              ref={initialFocusRef}
-              size="23"
-              tabIndex={-1}
-            >
+            <Text as="h1" color="modalText" id={titleId} size="23">
               Network
             </Text>
             <Box display="flex" flexDirection="column" gap="18">

--- a/packages/rainbowkit/src/components/Profile/Profile.tsx
+++ b/packages/rainbowkit/src/components/Profile/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { useAccount, useBalance } from 'wagmi';
 import { Box } from '../Box/Box';
 import { formatAddress } from '../ConnectButton/formatAddress';
@@ -11,7 +11,6 @@ import { ProfilePillImageClassName } from './Profile.css';
 
 export function Profile() {
   const [open, setOpen] = useState(false);
-  const initialFocusRef = useRef<HTMLHeadingElement | null>(null);
   const [{ data: accountData }, disconnect] = useAccount({
     fetchEns: true,
   });
@@ -81,16 +80,10 @@ export function Profile() {
       </div>
 
       {accountData && (
-        <Dialog
-          initialFocusRef={initialFocusRef}
-          onClose={() => setOpen(false)}
-          open={open}
-          titleId={titleId}
-        >
+        <Dialog onClose={() => setOpen(false)} open={open} titleId={titleId}>
           <DialogContent>
             <ProfileDetails
               accountData={accountData}
-              initialFocusRef={initialFocusRef}
               onClose={() => setOpen(false)}
               onDisconnect={() => disconnect()}
             />

--- a/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
+++ b/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
@@ -17,14 +17,12 @@ import { ProfileDetailsAction } from './ProfileDetailsAction';
 
 interface ProfileDetailsProps {
   accountData: ReturnType<typeof useAccount>[0]['data'];
-  initialFocusRef: React.MutableRefObject<HTMLHeadingElement | null>;
   onClose: () => void;
   onDisconnect: () => void;
 }
 
 export function ProfileDetails({
   accountData,
-  initialFocusRef,
   onClose,
   onDisconnect,
 }: ProfileDetailsProps) {
@@ -98,7 +96,6 @@ export function ProfileDetails({
                   as="h1"
                   color="modalText"
                   id={titleId}
-                  ref={initialFocusRef}
                   size="23"
                   weight="heavy"
                 >
@@ -153,13 +150,12 @@ export function ProfileDetails({
         />
       </Box>
       <Dialog
-        initialFocusRef={initialFocusRef}
         onClose={() => setSwitchWalletOpen(false)}
         open={switchWalletOpen}
         titleId={titleId}
       >
         <DialogContent>
-          <ConnectOptions initialFocusRef={initialFocusRef} />
+          <ConnectOptions />
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
Fixes RNBW-2515

This PR fixes some accessibility issues with the Dialog component. I've tried to keep it as lean as possible, so this implementation makes a few assumptions. 

- By default, focus on the Dialog Content
- Add `data-auto-focus` to an element to be focused first
- Fix issue with focus returning to trigger
- Remove outline styles from the dialog content (see inline comment)