### PR TITLE
feat: support toggling chain icon/name and avatar/address

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,10 +400,10 @@ The `ConnectButton` component exposes the following props to customize its appea
   </thead>
   <tbody>
     <tr>
-      <td><code>showAvatar</code></td>
-      <td><code>boolean</code></td>
-      <td><code>true</code></td>
-      <td>Whether the avatar is visible next to the account name</td>
+      <td><code>accountStatus</code></td>
+      <td><code>"avatar" | "address" | "full"</code></td>
+      <td><code>"full"</code></td>
+      <td>Whether the active account’s avatar and/or address is displayed</td>
     </tr>
     <tr>
       <td><code>showBalance</code></td>
@@ -412,10 +412,10 @@ The `ConnectButton` component exposes the following props to customize its appea
       <td>Whether the balance is visible next to the account name</td>
     </tr>
     <tr>
-      <td><code>showChains</code></td>
-      <td><code>boolean</code></td>
-      <td><code>true</code></td>
-      <td>Whether the chain button is visible next to the account button</td>
+      <td><code>chainStatus</code></td>
+      <td><code>"icon" | "name" | "full" | "none"</code></td>
+      <td><code>"full"</code></td>
+      <td>Whether the current chain’s icon and/or name is displayed, or hidden entirely</td>
     </tr>
   </tbody>
 </table>

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -1,10 +1,14 @@
 import { ConnectButton } from '@rainbow-me/rainbowkit';
