### PR TITLE
chore: adds neverBuiltDeps to pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
+    ],
+    "neverBuiltDependencies": [
+      "core-js-pure"
     ]
   }
 }


### PR DESCRIPTION
Testing `neverBuiltDependencies` from pnpm