### PR TITLE
fix: use curly apostrophes

### DIFF
--- a/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
@@ -115,7 +115,7 @@ export function GetDetail({
         style={{ maxWidth: 275, textAlign: 'center' }}
       >
         <Text color="modalText" size="14" weight="bold">
-          Not what you&apos;re looking for?
+          Not what you&rsquo;re looking for?
         </Text>
         <Text color="modalTextSecondary" size="14" weight="semibold">
           Select a wallet on the left to get started with a different wallet
@@ -228,7 +228,7 @@ export function ConnectDetail({
         {!ready ? null : name === 'Rainbow' ? (
           <>
             <Text color="menuTextSecondary" size="14" weight="bold">
-              Don&apos;t have the Rainbow Mobile App Yet?
+              Don&rsquo;t have the Rainbow Mobile App Yet?
             </Text>
             <Button
               label="GET"

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -116,7 +116,7 @@ export function MobileOptions({ onClose }: { onClose: () => void }) {
               </Text>
               <Text color="modalTextSecondary" size="16">
                 A wallet is used to send, receive, store, and display digital
-                assets like Ethereum and NFTs. It&apos;s also a new way to log
+                assets like Ethereum and NFTs. It&rsquo;s also a new way to log
                 in, without needing to create new accounts and passwords
                 on&nbsp;every&nbsp;website.
               </Text>
@@ -216,7 +216,7 @@ export function MobileOptions({ onClose }: { onClose: () => void }) {
               style={{ maxWidth: 360 }}
             >
               <Text color="modalText" size="16" weight="bold">
-                Not what you&apos;re looking for?
+                Not what you&rsquo;re looking for?
               </Text>
               <Text color="modalTextSecondary" size="16">
                 Select a wallet on the main screen to get started with a


### PR DESCRIPTION
This is a very important update.

Before:

<img width="519" alt="Screen Shot 2022-03-08 at 2 40 39 pm" src="https://user-images.githubusercontent.com/696693/157162011-964a153e-012f-445c-8e5d-96669677bd08.png">


After:

<img width="522" alt="Screen Shot 2022-03-08 at 2 40 19 pm" src="https://user-images.githubusercontent.com/696693/157162029-6b5a40fd-57fe-42c7-94ff-52091ccca601.png">