-import React, { useState } from 'react';
+import React, { ComponentProps, useState } from 'react';
+
+type ConnectButtonProps = ComponentProps<typeof ConnectButton>;
+type AccountStatus = ConnectButtonProps['accountStatus'];
+type ChainStatus = ConnectButtonProps['chainStatus'];
 
 const Example = () => {
-  const [showAvatar, setShowAvatar] = useState<boolean | undefined>();
+  const [accountStatus, setAccountStatus] = useState<AccountStatus>();
   const [showBalance, setShowBalance] = useState<boolean | undefined>();
-  const [showChains, setShowChains] = useState<boolean | undefined>();
+  const [chainStatus, setChainStatus] = useState<ChainStatus>();
 
   return (
     <div
@@ -22,9 +26,9 @@ const Example = () => {
         }}
       >
         <ConnectButton
-          showAvatar={showAvatar}
+          accountStatus={accountStatus}
+          chainStatus={chainStatus}
           showBalance={showBalance}
-          showChains={showChains}
         />
       </div>
 
@@ -72,45 +76,62 @@ const Example = () => {
 
       <div style={{ fontFamily: 'sans-serif' }}>
         <h3>ConnectButton props</h3>
-        <div
-          style={{
-            alignItems: 'flex-start',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 12,
-          }}
-        >
-          <label style={{ userSelect: 'none' }}>
-            <input
-              checked={showAvatar ?? true}
-              onChange={event => {
-                setShowAvatar(event.currentTarget.checked);
-              }}
-              type="checkbox"
-            />{' '}
-            showAvatar
-          </label>
-          <label style={{ userSelect: 'none' }}>
-            <input
-              checked={showBalance ?? true}
-              onChange={event => {
-                setShowBalance(event.currentTarget.checked);
-              }}
-              type="checkbox"
-            />{' '}
-            showBalance
-          </label>
-          <label style={{ userSelect: 'none' }}>
-            <input
-              checked={showChains ?? true}
-              onChange={event => {
-                setShowChains(event.currentTarget.checked);
-              }}
-              type="checkbox"
-            />{' '}
-            showChains
-          </label>
-        </div>
+        <table cellSpacing={12}>
+          <tbody>
+            <tr>
+              <td>
+                <label htmlFor="accountStatus">accountStatus</label>
+              </td>
+              <td>
+                <select
+                  id="accountStatus"
+                  onChange={event =>
+                    setAccountStatus(event.currentTarget.value as AccountStatus)
+                  }
+                  value={accountStatus}
+                >
+                  <option>full</option>
+                  <option>avatar</option>
+                  <option>address</option>
+                </select>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <label htmlFor="showBalance">showBalance</label>
+              </td>
+              <td>
+                <input
+                  checked={showBalance ?? true}
+                  id="showBalance"
+                  onChange={event => {
+                    setShowBalance(event.currentTarget.checked);
+                  }}
+                  type="checkbox"
+                />
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <label htmlFor="chainStatus">chainStatus</label>
+              </td>
+              <td>
+                <select
+                  id="chainStatus"
+                  onChange={event =>
+                    setChainStatus(event.currentTarget.value as ChainStatus)
+                  }
+                  value={chainStatus}
+                >
+                  <option>full</option>
+                  <option>icon</option>
+                  <option>name</option>
+                  <option>none</option>
+                </select>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -5,15 +5,15 @@ import { DropdownIcon } from '../Icons/Dropdown';
 import { ConnectButtonRenderer } from './ConnectButtonRenderer';
 
 export interface ConnectButtonProps {
-  showChains?: boolean;
+  accountStatus?: 'full' | 'avatar' | 'address';
   showBalance?: boolean;
-  showAvatar?: boolean;
+  chainStatus?: 'full' | 'icon' | 'name' | 'none';
 }
 
 export function ConnectButton({
-  showAvatar = true,
+  accountStatus = 'full',
+  chainStatus = 'full',
   showBalance = true,
-  showChains = true,
 }: ConnectButtonProps) {
   return (
     <ConnectButtonRenderer>
@@ -25,8 +25,20 @@ export function ConnectButton({
         openAccountModal,
         openChainModal,
         openConnectModal,
-      }) =>
-        account ? (
+      }) => {
+        const showChains = chainStatus !== 'none';
+        const showChainIcon = chainStatus === 'icon' || chainStatus === 'full';
+        const showChainName =
+          chainStatus === 'name' ||
+          chainStatus === 'full' ||
+          (chainStatus === 'icon' && !chain?.iconUrl); // If there is no iconUrl, show the name
+
+        const showAvatar =
+          accountStatus === 'avatar' || accountStatus === 'full';
+        const showAddress =
+          accountStatus === 'address' || accountStatus === 'full';
+
+        return account ? (
           <Box display="flex" gap="12">
             {showChains && chain && (
               <Box
@@ -47,6 +59,7 @@ export function ConnectButton({
                 display="flex"
                 fontFamily="body"
                 fontWeight="bold"
+                gap="6"
                 onClick={openChainModal}
                 paddingX="10"
                 paddingY="8"
@@ -58,7 +71,7 @@ export function ConnectButton({
                   <Box>Invalid network</Box>
                 ) : (
                   <Box alignItems="center" display="flex" gap="4">
-                    {chain.iconUrl ? (
+                    {showChainIcon && chain.iconUrl ? (
                       <img
                         alt={chain.name ?? 'Chain icon'}
                         height="24"
@@ -66,7 +79,7 @@ export function ConnectButton({
                         width="24"
                       />
                     ) : null}
-                    <div>{chain.name ?? chain.id}</div>
+                    {showChainName && <div>{chain.name ?? chain.id}</div>}
                   </Box>
                 )}
                 <DropdownIcon />
@@ -118,8 +131,9 @@ export function ConnectButton({
                       size={24}
                     />
                   )}
-                  <Box alignItems="center" display="flex">
-                    {account.displayName}
+
+                  <Box alignItems="center" display="flex" gap="6">
+                    {showAddress && <div>{account.displayName}</div>}
                     <DropdownIcon />
                   </Box>
                 </Box>
@@ -155,8 +169,8 @@ export function ConnectButton({
               Connect Wallet
             </Box>
           </Box>
-        )
-      }
+        );
+      }}
     </ConnectButtonRenderer>
   );
 }

--- a/packages/rainbowkit/src/components/Icons/Dropdown.tsx
+++ b/packages/rainbowkit/src/components/Icons/Dropdown.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
-import { DropdownIconClassName } from './Icons.css';
 
 export const DropdownIcon = () => (
-  <svg
-    className={DropdownIconClassName}
-    fill="none"
-    height="7"
-    width="14"
-    xmlns="http://www.w3.org/2000/svg"
-  >
+  <svg fill="none" height="7" width="14" xmlns="http://www.w3.org/2000/svg">
     <path
       d="M12.75 1.54001L8.51647 5.0038C7.77974 5.60658 6.72026 5.60658 5.98352 5.0038L1.75 1.54001"
       stroke="currentColor"

--- a/packages/rainbowkit/src/components/Icons/Icons.css.ts
+++ b/packages/rainbowkit/src/components/Icons/Icons.css.ts
@@ -1,10 +1,6 @@
 import { keyframes, style } from '@vanilla-extract/css';
 import { sprinkles } from '../../css/sprinkles.css';
 
-export const DropdownIconClassName = sprinkles({
-  marginLeft: '6',
-});
-
 export const CloseIconClassName = sprinkles({
   marginLeft: '6',
 });


### PR DESCRIPTION
Note that to prevent invalid states (e.g. hiding both avatar and account name), I've switched from boolean props to enums.

Couldn't think of better names for the props, so happy to hear any suggestions 😅