### PR TITLE
fix: move WC to bottom of popular wallets

### DIFF
--- a/packages/rainbowkit/src/wallets/getDefaultWallets.ts
+++ b/packages/rainbowkit/src/wallets/getDefaultWallets.ts
@@ -31,12 +31,12 @@ export const getDefaultWallets = ({
       groupName: 'Popular',
       wallets: [
         rainbow({ chains, infuraId }),
-        walletConnect({ chains, infuraId }),
         coinbase({ appName, chains, jsonRpcUrl }),
         metaMask({ chains, infuraId, shimDisconnect: true }),
         ...(needsInjectedWalletFallback
           ? [injected({ chains, shimDisconnect: true })]
           : []),
+        walletConnect({ chains, infuraId }),
       ],
     },
   ];


### PR DESCRIPTION
<img width="773" alt="Screen Shot 2022-03-31 at 2 29 45 AM" src="https://user-images.githubusercontent.com/16931094/160990661-09a8de53-acc7-4276-b63b-7b6c0f04fbd1.png">

the ticket mentions to do this for the examples too -- i moved it in getDefaultWallets(), not sure which examples don't rely on that