### PR TITLE
fix: make QR code squares slightly less round

### DIFF
--- a/packages/rainbowkit/src/components/QRCode/QRCode.tsx
+++ b/packages/rainbowkit/src/components/QRCode/QRCode.tsx
@@ -60,8 +60,8 @@ export function QRCode({
             fill={i % 2 !== 0 ? 'white' : 'black'}
             height={cellSize * (7 - i * 2)}
             key={`${i}-${x}-${y}`}
-            rx={(i - 3) * -5 + (i === 0 ? 2 : 0)} // calculated border radius for corner squares
-            ry={(i - 3) * -5 + (i === 0 ? 2 : 0)} // calculated border radius for corner squares
+            rx={(i - 2) * -5 + (i === 0 ? 2 : 0)} // calculated border radius for corner squares
+            ry={(i - 2) * -5 + (i === 0 ? 2 : 0)} // calculated border radius for corner squares
             width={cellSize * (7 - i * 2)}
             x={x1 + cellSize * i}
             y={y1 + cellSize * i}


### PR DESCRIPTION
make borders less round in QR code so camera picks them up easier

before:
<img width="406" alt="Screen Shot 2022-03-07 at 5 30 01 PM" src="https://user-images.githubusercontent.com/16931094/157128870-6c55baaa-26a2-46bf-a21b-7b0f4a8e21ca.png">

after:
<img width="407" alt="Screen Shot 2022-03-07 at 5 29 39 PM" src="https://user-images.githubusercontent.com/16931094/157128879-3fd1df9b-df67-482c-949e-bd306de79484.png">

