### PR TITLE
chore: type check docs site and example app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Lint and format
         run: pnpm lint && pnpm format
       - name: Build packages
-        run: pnpm build -r
+        run: pnpm build --recursive
       - name: Run tests
         run: pnpm test

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "postinstall": "husky install",
-    "dev": "pnpm dev -r --parallel",
+    "dev": "pnpm dev --recursive --parallel",
     "start": "pnpm dev",
-    "lint": "eslint . --ext=js,mjs,ts,cjs,tsx && pnpm typecheck -r",
+    "lint": "eslint . --ext=js,mjs,ts,cjs,tsx && pnpm typecheck --recursive",
     "lint:fix": "eslint . --ext=js,mjs,ts,cjs,tsx --fix",
     "format": "prettier --check \"./**/*.{ts,js,mjs,cjs,md,tsx}\"",
     "format:fix": "prettier --write \"./**/*.{ts,js,mjs,cjs,md,tsx}\"",
@@ -16,7 +16,7 @@
     "chgset:version": "changeset version",
     "chgset": "pnpm chgset:run && pnpm chgset:version",
     "release": "changeset publish",
-    "prerelease": "MINIFY_CSS=true pnpm build -r && cp README.md packages/rainbowkit/README.md",
+    "prerelease": "MINIFY_CSS=true pnpm build --recursive && cp README.md packages/rainbowkit/README.md",
     "ci:example": "pnpm prepare --filter=@rainbow-me/rainbowkit && pnpm build --filter=example",
     "ci:site": "pnpm prepare --filter=@rainbow-me/rainbowkit && pnpm build:site --filter=site"
   },

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -20,7 +20,8 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "next build"
+    "build": "next build",
+    "typecheck": "pnpm tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/site/package.json
+++ b/site/package.json
@@ -24,7 +24,8 @@
   },
   "scripts": {
     "dev:site": "next dev",
-    "build:site": "next build"
+    "build:site": "next build",
+    "typecheck": "pnpm tsc --noEmit"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Any type errors in these packages weren't being picked up in CI. To fix this, we need to add `typecheck` scripts which are then picked up by the top-level `pnpm lint` script via `pnpm typecheck --recursive`.

Note that, to make this a bit clearer, I've also swapped the shorthand `-r` for `--recursive` in this PR.