### PR TITLE
feat: make UI respond to custom qrcode wallets

### DIFF
--- a/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
@@ -254,10 +254,10 @@ export function ConnectDetail({
         justifyContent="space-between"
         marginTop="6"
       >
-        {!ready ? null : name === 'Rainbow' ? (
+        {!ready ? null : qrCode ? (
           <>
             <Text color="modalTextSecondary" size="14" weight="medium">
-              Don&rsquo;t have the Rainbow App?
+              Don&rsquo;t have the {name} App?
             </Text>
             <ActionButton
               label="GET"
@@ -378,7 +378,13 @@ export function InstructionDetail({
             gap="16"
             key={idx}
           >
-            <Box height="48" minWidth="48" width="48">
+            <Box
+              borderRadius="10"
+              height="48"
+              minWidth="48"
+              overflow="hidden"
+              width="48"
+            >
               {stepIcons[d.step]?.(wallet)}
             </Box>
             <Box display="flex" flexDirection="column" gap="4">

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -32,7 +32,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
     string | undefined
   >();
   const [selectedWallet, setSelectedWallet] = useState<WalletConnector>();
-  const isRainbow = selectedOptionId === 'rainbow';
+  const hasQrCode = !!selectedWallet?.qrCode;
   const [connectionError, setConnectionError] = useState(false);
   const wallets = useWalletConnectors().filter(
     wallet => wallet.ready || wallet.downloadUrls?.browserExtension
@@ -94,13 +94,13 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
           wallet={selectedWallet}
         />
       );
-      headerLabel = isRainbow && 'Scan with Rainbow to connect';
+      headerLabel = hasQrCode && `Scan with ${selectedWallet.name} to connect`;
       break;
     case WalletStep.Download:
       walletContent = selectedWallet && (
         <DownloadDetail setWalletStep={setWalletStep} wallet={selectedWallet} />
       );
-      headerLabel = isRainbow && 'Install Rainbow';
+      headerLabel = hasQrCode && `Install ${selectedWallet.name}`;
       headerBackButtonLink = WalletStep.Connect;
       break;
     case WalletStep.Instructions:
@@ -110,7 +110,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
           wallet={selectedWallet}
         />
       );
-      headerLabel = isRainbow && 'Get started with Rainbow';
+      headerLabel = hasQrCode && `Get started with ${selectedWallet.name}`;
       headerBackButtonLink = WalletStep.Download;
       break;
     default:


### PR DESCRIPTION
listen for qrCode prop in the walletConfig to display the QrCode headers & footers, plus allow to enter the wallet step flow. 

example using argent:
https://user-images.githubusercontent.com/16931094/159568711-542df106-5a38-41b0-b569-246de9477324.mov

