### PR TITLE
fix: show correct gas token for selected chain

### DIFF
--- a/packages/rainbowkit/src/components/Profile/Profile.tsx
+++ b/packages/rainbowkit/src/components/Profile/Profile.tsx
@@ -48,7 +48,7 @@ export function Profile() {
         >
           {balanceData && (
             <Box padding="8" paddingLeft="12">
-              {ethBalanceFormatted} ETH
+              {ethBalanceFormatted} {balanceData.symbol}
             </Box>
           )}
           <Box

--- a/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
+++ b/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
@@ -112,7 +112,7 @@ export function ProfileDetails({
                       size="16"
                       weight="heavy"
                     >
-                      {balance} ETH
+                      {balance} {balanceData.symbol}
                     </Text>
                   </Box>
                 )}


### PR DESCRIPTION
[useBalance has a return value](https://wagmi-xyz.vercel.app/docs/hooks/useBalance#result) for `symbol`, which is the correct gas token for a specific chain.

Fixes RNBW-2533.