### PR TITLE
feat: animate dialog on enter

### DIFF
--- a/packages/rainbowkit/src/components/ConnectOptions/ConnectOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/ConnectOptions.tsx
@@ -34,7 +34,9 @@ export default function ConnectOptions() {
         Connect Wallet
       </Text>
 
-      <Box>{uri && <QRCode logoSize={72} size={342} uri={uri} />}</Box>
+      <Box style={{ height: '342px' }}>
+        {uri && <QRCode logoSize={72} size={342} uri={uri} />}
+      </Box>
 
       <Box display="flex" flexDirection="column" gap="18">
         {wallets.map(wallet => {

--- a/packages/rainbowkit/src/components/Dialog/Dialog.css.ts
+++ b/packages/rainbowkit/src/components/Dialog/Dialog.css.ts
@@ -1,5 +1,10 @@
-import { style } from '@vanilla-extract/css';
+import { keyframes, style } from '@vanilla-extract/css';
 import { sprinkles } from '../../css/sprinkles.css';
+
+const slideUp = keyframes({
+  '0%': { transform: 'translateY(100%)' },
+  '100%': { transform: 'translateY(0deg)' },
+});
 
 export const overlay = style([
   sprinkles({
@@ -24,6 +29,7 @@ export const content = style([
     position: 'relative',
   }),
   {
+    animation: `${slideUp} 500ms cubic-bezier(0.16, 1, 0.3, 1)`,
     width: '390px',
   },
 ]);


### PR DESCRIPTION
Fixes RNBW-2539

---

This PR adds a slide up CSS animation to the dialog's content. Notes:
- only animate on enter
- not sure what the "animation guidelines" for rainbow are, so went with a Ease Out Back curve which I personally like

If we want to slide it down on exit, it'll require some extra code/logic to listen to the element's presence, etc. Prob not worth the extra bundle size

https://user-images.githubusercontent.com/372831/153893135-e7d473ee-33a1-419d-9223-e6ba6bb74434.mp4