### PR TITLE
refactor: pass ConnectButton state down to to modal components

### DIFF
--- a/packages/rainbowkit/src/components/AccountModal/AccountModal.tsx
+++ b/packages/rainbowkit/src/components/AccountModal/AccountModal.tsx
@@ -1,20 +1,27 @@
 import React from 'react';
-import { useAccount } from 'wagmi';
+import { useAccount, useBalance, useNetwork } from 'wagmi';
 import { Dialog } from '../Dialog/Dialog';
 import { DialogContent } from '../Dialog/DialogContent';
 import { ProfileDetails } from '../ProfileDetails/ProfileDetails';
 import { TxList } from '../Txs/TxList';
 
 export interface AccountModalProps {
+  accountData: ReturnType<typeof useAccount>[0]['data'];
+  balanceData: ReturnType<typeof useBalance>[0]['data'];
+  networkData: ReturnType<typeof useNetwork>[0]['data'];
   open: boolean;
   onClose: () => void;
+  onDisconnect: () => void;
 }
 
-export function AccountModal({ onClose, open }: AccountModalProps) {
-  const [{ data: accountData }, disconnect] = useAccount({
-    fetchEns: true,
-  });
-
+export function AccountModal({
+  accountData,
+  balanceData,
+  networkData,
+  onClose,
+  onDisconnect,
+  open,
+}: AccountModalProps) {
   if (!accountData) {
     return null;
   }
@@ -28,8 +35,10 @@ export function AccountModal({ onClose, open }: AccountModalProps) {
           <DialogContent>
             <ProfileDetails
               accountData={accountData}
+              balanceData={balanceData}
+              networkData={networkData}
               onClose={onClose}
-              onDisconnect={() => disconnect()}
+              onDisconnect={onDisconnect}
             />
           </DialogContent>
           <DialogContent marginTop="24">

--- a/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
+++ b/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
@@ -10,12 +10,18 @@ import { Text } from '../Text/Text';
 export interface ChainModalProps {
   open: boolean;
   onClose: () => void;
+  networkData: ReturnType<typeof useNetwork>[0]['data'];
+  onSwitchNetwork?: (chainId: number) => unknown;
 }
 
-export function ChainModal({ onClose, open }: ChainModalProps) {
+export function ChainModal({
+  networkData,
+  onClose,
+  onSwitchNetwork,
+  open,
+}: ChainModalProps) {
   const [isSwitching, setIsSwitching] = useState(false);
   const [{ data: connectData }] = useConnect();
-  const [{ data: networkData }, switchNetwork] = useNetwork();
   const titleId = 'rk_chain_modal_title';
 
   const chainIconUrlsById = useChainIconUrlsById();
@@ -59,7 +65,7 @@ export function ChainModal({ onClose, open }: ChainModalProps) {
             </Text>
           </Box>
           <Box display="flex" flexDirection="column" gap="10">
-            {switchNetwork &&
+            {onSwitchNetwork &&
               networkData.chains.map(chain => {
                 const isCurrentChain = chain.id === networkData.chain?.id;
                 const chainIconUrl = chainIconUrlsById[chain.id];
@@ -73,7 +79,7 @@ export function ChainModal({ onClose, open }: ChainModalProps) {
                         ? undefined
                         : () => {
                             setIsSwitching(chain.id);
-                            switchNetwork(chain.id);
+                            onSwitchNetwork(chain.id);
                           }
                     }
                   >

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -191,7 +191,7 @@ export function ConnectButton({
 }: ConnectButtonProps) {
   const isMounted = useIsMounted();
 
-  const [{ data: accountData }] = useAccount({
+  const [{ data: accountData }, disconnect] = useAccount({
     fetchEns: true,
   });
 
@@ -199,7 +199,7 @@ export function ConnectButton({
     addressOrName: accountData?.address,
   });
 
-  const [{ data: networkData }] = useNetwork();
+  const [{ data: networkData }, switchNetwork] = useNetwork();
 
   const chainIconUrlsById = useChainIconUrlsById();
   const chainIconUrl = networkData.chain
@@ -272,8 +272,20 @@ export function ConnectButton({
       })}
 
       <ConnectModal onClose={hideConnectModal} open={connectModalOpen} />
-      <AccountModal onClose={hideAccountModal} open={accountModalOpen} />
-      <ChainModal onClose={hideChainModal} open={chainModalOpen} />
+      <AccountModal
+        accountData={accountData}
+        balanceData={balanceData}
+        networkData={networkData}
+        onClose={hideAccountModal}
+        onDisconnect={disconnect}
+        open={accountModalOpen}
+      />
+      <ChainModal
+        networkData={networkData}
+        onClose={hideChainModal}
+        onSwitchNetwork={switchNetwork}
+        open={chainModalOpen}
+      />
     </>
   );
 }

--- a/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
+++ b/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
@@ -20,21 +20,19 @@ import { ProfileDetailsAction } from './ProfileDetailsAction';
 
 interface ProfileDetailsProps {
   accountData: ReturnType<typeof useAccount>[0]['data'];
+  balanceData: ReturnType<typeof useBalance>[0]['data'];
+  networkData: ReturnType<typeof useNetwork>[0]['data'];
   onClose: () => void;
   onDisconnect: () => void;
 }
 
 export function ProfileDetails({
   accountData,
+  balanceData,
+  networkData,
   onClose,
   onDisconnect,
 }: ProfileDetailsProps) {
-  const [{ data: balanceData }] = useBalance({
-    addressOrName: accountData?.address,
-  });
-
-  const [{ data: networkData }] = useNetwork();
-
   const [copiedAddress, setCopiedAddress] = useState(false);
 
   const copyAddressAction = useCallback(() => {


### PR DESCRIPTION
Since all connection/account/chain logic is now centrally managed in the ConnectButton component, it makes sense to pass the resolved state down to the child components rather than requiring them to load their own data. This should also speed up some things, e.g. the balance should be immediately visible when opening the account modal.