### PR TITLE
RNBW-2817: adds argent to available wallets

### DIFF
--- a/.changeset/modern-wolves-eat.md
+++ b/.changeset/modern-wolves-eat.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Adds Argent to available wallets

--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -45,7 +45,7 @@ const wallets = getDefaultWallets({
 
 const connectors = connectorsForWallets([
   ...wallets,
-  wallet.argent({ chains, infuraId }),
+  { groupName: 'Other', wallets: [wallet.argent({ chains, infuraId })] },
 ]);
 
 const themes = [

--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -7,6 +7,7 @@ import {
   lightTheme,
   midnightTheme,
   RainbowKitProvider,
+  wallet,
 } from '@rainbow-me/rainbowkit';
 import { providers } from 'ethers';
 import type { AppProps } from 'next/app';
@@ -42,7 +43,10 @@ const wallets = getDefaultWallets({
     }/${infuraId}`,
 });
 
-const connectors = connectorsForWallets(wallets);
+const connectors = connectorsForWallets([
+  ...wallets,
+  wallet.argent({ chains, infuraId }),
+]);
 
 const themes = [
   { name: 'light', theme: lightTheme },

--- a/packages/rainbowkit/src/components/RainbowKitProvider/wallet.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/wallet.ts
@@ -137,7 +137,7 @@ export const argent = ({ chains, infuraId }: ArgentOptions): Wallet => {
       },
       // TODO: replace with high quality icon
       iconUrl:
-        'https://imagedelivery.net/_aTEfDRm7z3tKgu9JhfeKA/ce5fbfe8-13b5-4f5f-184a-34f6ee7a3d00/lg',
+        'https://cloudflare-ipfs.com/ipfs/QmenqGTM4sPU7x27a4zdZfMCMrWvxZxnVST8dbyFFvUZZQ',
       id: 'argent',
       mobile: {
         getUri: () => {

--- a/packages/rainbowkit/src/components/RainbowKitProvider/wallet.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/wallet.ts
@@ -154,13 +154,13 @@ export const argent = ({ chains, infuraId }: ArgentOptions): Wallet => {
           steps: [
             {
               description:
-                'We recommend putting Argent on your home screen for faster access to your wallet.',
+                'Put Argent on your home screen for faster access to your wallet.',
               step: 'install',
               title: 'Open the Argent app',
             },
             {
               description:
-                'You can easily backup your wallet using our backup feature on your phone.',
+                'Create a wallet and username, or import an existing wallet.',
               step: 'create',
               title: 'Create or Import a Wallet',
             },
@@ -168,7 +168,7 @@ export const argent = ({ chains, infuraId }: ArgentOptions): Wallet => {
               description:
                 'After you scan, a connection prompt will appear for you to connect your wallet.',
               step: 'scan',
-              title: 'Tap the scan button',
+              title: 'Tap the Scan QR button',
             },
           ],
         },

--- a/packages/rainbowkit/src/components/RainbowKitProvider/wallet.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/wallet.ts
@@ -115,7 +115,6 @@ interface ArgentOptions {
   infuraId?: string;
 }
 
-// not included in default wallets
 export const argent = ({ chains, infuraId }: ArgentOptions): Wallet => {
   return () => {
     const connector = new WalletConnectConnector({

--- a/packages/rainbowkit/src/components/RainbowKitProvider/wallet.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/wallet.ts
@@ -135,7 +135,6 @@ export const argent = ({ chains, infuraId }: ArgentOptions): Wallet => {
           ? 'https://apps.apple.com/us/app/argent/id1358741926'
           : 'https://argent.link/app',
       },
-      // TODO: replace with high quality icon
       iconUrl:
         'https://cloudflare-ipfs.com/ipfs/QmenqGTM4sPU7x27a4zdZfMCMrWvxZxnVST8dbyFFvUZZQ',
       id: 'argent',

--- a/packages/rainbowkit/src/components/RainbowKitProvider/wallet.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/wallet.ts
@@ -110,6 +110,75 @@ const rainbow = ({ chains, infuraId }: RainbowOptions): Wallet => {
   };
 };
 
+interface ArgentOptions {
+  chains: Chain[];
+  infuraId?: string;
+}
+
+// not included in default wallets
+export const argent = ({ chains, infuraId }: ArgentOptions): Wallet => {
+  return () => {
+    const connector = new WalletConnectConnector({
+      chains,
+      options: {
+        infuraId,
+        qrcode: false,
+      },
+    });
+
+    return {
+      connector,
+      downloadUrls: {
+        mobile: isAndroid()
+          ? 'https://play.google.com/store/apps/details?id=im.argent.contractwalletclient'
+          : isIOS()
+          ? 'https://apps.apple.com/us/app/argent/id1358741926'
+          : 'https://argent.link/app',
+      },
+      // TODO: replace with high quality icon
+      iconUrl:
+        'https://imagedelivery.net/_aTEfDRm7z3tKgu9JhfeKA/ce5fbfe8-13b5-4f5f-184a-34f6ee7a3d00/lg',
+      id: 'argent',
+      mobile: {
+        getUri: () => {
+          const { uri } = connector.getProvider().connector;
+
+          return isAndroid()
+            ? uri
+            : `https://argent.link/app/wc?uri=${encodeURIComponent(uri)}`;
+        },
+      },
+      name: 'Argent',
+      qrCode: {
+        getUri: () => connector.getProvider().connector.uri,
+        instructions: {
+          learnMoreUrl: 'https://www.argent.xyz/learn/what-is-a-crypto-wallet/',
+          steps: [
+            {
+              description:
+                'We recommend putting Argent on your home screen for faster access to your wallet.',
+              step: 'install',
+              title: 'Open the Argent app',
+            },
+            {
+              description:
+                'You can easily backup your wallet using our backup feature on your phone.',
+              step: 'create',
+              title: 'Create or Import a Wallet',
+            },
+            {
+              description:
+                'After you scan, a connection prompt will appear for you to connect your wallet.',
+              step: 'scan',
+              title: 'Tap the scan button',
+            },
+          ],
+        },
+      },
+    };
+  };
+};
+
 interface WalletConnectOptions {
   chains: Chain[];
   infuraId?: string;
@@ -244,6 +313,7 @@ const injected =
   };
 
 export const wallet = {
+  argent,
   coinbase,
   injected,
   metaMask,


### PR DESCRIPTION
- Adds Argent as an available wallet

Tested:
- iOS deeplinking works with Argent 
- @markdalgleish tested deeplinking works with Argent on Android (thanks!)

TODO:

- [x] Better Argent image uploaded to IPFS
- [x] Better Argent steps for acquiring wallet
- [x] Blocked by Rainbow specific features within RainbowKit
- [x] ~~Add configuration for non-default wallets to playground (i.e. checking box to add Argent?)~~
- [x] ~~Util for creating WalletConnect wallets~~ future PR