### PR TITLE
feat: support responsive ConnectButton appearance props

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,9 @@ const App = () => {
 
 ## `ConnectButton`
 
-The `ConnectButton` component exposes the following props to customize its appearance.
+The `ConnectButton` component exposes several props to customize its appearance by toggling the visibility of different elements.
+
+These props can also be defined in a responsive format, e.g. `showBalance={{ smallScreen: false, largeScreen: true }}`, allowing you to customize its appearance across different screen sizes. Note that the built-in `"largeScreen"` breakpoint is `768px`.
 
 <table>
   <thead>
@@ -401,21 +403,21 @@ The `ConnectButton` component exposes the following props to customize its appea
   <tbody>
     <tr>
       <td><code>accountStatus</code></td>
-      <td><code>"avatar" | "address" | "full"</code></td>
+      <td><code>"avatar" | "address" | "full" | { smallScreen: AccountStatus, largeScreen?: AccountStatus }</code></td>
       <td><code>"full"</code></td>
       <td>Whether the active account’s avatar and/or address is displayed</td>
     </tr>
     <tr>
-      <td><code>showBalance</code></td>
-      <td><code>boolean</code></td>
-      <td><code>true</code></td>
-      <td>Whether the balance is visible next to the account name</td>
+      <td><code>chainStatus</code></td>
+      <td><code>"icon" | "name" | "full" | "none" | { smallScreen: ChainStatus, largeScreen?: ChainStatus }</code></td>
+      <td><code>{ smallScreen: "icon", largeScreen: "full" }</code></td>
+      <td>Whether the current chain’s icon and/or name is displayed, or hidden entirely</td>
     </tr>
     <tr>
-      <td><code>chainStatus</code></td>
-      <td><code>"icon" | "name" | "full" | "none"</code></td>
-      <td><code>"full"</code></td>
-      <td>Whether the current chain’s icon and/or name is displayed, or hidden entirely</td>
+      <td><code>showBalance</code></td>
+      <td><code>boolean | { smallScreen: boolean, largeScreen?: boolean }</code></td>
+      <td><code>{ smallScreen: false, largeScreen: true }</code></td>
+      <td>Whether the balance is visible next to the account name</td>
     </tr>
   </tbody>
 </table>

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -2,13 +2,29 @@ import { ConnectButton } from '@rainbow-me/rainbowkit';
 import React, { ComponentProps, useState } from 'react';
 
 type ConnectButtonProps = ComponentProps<typeof ConnectButton>;
-type AccountStatus = ConnectButtonProps['accountStatus'];
-type ChainStatus = ConnectButtonProps['chainStatus'];
+type ExtractString<Value> = Value extends string ? Value : never;
+type AccountStatus = ExtractString<ConnectButtonProps['accountStatus']>;
+type ChainStatus = ExtractString<ConnectButtonProps['chainStatus']>;
 
 const Example = () => {
-  const [accountStatus, setAccountStatus] = useState<AccountStatus>();
-  const [showBalance, setShowBalance] = useState<boolean | undefined>();
-  const [chainStatus, setChainStatus] = useState<ChainStatus>();
+  const defaultProps = ConnectButton.__defaultProps;
+
+  const [accountStatusSmallScreen, setAccountStatusSmallScreen] =
+    useState<AccountStatus>(defaultProps.accountStatus);
+  const [accountStatusLargeScreen, setAccountStatusLargeScreen] =
+    useState<AccountStatus>(defaultProps.accountStatus);
+
+  const [chainStatusSmallScreen, setChainStatusSmallScreen] =
+    useState<ChainStatus>(defaultProps.chainStatus.smallScreen);
+  const [chainStatusLargeScreen, setChainStatusLargeScreen] =
+    useState<ChainStatus>(defaultProps.chainStatus.largeScreen);
+
+  const [showBalanceSmallScreen, setShowBalanceSmallScreen] = useState<boolean>(
+    defaultProps.showBalance.smallScreen
+  );
+  const [showBalanceLargeScreen, setShowBalanceLargeScreen] = useState<boolean>(
+    defaultProps.showBalance.largeScreen
+  );
 
   return (
     <div
@@ -26,9 +42,18 @@ const Example = () => {
         }}
       >
         <ConnectButton
-          accountStatus={accountStatus}
-          chainStatus={chainStatus}
-          showBalance={showBalance}
+          accountStatus={{
+            largeScreen: accountStatusLargeScreen,
+            smallScreen: accountStatusSmallScreen,
+          }}
+          chainStatus={{
+            largeScreen: chainStatusLargeScreen,
+            smallScreen: chainStatusSmallScreen,
+          }}
+          showBalance={{
+            largeScreen: showBalanceLargeScreen,
+            smallScreen: showBalanceSmallScreen,
+          }}
         />
       </div>
 
@@ -77,6 +102,13 @@ const Example = () => {
       <div style={{ fontFamily: 'sans-serif' }}>
         <h3>ConnectButton props</h3>
         <table cellSpacing={12}>
+          <thead>
+            <tr>
+              <th>Prop</th>
+              <th>smallScreen</th>
+              <th>largeScreen</th>
+            </tr>
+          </thead>
           <tbody>
             <tr>
               <td>
@@ -86,9 +118,26 @@ const Example = () => {
                 <select
                   id="accountStatus"
                   onChange={event =>
-                    setAccountStatus(event.currentTarget.value as AccountStatus)
+                    setAccountStatusSmallScreen(
+                      event.currentTarget.value as AccountStatus
+                    )
                   }
-                  value={accountStatus}
+                  value={accountStatusSmallScreen}
+                >
+                  <option>full</option>
+                  <option>avatar</option>
+                  <option>address</option>
+                </select>
+              </td>
+              <td>
+                <select
+                  id="accountStatus"
+                  onChange={event =>
+                    setAccountStatusLargeScreen(
+                      event.currentTarget.value as AccountStatus
+                    )
+                  }
+                  value={accountStatusLargeScreen}
                 >
                   <option>full</option>
                   <option>avatar</option>
@@ -102,10 +151,20 @@ const Example = () => {
               </td>
               <td>
                 <input
-                  checked={showBalance ?? true}
+                  checked={showBalanceSmallScreen}
                   id="showBalance"
                   onChange={event => {
-                    setShowBalance(event.currentTarget.checked);
+                    setShowBalanceSmallScreen(event.currentTarget.checked);
+                  }}
+                  type="checkbox"
+                />
+              </td>
+              <td>
+                <input
+                  checked={showBalanceLargeScreen}
+                  id="showBalance"
+                  onChange={event => {
+                    setShowBalanceLargeScreen(event.currentTarget.checked);
                   }}
                   type="checkbox"
                 />
@@ -119,9 +178,27 @@ const Example = () => {
                 <select
                   id="chainStatus"
                   onChange={event =>
-                    setChainStatus(event.currentTarget.value as ChainStatus)
+                    setChainStatusSmallScreen(
+                      event.currentTarget.value as ChainStatus
+                    )
                   }
-                  value={chainStatus}
+                  value={chainStatusSmallScreen}
+                >
+                  <option>full</option>
+                  <option>icon</option>
+                  <option>name</option>
+                  <option>none</option>
+                </select>
+              </td>
+              <td>
+                <select
+                  id="chainStatus"
+                  onChange={event =>
+                    setChainStatusLargeScreen(
+                      event.currentTarget.value as ChainStatus
+                    )
+                  }
+                  value={chainStatusLargeScreen}
                 >
                   <option>full</option>
                   <option>icon</option>

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@vanilla-extract/css": "^1.6.6",
     "@vanilla-extract/dynamic": "^2.0.2",
-    "@vanilla-extract/sprinkles": "^1.3.2",
+    "@vanilla-extract/sprinkles": "^1.4.0",
     "clsx": "^1.1.1",
     "detect-browser": "^5.3.0",
     "focus-visible": "^5.2.0",

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -1,19 +1,29 @@
 import React from 'react';
+import { mapResponsiveValue, ResponsiveValue } from '../../css/sprinkles.css';
 import { Avatar } from '../Avatar/Avatar';
 import { Box } from '../Box/Box';
 import { DropdownIcon } from '../Icons/Dropdown';
 import { ConnectButtonRenderer } from './ConnectButtonRenderer';
 
+type AccountStatus = 'full' | 'avatar' | 'address';
+type ChainStatus = 'full' | 'icon' | 'name' | 'none';
+
 export interface ConnectButtonProps {
-  accountStatus?: 'full' | 'avatar' | 'address';
-  showBalance?: boolean;
-  chainStatus?: 'full' | 'icon' | 'name' | 'none';
+  accountStatus?: ResponsiveValue<AccountStatus>;
+  showBalance?: ResponsiveValue<boolean>;
+  chainStatus?: ResponsiveValue<ChainStatus>;
 }
 
+const defaultProps = {
+  accountStatus: 'full',
+  chainStatus: { largeScreen: 'full', smallScreen: 'icon' },
+  showBalance: { largeScreen: true, smallScreen: false },
+} as const;
+
 export function ConnectButton({
-  accountStatus = 'full',
-  chainStatus = 'full',
-  showBalance = true,
+  accountStatus = defaultProps.accountStatus,
+  chainStatus = defaultProps.chainStatus,
+  showBalance = defaultProps.showBalance,
 }: ConnectButtonProps) {
   return (
     <ConnectButtonRenderer>
@@ -26,21 +36,9 @@ export function ConnectButton({
         openChainModal,
         openConnectModal,
       }) => {
-        const showChains = chainStatus !== 'none';
-        const showChainIcon = chainStatus === 'icon' || chainStatus === 'full';
-        const showChainName =
-          chainStatus === 'name' ||
-          chainStatus === 'full' ||
-          (chainStatus === 'icon' && !chain?.iconUrl); // If there is no iconUrl, show the name
-
-        const showAvatar =
-          accountStatus === 'avatar' || accountStatus === 'full';
-        const showAddress =
-          accountStatus === 'address' || accountStatus === 'full';
-
         return account ? (
           <Box display="flex" gap="12">
-            {showChains && chain && (
+            {chain && (
               <Box
                 alignItems="center"
                 as="button"
@@ -56,7 +54,9 @@ export function ConnectButton({
                     ? 'connectButtonTextError'
                     : 'connectButtonText'
                 }
-                display="flex"
+                display={mapResponsiveValue(chainStatus, value =>
+                  value === 'none' ? 'none' : 'flex'
+                )}
                 fontFamily="body"
                 fontWeight="bold"
                 gap="6"
@@ -71,15 +71,33 @@ export function ConnectButton({
                   <Box>Invalid network</Box>
                 ) : (
                   <Box alignItems="center" display="flex" gap="4">
-                    {showChainIcon && chain.iconUrl ? (
-                      <img
+                    {chain.iconUrl ? (
+                      <Box
                         alt={chain.name ?? 'Chain icon'}
+                        as="img"
+                        display={mapResponsiveValue(chainStatus, value =>
+                          value === 'full' || value === 'icon'
+                            ? 'block'
+                            : 'none'
+                        )}
                         height="24"
                         src={chain.iconUrl}
                         width="24"
                       />
                     ) : null}
-                    {showChainName && <div>{chain.name ?? chain.id}</div>}
+                    <Box
+                      display={mapResponsiveValue(chainStatus, value => {
+                        if (value === 'icon' && !chain.iconUrl) {
+                          return 'block'; // Show the chain name if there is no iconUrl
+                        }
+
+                        return value === 'full' || value === 'name'
+                          ? 'block'
+                          : 'none';
+                      })}
+                    >
+                      {chain.name ?? chain.id}
+                    </Box>
                   </Box>
                 )}
                 <DropdownIcon />
@@ -101,8 +119,14 @@ export function ConnectButton({
               transition="default"
               type="button"
             >
-              {showBalance && account.displayBalance && (
-                <Box padding="8" paddingLeft="12">
+              {account.displayBalance && (
+                <Box
+                  display={mapResponsiveValue(showBalance, value =>
+                    value ? 'block' : 'none'
+                  )}
+                  padding="8"
+                  paddingLeft="12"
+                >
                   {account.displayBalance}
                 </Box>
               )}
@@ -122,16 +146,28 @@ export function ConnectButton({
                 transition="default"
               >
                 <Box alignItems="center" display="flex" gap="6" height="24">
-                  {showAvatar && (
+                  <Box
+                    display={mapResponsiveValue(accountStatus, value =>
+                      value === 'full' || value === 'avatar' ? 'block' : 'none'
+                    )}
+                  >
                     <Avatar
                       address={account.address}
                       imageUrl={account.ensAvatar}
                       size={24}
                     />
-                  )}
+                  </Box>
 
                   <Box alignItems="center" display="flex" gap="6">
-                    {showAddress && <div>{account.displayName}</div>}
+                    <Box
+                      display={mapResponsiveValue(accountStatus, value =>
+                        value === 'full' || value === 'address'
+                          ? 'block'
+                          : 'none'
+                      )}
+                    >
+                      {account.displayName}
+                    </Box>
                     <DropdownIcon />
                   </Box>
                 </Box>
@@ -171,4 +207,5 @@ export function ConnectButton({
   );
 }
 
+ConnectButton.__defaultProps = defaultProps;
 ConnectButton.Custom = ConnectButtonRenderer;

--- a/packages/rainbowkit/src/components/Dialog/Dialog.css.ts
+++ b/packages/rainbowkit/src/components/Dialog/Dialog.css.ts
@@ -15,8 +15,8 @@ const bleed = 200;
 export const overlay = style([
   sprinkles({
     alignItems: {
-      desktop: 'center',
-      mobile: 'flex-end',
+      largeScreen: 'center',
+      smallScreen: 'flex-end',
     },
     background: 'modalBackdrop',
     display: 'flex',

--- a/packages/rainbowkit/src/components/Dialog/DialogContent.css.ts
+++ b/packages/rainbowkit/src/components/Dialog/DialogContent.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css';
-import { desktopMinWidth, sprinkles } from '../../css/sprinkles.css';
+import { largeScreenMinWidth, sprinkles } from '../../css/sprinkles.css';
 
 export const dialogContent = style([
   sprinkles({
@@ -14,7 +14,7 @@ export const dialogContent = style([
 const bleed = 200;
 export const bottomSheetOverrides = style({
   '@media': {
-    [`screen and (max-width: ${desktopMinWidth - 1}px)`]: {
+    [`screen and (max-width: ${largeScreenMinWidth - 1}px)`]: {
       borderBottomLeftRadius: 0,
       borderBottomRightRadius: 0,
       marginTop: -bleed,

--- a/packages/rainbowkit/src/css/sprinkles.css.ts
+++ b/packages/rainbowkit/src/css/sprinkles.css.ts
@@ -1,6 +1,11 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 import { createGlobalThemeContract } from '@vanilla-extract/css';
-import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles';
+import {
+  createMapValueFn,
+  createSprinkles,
+  defineProperties,
+  RequiredConditionalValue,
+} from '@vanilla-extract/sprinkles';
 
 import './reset.css';
 
@@ -107,20 +112,28 @@ const interactionProperties = defineProperties({
   },
 });
 
-export const desktopMinWidth = 768;
+export const largeScreenMinWidth = 768;
 
-const responsiveLayoutStyles = defineProperties({
+const responsiveProperties = defineProperties({
   conditions: {
-    mobile: {},
-    desktop: { '@media': `screen and (min-width: ${desktopMinWidth}px)` },
+    smallScreen: {},
+    largeScreen: {
+      '@media': `screen and (min-width: ${largeScreenMinWidth}px)`,
+    },
   },
-  defaultCondition: 'mobile',
+  defaultCondition: 'smallScreen',
   properties: {
     alignItems: flexAlignment,
+    display: ['none', 'block', 'flex'],
   },
 });
 
-const layoutStyles = defineProperties({
+export type ResponsiveValue<Value extends string | number | boolean> =
+  RequiredConditionalValue<typeof responsiveProperties, Value>;
+
+export const mapResponsiveValue = createMapValueFn(responsiveProperties);
+
+const unresponsiveProperties = defineProperties({
   properties: {
     alignSelf: flexAlignment,
     backgroundSize: ['cover'] as const,
@@ -138,7 +151,7 @@ const layoutStyles = defineProperties({
       '2': '2px',
       '4': '4px',
     },
-    display: ['none', 'block', 'flex', 'inline-flex'],
+    cursor: ['pointer'],
     flexDirection: ['row', 'column'],
     fontFamily: themeVars.fonts,
     fontSize: {
@@ -187,7 +200,7 @@ const layoutStyles = defineProperties({
   },
 });
 
-const colorStyles = defineProperties({
+const colorProperties = defineProperties({
   conditions: {
     base: {},
     hover: { selector: '&:hover' },
@@ -202,17 +215,10 @@ const colorStyles = defineProperties({
   },
 });
 
-const unresponsiveProperties = defineProperties({
-  properties: {
-    cursor: ['pointer'],
-  } as const,
-});
-
 export const sprinkles = createSprinkles(
-  colorStyles,
+  colorProperties,
   interactionProperties,
-  layoutStyles,
-  responsiveLayoutStyles,
+  responsiveProperties,
   unresponsiveProperties
 );
 export type Sprinkles = Parameters<typeof sprinkles>[0];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,5 @@
 lockfileVersion: 5.3
 
-onlyBuiltDependencies:
-  - esbuild
-
 importers:
 
   .:
@@ -101,7 +98,7 @@ importers:
       '@vanilla-extract/css': ^1.6.6
       '@vanilla-extract/dynamic': ^2.0.2
       '@vanilla-extract/private': ^1.0.2
-      '@vanilla-extract/sprinkles': ^1.3.2
+      '@vanilla-extract/sprinkles': ^1.4.0
       autoprefixer: ^10.4.0
       clsx: ^1.1.1
       detect-browser: ^5.3.0
@@ -113,7 +110,7 @@ importers:
     dependencies:
       '@vanilla-extract/css': 1.6.8
       '@vanilla-extract/dynamic': 2.0.2
-      '@vanilla-extract/sprinkles': 1.3.3_@vanilla-extract+css@1.6.8
+      '@vanilla-extract/sprinkles': 1.4.0_@vanilla-extract+css@1.6.8
       clsx: 1.1.1
       detect-browser: 5.3.0
       focus-visible: 5.2.0
@@ -2645,8 +2642,8 @@ packages:
   /@vanilla-extract/private/1.0.3:
     resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
 
-  /@vanilla-extract/sprinkles/1.3.3_@vanilla-extract+css@1.6.8:
-    resolution: {integrity: sha512-LoxDYbVSrNZdsXME09UUescV9v2tT0AI2yalavR3KCGNY89i2Lp7j7iNZuXJMPK4MzW7CErfYDffcpJ5+PyU2g==}
+  /@vanilla-extract/sprinkles/1.4.0_@vanilla-extract+css@1.6.8:
+    resolution: {integrity: sha512-q9Tu5bHkN/fT0IFkBDEsNeTKN/8CFYkgGVDw0iZ+wM/n9IKhWrKLnOjDk1v9NpCXD3rUQqDipl0pdGCEcBe4RQ==}
     peerDependencies:
       '@vanilla-extract/css': ^1.0.0
     dependencies:
@@ -7991,3 +7988,6 @@ packages:
     dependencies:
       bn.js: 4.12.0
       ethereumjs-util: 6.2.1
+
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
This also gives us a much better default layout on mobile, ensuring content fits on the screen out of the box.

Note that I've renamed our responsive conditions from `'mobile' | 'desktop'` to `'smallScreen' | 'largeScreen'` to avoid any confusion for consumers since it's not based on the device type. Also gives us room to add more breakpoints in the future without the naming getting too awkward.