### PR TITLE
fix: ensure prepare script builds CSS in production mode

### DIFF
--- a/.changeset/honest-donuts-smell.md
+++ b/.changeset/honest-donuts-smell.md
@@ -1,0 +1,9 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Shrink bundled CSS size by using minified identifiers
+
+We were previously publishing CSS with human-readable debug identifiers (class names, keyframes etc.), but these have now been replaced with their smaller hash-only versions, e.g. the `.reset__iekbcc0` class is now `.iekbcc0`.
+
+While these identifiers have never been guaranteed to be stable between versions, it’s possible that some consumers may have been given a false sense of API stability due to these debug names. If you have any custom CSS overrides that break due to these changes, it’s recommended that you avoid referencing them entirely rather than updating them since they’re likely to change again without notice in future releases.

--- a/package.json
+++ b/package.json
@@ -15,11 +15,10 @@
     "test:watch": "vitest --watch",
     "changeset": "changeset",
     "clean": "rm -rf ./packages/rainbowkit/dist && rm -rf ./packages/rainbowkit/node_modules && pnpm install",
-    "release": "changeset publish",
+    "release": "pnpm release:verify-git && pnpm release:build && changeset publish",
     "release:verify-git": "git diff --exit-code && git rev-parse --abbrev-ref HEAD | grep \"main\"",
     "release:build": "pnpm clean && pnpm lint && pnpm test && MINIFY_CSS=true pnpm build --recursive && cp README.md packages/rainbowkit/README.md",
     "release:test": "pnpm release:build && pnpm dev --filter example",
-    "prerelease": "pnpm release:verify-git && pnpm release:build",
     "ci:example": "pnpm prepare --filter=@rainbow-me/rainbowkit && pnpm build --filter=example",
     "ci:site": "pnpm prepare --filter=@rainbow-me/rainbowkit && pnpm build --filter=site"
   },

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -22,7 +22,7 @@
     "build": "node build.js",
     "build:watch": "node build.js --watch",
     "dev": "pnpm build:watch & pnpm typegen:watch",
-    "prepare": "pnpm build",
+    "prepare": "MINIFY_CSS=true pnpm build",
     "prebuild": "pnpm typegen",
     "typecheck": "pnpm tsc --noEmit",
     "typegen": "tsc --emitDeclarationOnly || true",


### PR DESCRIPTION
I noticed that the CSS published to npm was in debug mode. Turns out it's because npm automatically runs the `prepare` script before publish, and this script runs the build in dev mode. To fix this, I've updated the prepare script to enable the minified CSS flag.

I also cleaned up the `release` script to include the `prerelease` script inline to reduce indirection.