### PR TITLE
test: disable watching by default, add test:watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --check \"./**/*.{ts,js,mjs,cjs,md,tsx}\"",
     "format:fix": "prettier --write \"./**/*.{ts,js,mjs,cjs,md,tsx}\"",
     "test": "vitest",
+    "test:watch": "vitest --watch",
     "chgset:run": "changeset",
     "chgset:version": "changeset version",
     "chgset": "pnpm chgset:run && pnpm chgset:version",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,4 +2,7 @@ import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 
 export default {
   plugins: [vanillaExtractPlugin()],
+  test: {
+    watch: false,
+  },
 };


### PR DESCRIPTION
I ran into an issue where running `git commit` after resolving a merge conflict got stuck because it ran the tests in watch mode during the precommit hook. This fixes it by turning off watch mode in our base `pnpm test` script, while adding a `pnpm test:watch` script.