### PR TITLE
feat: support toggling balance, avatar and chain visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,9 +385,44 @@ const App = () => {
 };
 ```
 
-## Custom buttons
+## `ConnectButton`
 
-If you want to customize the rendering of the top-level RainbowKit buttons, the `ConnectButton` component also accepts a render prop, i.e. a function as a child. This function is passed everything needed to re-implement the built-in buttons.
+The `ConnectButton` component exposes the following props to customize its appearance.
+
+<table>
+  <thead>
+    <tr>
+    <th>Prop</th>
+    <th>Type</th>
+    <th>Default</th>
+    <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>showAvatar</code></td>
+      <td><code>boolean</code></td>
+      <td><code>true</code></td>
+      <td>Whether the avatar is visible next to the account name</td>
+    </tr>
+    <tr>
+      <td><code>showBalance</code></td>
+      <td><code>boolean</code></td>
+      <td><code>true</code></td>
+      <td>Whether the balance is visible next to the account name</td>
+    </tr>
+    <tr>
+      <td><code>showChains</code></td>
+      <td><code>boolean</code></td>
+      <td><code>true</code></td>
+      <td>Whether the chain button is visible next to the account button</td>
+    </tr>
+  </tbody>
+</table>
+
+### Creating custom buttons
+
+If you want to create your own custom connection buttons, the low-level `ConnectButton.Custom` component is also provided which accepts a render prop, i.e. a function as a child. This function is passed everything needed to re-implement the built-in buttons.
 
 A minimal re-implementation of the built-in buttons would look something like this:
 
@@ -397,23 +432,23 @@ import { ConnectButton } from '@rainbow-me/rainbowkit';
 export const YourApp = () => {
   return (
     <>
-      <ConnectButton>
+      <ConnectButton.Custom>
         {({
           account,
           chain,
-          showAccountModal,
-          showChainModal,
-          showConnectModal,
+          openAccountModal,
+          openChainModal,
+          openConnectModal,
         }) =>
           !account ? (
-            <button onClick={showConnectModal} type="button">
+            <button onClick={openConnectModal} type="button">
               Connect Wallet
             </button>
           ) : (
             <div style={{ display: 'flex', gap: 12 }}>
               {chain && (
                 <button
-                  onClick={showChainModal}
+                  onClick={openChainModal}
                   style={{ display: 'flex', alignItems: 'center' }}
                   type="button"
                 >
@@ -428,14 +463,14 @@ export const YourApp = () => {
                   {chain.unsupported && ' (unsupported)'}
                 </button>
               )}
-              <button onClick={showAccountModal} type="button">
+              <button onClick={openAccountModal} type="button">
                 {account.displayName}
                 {account.displayBalance ? ` (${account.displayBalance})` : ''}
               </button>
             </div>
           )
         }
-      </ConnectButton>
+      </ConnectButton.Custom>
     </>
   );
 };
@@ -554,19 +589,19 @@ The following props are passed to your render function.
   </thead>
   <tbody>
     <tr>
-      <td><code>showAccountModal</code></td>
+      <td><code>openAccountModal</code></td>
       <td><code>() => void</code></td>
-      <td>Function to show the account modal</td>
+      <td>Function to open the account modal</td>
     </tr>
     <tr>
-      <td><code>showChainModal</code></td>
+      <td><code>openChainModal</code></td>
       <td><code>() => void</code></td>
-      <td>Function to show the chain modal</td>
+      <td>Function to open the chain modal</td>
     </tr>
     <tr>
-      <td><code>showConnectModal</code></td>
+      <td><code>openConnectModal</code></td>
       <td><code>() => void</code></td>
-      <td>Function to show the connect modal</td>
+      <td>Function to open the connect modal</td>
     </tr>
     <tr>
       <td><code>accountModalOpen</code></td>

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -1,7 +1,11 @@
 import { ConnectButton } from '@rainbow-me/rainbowkit';
-import React from 'react';
+import React, { useState } from 'react';
 
 const Example = () => {
+  const [showAvatar, setShowAvatar] = useState<boolean | undefined>();
+  const [showBalance, setShowBalance] = useState<boolean | undefined>();
+  const [showChains, setShowChains] = useState<boolean | undefined>();
+
   return (
     <div
       style={{
@@ -17,27 +21,31 @@ const Example = () => {
           justifyContent: 'flex-end',
         }}
       >
-        <ConnectButton />
+        <ConnectButton
+          showAvatar={showAvatar}
+          showBalance={showBalance}
+          showChains={showChains}
+        />
       </div>
 
       <div>
         <h3 style={{ fontFamily: 'sans-serif' }}>Custom buttons</h3>
-        <ConnectButton>
+        <ConnectButton.Custom>
           {({
             account,
             chain,
-            showAccountModal,
-            showChainModal,
-            showConnectModal,
+            openAccountModal,
+            openChainModal,
+            openConnectModal,
           }) =>
             !account ? (
-              <button onClick={showConnectModal} type="button">
+              <button onClick={openConnectModal} type="button">
                 Connect Wallet
               </button>
             ) : (
               <div style={{ display: 'flex', gap: 12 }}>
                 <button
-                  onClick={showChainModal}
+                  onClick={openChainModal}
                   style={{ alignItems: 'center', display: 'flex' }}
                   type="button"
                 >
@@ -50,7 +58,7 @@ const Example = () => {
                   )}
                   {chain.name ?? chain.id}
                 </button>
-                <button onClick={showAccountModal} type="button">
+                <button onClick={openAccountModal} type="button">
                   {account.displayName}
                   {account.balanceFormatted
                     ? ` (${account.balanceFormatted})`
@@ -59,7 +67,43 @@ const Example = () => {
               </div>
             )
           }
-        </ConnectButton>
+        </ConnectButton.Custom>
+      </div>
+
+      <div style={{ fontFamily: 'sans-serif' }}>
+        <h3>ConnectButton props</h3>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <label style={{ userSelect: 'none' }}>
+            <input
+              checked={showAvatar ?? true}
+              onChange={event => {
+                setShowAvatar(event.currentTarget.checked);
+              }}
+              type="checkbox"
+            />{' '}
+            showAvatar
+          </label>
+          <label style={{ userSelect: 'none' }}>
+            <input
+              checked={showBalance ?? true}
+              onChange={event => {
+                setShowBalance(event.currentTarget.checked);
+              }}
+              type="checkbox"
+            />{' '}
+            showBalance
+          </label>
+          <label style={{ userSelect: 'none' }}>
+            <input
+              checked={showChains ?? true}
+              onChange={event => {
+                setShowChains(event.currentTarget.checked);
+              }}
+              type="checkbox"
+            />{' '}
+            showChains
+          </label>
+        </div>
       </div>
     </div>
   );

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -1,291 +1,165 @@
-import React, { ReactNode, useCallback, useEffect, useState } from 'react';
-import { useAccount, useBalance, useNetwork } from 'wagmi';
-import { useIsMounted } from '../../hooks/useIsMounted';
-import { AccountModal } from '../AccountModal/AccountModal';
+import React from 'react';
 import { Box } from '../Box/Box';
-import { ChainModal } from '../ChainModal/ChainModal';
-import { ConnectModal } from '../ConnectModal/ConnectModal';
 import { DropdownIcon } from '../Icons/Dropdown';
-import { useChainIconUrlsById } from '../RainbowKitProvider/ChainIconsContext';
-import { formatAddress } from './formatAddress';
-
-const useBooleanState = (initialValue: boolean) => {
-  const [value, setValue] = useState(initialValue);
-  const setTrue = useCallback(() => setValue(true), []);
-  const setFalse = useCallback(() => setValue(false), []);
-
-  return { setFalse, setTrue, value };
-};
-
-type ConnectButtonRenderer = (renderProps: {
-  account?: {
-    address: string;
-    balanceDecimals?: number;
-    balanceFormatted?: string;
-    balanceSymbol?: string;
-    displayBalance?: string;
-    displayName: string;
-    ensAvatar?: string;
-    ensName?: string;
-  };
-  chain?: {
-    iconUrl?: string;
-    id: number;
-    name?: string;
-    unsupported?: boolean;
-  };
-  showAccountModal: () => void;
-  showChainModal: () => void;
-  showConnectModal: () => void;
-  accountModalOpen: boolean;
-  chainModalOpen: boolean;
-  connectModalOpen: boolean;
-}) => ReactNode;
-
-const defaultConnectButtonRenderer: ConnectButtonRenderer = ({
-  account,
-  accountModalOpen,
-  chain,
-  connectModalOpen,
-  showAccountModal,
-  showChainModal,
-  showConnectModal,
-}) =>
-  account ? (
-    <Box display="flex" gap="12">
-      {chain && (
-        <Box
-          alignItems="center"
-          as="button"
-          background={
-            chain.unsupported
-              ? 'connectButtonBackgroundError'
-              : 'connectButtonBackground'
-          }
-          borderRadius="connectButton"
-          boxShadow="connectButton"
-          color={
-            chain.unsupported ? 'connectButtonTextError' : 'connectButtonText'
-          }
-          display="flex"
-          fontFamily="body"
-          fontWeight="bold"
-          onClick={showChainModal}
-          paddingX="10"
-          paddingY="8"
-          transform={{ active: 'shrink', hover: 'grow' }}
-          transition="default"
-          type="button"
-        >
-          {chain.unsupported ? (
-            <Box>Invalid network</Box>
-          ) : (
-            <Box alignItems="center" display="flex" gap="4">
-              {chain.iconUrl ? (
-                <img
-                  alt={chain.name ?? 'Chain icon'}
-                  height="24"
-                  src={chain.iconUrl}
-                  width="24"
-                />
-              ) : null}
-              <div>{chain.name ?? chain.id}</div>
-            </Box>
-          )}
-          <DropdownIcon />
-        </Box>
-      )}
-
-      <Box
-        alignItems="center"
-        as="button"
-        background="connectButtonBackground"
-        borderRadius="connectButton"
-        boxShadow="connectButton"
-        color="connectButtonText"
-        display="flex"
-        fontFamily="body"
-        fontWeight="bold"
-        onClick={showAccountModal}
-        transform={{ active: 'shrink', hover: 'grow' }}
-        transition="default"
-        type="button"
-      >
-        {account.displayBalance && (
-          <Box padding="8" paddingLeft="12">
-            {account.displayBalance}
-          </Box>
-        )}
-        <Box
-          background="connectButtonInnerBackground"
-          borderColor={
-            accountModalOpen
-              ? 'connectedProfileBorder'
-              : 'connectButtonBackground'
-          }
-          borderRadius="connectButton"
-          borderStyle="solid"
-          borderWidth="2"
-          color="connectButtonText"
-          fontFamily="body"
-          fontWeight="bold"
-          paddingX="8"
-          paddingY="6"
-          transition="default"
-        >
-          <Box alignItems="center" display="flex" height="24">
-            {account.ensAvatar ? (
-              <Box
-                alt="ENS Avatar"
-                as="img"
-                borderRadius="full"
-                height="24"
-                marginRight="6"
-                src={account.ensAvatar}
-                width="24"
-              />
-            ) : null}
-            {account.displayName}
-            <DropdownIcon />
-          </Box>
-        </Box>
-      </Box>
-    </Box>
-  ) : (
-    <Box
-      background="connectButtonBackground"
-      borderRadius="connectButton"
-      transform={{ active: 'shrink', hover: 'grow' }}
-      transition="default"
-    >
-      <Box
-        as="button"
-        background="connectButtonInnerBackground"
-        borderColor={
-          connectModalOpen
-            ? 'connectedProfileBorder'
-            : 'connectButtonBackground'
-        }
-        borderRadius="connectButton"
-        borderStyle="solid"
-        borderWidth="2"
-        boxShadow="connectButton"
-        color="connectButtonText"
-        fontFamily="body"
-        fontWeight="bold"
-        onClick={showConnectModal}
-        padding="8"
-        type="button"
-      >
-        Connect Wallet
-      </Box>
-    </Box>
-  );
+import { ConnectButtonRenderer } from './ConnectButtonRenderer';
 
 export interface ConnectButtonProps {
-  children?: ConnectButtonRenderer;
+  showChains?: boolean;
+  showBalance?: boolean;
+  showAvatar?: boolean;
 }
 
 export function ConnectButton({
-  children = defaultConnectButtonRenderer,
+  showAvatar = true,
+  showBalance = true,
+  showChains = true,
 }: ConnectButtonProps) {
-  const isMounted = useIsMounted();
-
-  const [{ data: accountData }, disconnect] = useAccount({
-    fetchEns: true,
-  });
-
-  const [{ data: balanceData }] = useBalance({
-    addressOrName: accountData?.address,
-  });
-
-  const [{ data: networkData }, switchNetwork] = useNetwork();
-
-  const chainIconUrlsById = useChainIconUrlsById();
-  const chainIconUrl = networkData.chain
-    ? chainIconUrlsById[networkData.chain.id] ?? undefined
-    : undefined;
-
-  const {
-    setFalse: hideConnectModal,
-    setTrue: showConnectModal,
-    value: connectModalOpen,
-  } = useBooleanState(false);
-
-  const {
-    setFalse: hideAccountModal,
-    setTrue: showAccountModal,
-    value: accountModalOpen,
-  } = useBooleanState(false);
-
-  const {
-    setFalse: hideChainModal,
-    setTrue: showChainModal,
-    value: chainModalOpen,
-  } = useBooleanState(false);
-
-  const hasAccountData = Boolean(accountData);
-  useEffect(() => {
-    hideConnectModal();
-    hideAccountModal();
-    hideChainModal();
-  }, [hasAccountData, hideConnectModal, hideAccountModal, hideChainModal]);
-
-  if (!isMounted) {
-    return null;
-  }
-
-  const displayBalance = balanceData
-    ? `${Number(balanceData.formatted).toPrecision(3)} ${balanceData.symbol}`
-    : undefined;
-
   return (
-    <>
-      {children({
-        account: accountData
-          ? {
-              address: accountData.address,
-              balanceDecimals: balanceData?.decimals,
-              balanceFormatted: balanceData?.formatted,
-              balanceSymbol: balanceData?.symbol,
-              displayBalance,
-              displayName:
-                accountData.ens?.name ?? formatAddress(accountData.address),
-              ensAvatar: accountData.ens?.avatar ?? undefined,
-              ensName: accountData.ens?.name,
-            }
-          : undefined,
+    <ConnectButtonRenderer>
+      {({
+        account,
         accountModalOpen,
-        chain: networkData?.chain
-          ? {
-              iconUrl: chainIconUrl,
-              id: networkData.chain.id,
-              name: networkData.chain.name,
-              unsupported: networkData.chain.unsupported,
-            }
-          : undefined,
-        chainModalOpen,
+        chain,
         connectModalOpen,
-        showAccountModal,
-        showChainModal,
-        showConnectModal,
-      })}
+        openAccountModal,
+        openChainModal,
+        openConnectModal,
+      }) =>
+        account ? (
+          <Box display="flex" gap="12">
+            {showChains && chain && (
+              <Box
+                alignItems="center"
+                as="button"
+                background={
+                  chain.unsupported
+                    ? 'connectButtonBackgroundError'
+                    : 'connectButtonBackground'
+                }
+                borderRadius="connectButton"
+                boxShadow="connectButton"
+                color={
+                  chain.unsupported
+                    ? 'connectButtonTextError'
+                    : 'connectButtonText'
+                }
+                display="flex"
+                fontFamily="body"
+                fontWeight="bold"
+                onClick={openChainModal}
+                paddingX="10"
+                paddingY="8"
+                transform={{ active: 'shrink', hover: 'grow' }}
+                transition="default"
+                type="button"
+              >
+                {chain.unsupported ? (
+                  <Box>Invalid network</Box>
+                ) : (
+                  <Box alignItems="center" display="flex" gap="4">
+                    {chain.iconUrl ? (
+                      <img
+                        alt={chain.name ?? 'Chain icon'}
+                        height="24"
+                        src={chain.iconUrl}
+                        width="24"
+                      />
+                    ) : null}
+                    <div>{chain.name ?? chain.id}</div>
+                  </Box>
+                )}
+                <DropdownIcon />
+              </Box>
+            )}
 
-      <ConnectModal onClose={hideConnectModal} open={connectModalOpen} />
-      <AccountModal
-        accountData={accountData}
-        balanceData={balanceData}
-        networkData={networkData}
-        onClose={hideAccountModal}
-        onDisconnect={disconnect}
-        open={accountModalOpen}
-      />
-      <ChainModal
-        networkData={networkData}
-        onClose={hideChainModal}
-        onSwitchNetwork={switchNetwork}
-        open={chainModalOpen}
-      />
-    </>
+            <Box
+              alignItems="center"
+              as="button"
+              background="connectButtonBackground"
+              borderRadius="connectButton"
+              boxShadow="connectButton"
+              color="connectButtonText"
+              display="flex"
+              fontFamily="body"
+              fontWeight="bold"
+              onClick={openAccountModal}
+              transform={{ active: 'shrink', hover: 'grow' }}
+              transition="default"
+              type="button"
+            >
+              {showBalance && account.displayBalance && (
+                <Box padding="8" paddingLeft="12">
+                  {account.displayBalance}
+                </Box>
+              )}
+              <Box
+                background="connectButtonInnerBackground"
+                borderColor={
+                  accountModalOpen
+                    ? 'connectedProfileBorder'
+                    : 'connectButtonBackground'
+                }
+                borderRadius="connectButton"
+                borderStyle="solid"
+                borderWidth="2"
+                color="connectButtonText"
+                fontFamily="body"
+                fontWeight="bold"
+                paddingX="8"
+                paddingY="6"
+                transition="default"
+              >
+                <Box alignItems="center" display="flex" height="24">
+                  {showAvatar && account.ensAvatar ? (
+                    <Box
+                      alt="ENS Avatar"
+                      as="img"
+                      borderRadius="full"
+                      height="24"
+                      marginRight="6"
+                      src={account.ensAvatar}
+                      width="24"
+                    />
+                  ) : null}
+                  {account.displayName}
+                  <DropdownIcon />
+                </Box>
+              </Box>
+            </Box>
+          </Box>
+        ) : (
+          <Box
+            background="connectButtonBackground"
+            borderRadius="connectButton"
+            transform={{ active: 'shrink', hover: 'grow' }}
+            transition="default"
+          >
+            <Box
+              as="button"
+              background="connectButtonInnerBackground"
+              borderColor={
+                connectModalOpen
+                  ? 'connectedProfileBorder'
+                  : 'connectButtonBackground'
+              }
+              borderRadius="connectButton"
+              borderStyle="solid"
+              borderWidth="2"
+              boxShadow="connectButton"
+              color="connectButtonText"
+              fontFamily="body"
+              fontWeight="bold"
+              onClick={openConnectModal}
+              padding="8"
+              type="button"
+            >
+              Connect Wallet
+            </Box>
+          </Box>
+        )
+      }
+    </ConnectButtonRenderer>
   );
 }
+
+ConnectButton.Custom = ConnectButtonRenderer;

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
@@ -1,0 +1,149 @@
+import React, { ReactNode, useCallback, useEffect, useState } from 'react';
+import { useAccount, useBalance, useNetwork } from 'wagmi';
+import { useIsMounted } from '../../hooks/useIsMounted';
+import { AccountModal } from '../AccountModal/AccountModal';
+import { ChainModal } from '../ChainModal/ChainModal';
+import { ConnectModal } from '../ConnectModal/ConnectModal';
+import { useChainIconUrlsById } from '../RainbowKitProvider/ChainIconsContext';
+import { formatAddress } from './formatAddress';
+
+const useBooleanState = (initialValue: boolean) => {
+  const [value, setValue] = useState(initialValue);
+  const setTrue = useCallback(() => setValue(true), []);
+  const setFalse = useCallback(() => setValue(false), []);
+
+  return { setFalse, setTrue, value };
+};
+
+export interface ConnectButtonRendererProps {
+  children: (renderProps: {
+    account?: {
+      address: string;
+      balanceDecimals?: number;
+      balanceFormatted?: string;
+      balanceSymbol?: string;
+      displayBalance?: string;
+      displayName: string;
+      ensAvatar?: string;
+      ensName?: string;
+    };
+    chain?: {
+      iconUrl?: string;
+      id: number;
+      name?: string;
+      unsupported?: boolean;
+    };
+    openAccountModal: () => void;
+    openChainModal: () => void;
+    openConnectModal: () => void;
+    accountModalOpen: boolean;
+    chainModalOpen: boolean;
+    connectModalOpen: boolean;
+  }) => ReactNode;
+}
+
+export function ConnectButtonRenderer({
+  children,
+}: ConnectButtonRendererProps) {
+  const isMounted = useIsMounted();
+
+  const [{ data: accountData }, disconnect] = useAccount({
+    fetchEns: true,
+  });
+
+  const [{ data: balanceData }] = useBalance({
+    addressOrName: accountData?.address,
+  });
+
+  const [{ data: networkData }, switchNetwork] = useNetwork();
+
+  const chainIconUrlsById = useChainIconUrlsById();
+  const chainIconUrl = networkData.chain
+    ? chainIconUrlsById[networkData.chain.id] ?? undefined
+    : undefined;
+
+  const {
+    setFalse: closeConnectModal,
+    setTrue: openConnectModal,
+    value: connectModalOpen,
+  } = useBooleanState(false);
+
+  const {
+    setFalse: closeAccountModal,
+    setTrue: openAccountModal,
+    value: accountModalOpen,
+  } = useBooleanState(false);
+
+  const {
+    setFalse: closeChainModal,
+    setTrue: openChainModal,
+    value: chainModalOpen,
+  } = useBooleanState(false);
+
+  const hasAccountData = Boolean(accountData);
+  useEffect(() => {
+    closeConnectModal();
+    closeAccountModal();
+    closeChainModal();
+  }, [hasAccountData, closeConnectModal, closeAccountModal, closeChainModal]);
+
+  if (!isMounted) {
+    return null;
+  }
+
+  const displayBalance = balanceData
+    ? `${Number(balanceData.formatted).toPrecision(3)} ${balanceData.symbol}`
+    : undefined;
+
+  return (
+    <>
+      {children({
+        account: accountData
+          ? {
+              address: accountData.address,
+              balanceDecimals: balanceData?.decimals,
+              balanceFormatted: balanceData?.formatted,
+              balanceSymbol: balanceData?.symbol,
+              displayBalance,
+              displayName:
+                accountData.ens?.name ?? formatAddress(accountData.address),
+              ensAvatar: accountData.ens?.avatar ?? undefined,
+              ensName: accountData.ens?.name,
+            }
+          : undefined,
+        accountModalOpen,
+        chain: networkData?.chain
+          ? {
+              iconUrl: chainIconUrl,
+              id: networkData.chain.id,
+              name: networkData.chain.name,
+              unsupported: networkData.chain.unsupported,
+            }
+          : undefined,
+        chainModalOpen,
+        connectModalOpen,
+        openAccountModal,
+        openChainModal,
+        openConnectModal,
+      })}
+
+      <ConnectModal onClose={closeConnectModal} open={connectModalOpen} />
+      <AccountModal
+        accountData={accountData}
+        balanceData={balanceData}
+        networkData={networkData}
+        onClose={closeAccountModal}
+        onDisconnect={disconnect}
+        open={accountModalOpen}
+      />
+      <ChainModal
+        networkData={networkData}
+        onClose={closeChainModal}
+        onSwitchNetwork={switchNetwork}
+        open={chainModalOpen}
+      />
+    </>
+  );
+}
+
+ConnectButtonRenderer.displayName = 'ConnectButton.Custom';


### PR DESCRIPTION
Since the `ConnectButton` component now has props that toggle the appearance of the built-in buttons, I needed to split out the custom button renderer into its own component, otherwise these new props are completely redundant when using a custom renderer. I've exposed it as `<ConnectButton.Custom>` but happy to change this.

To avoid confusion with the `showAvatar`/`showBalance`/`showChains` props, I've renamed the `show` functions passed to the custom button renderer, calling them `open` functions instead, e.g. `showConnectModal` -> `openConnectModal`.

I've added some checkboxes to the example app so you can easily toggle these props to see it in different states.