### PR TITLE
fix: better disable wallet options that are not ready

### DIFF
--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -111,6 +111,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
             return (
               <ModalSelection
                 currentlySelected={wallet.id === selectedOptionId}
+                disabled={!wallet.ready}
                 key={wallet.id}
                 onClick={() => onSelectWallet(wallet)}
               >
@@ -122,7 +123,6 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
                         : 'modalText'
                       : 'modalTextSecondary'
                   }
-                  disabled={!wallet.ready}
                   fontFamily="body"
                   fontSize="16"
                   fontWeight="bold"

--- a/packages/rainbowkit/src/components/ModalSelection/ModalSelection.tsx
+++ b/packages/rainbowkit/src/components/ModalSelection/ModalSelection.tsx
@@ -4,6 +4,7 @@ import { HoverClassName, SelectedClassName } from './ModalSelection.css';
 
 type Props = {
   children?: React.ReactNode;
+  disabled?: boolean;
   onClick?: React.MouseEventHandler<HTMLElement> | undefined;
   as?: React.ElementType<any>;
   currentlySelected?: boolean;
@@ -15,6 +16,7 @@ export const ModalSelection = React.forwardRef(
       as = 'button',
       children,
       currentlySelected = false,
+      disabled,
       onClick,
       ...urlProps
     }: Props,
@@ -23,8 +25,14 @@ export const ModalSelection = React.forwardRef(
     return (
       <Box
         as={as}
-        className={currentlySelected ? SelectedClassName : HoverClassName}
-        disabled={currentlySelected}
+        className={
+          disabled
+            ? null
+            : currentlySelected
+            ? SelectedClassName
+            : HoverClassName
+        }
+        disabled={currentlySelected || disabled}
         onClick={onClick}
         ref={ref}
         {...urlProps}


### PR DESCRIPTION
fixes this issue:

![eb5ad650-4520-4a2f-a6a1-a1c3670a3b8c](https://user-images.githubusercontent.com/16931094/156856009-4938cc7d-ce14-40ed-b991-cc22f7b5fec4.png)


now if wallets are not ready they are unclickable & have no hover effect