### PR TITLE
fix: ensure 'useMobileWalletButton' hook is always available

### DIFF
--- a/packages/rainbowkit/src/components/RainbowKitProvider/omitUndefinedValues.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/omitUndefinedValues.ts
@@ -1,0 +1,5 @@
+export function omitUndefinedValues<T>(obj: T): T {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([_key, value]) => value !== undefined)
+  ) as T;
+}

--- a/packages/rainbowkit/src/components/RainbowKitProvider/wallet.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/wallet.ts
@@ -5,6 +5,7 @@ import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
 import { WalletLinkConnector } from 'wagmi/connectors/walletLink';
 import { isMobile } from '../../utils/isMobile';
 import { Chain } from './ChainIconsContext';
+import { omitUndefinedValues } from './omitUndefinedValues';
 
 export type WalletConnectorConfig<C extends Connector = Connector> = {
   connector: C;
@@ -242,7 +243,7 @@ export const getDefaultWallets = ({
 export const connectorsForWallets = (wallets: Wallet[] = []) => {
   const connectors = (connectorArgs: ConnectorArgs) =>
     wallets.map(createWallet => {
-      const wallet = createWallet(connectorArgs);
+      const wallet = omitUndefinedValues(createWallet(connectorArgs));
 
       if (wallet.connector._wallet) {
         throw new Error(


### PR DESCRIPTION
We were getting errors about a missing `useMobileWalletButton` hook when toggling between desktop and mobile in browser dev tools. This error doesn't occur for end users though because you had to transition between the different devices within the same session.

Turns out it's because the `metaMask` wallet was setting this hook to undefined on desktop which was overriding the default implementation, resulting in a missing hook. This PR fixes it at the source by omitting any undefined values from wallet objects before making them available to the rest of the application.