### PR TITLE
RNBW-2792: adds `clean` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "chgset:run": "changeset",
     "chgset:version": "changeset version",
     "chgset": "pnpm chgset:run && pnpm chgset:version",
+    "clean": "rm -rf ./packages/rainbowkit/dist && rm -rf ./packages/rainbowkit/node_modules",
     "release": "changeset publish",
     "prerelease": "MINIFY_CSS=true pnpm build --recursive && cp README.md packages/rainbowkit/README.md",
     "ci:example": "pnpm prepare --filter=@rainbow-me/rainbowkit && pnpm build --filter=example",


### PR DESCRIPTION
RNBW-2792

- Removes `/dist` and `/node_modules` from `rainbowkit` package.
- To be used prior to building and publishing locally