### PR TITLE
fix: ensure official WalletConnect modal is available

### DIFF
--- a/packages/rainbowkit/src/wallets/connectorsForWallets.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.ts
@@ -24,7 +24,7 @@ export const connectorsForWallets = (walletList: WalletList) => {
         }
 
         let walletConnectModalConnector: Connector | undefined;
-        if (walletMeta.id === 'walletConnect' && connector.qrCode) {
+        if (walletMeta.id === 'walletConnect' && connectionMethods.qrCode) {
           const { chains, options } = connector;
 
           walletConnectModalConnector = new WalletConnectConnector({


### PR DESCRIPTION
I accidentally broke this in https://github.com/rainbow-me/rainbowkit/pull/196.