### PR TITLE
docs: add manual instructions for publishing GitHub releases

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,4 +45,13 @@ Assuming everything went well, the release script will create a new git tag for 
 git push --tags
 ```
 
+Once you’ve pushed the tag, you can create a new release on GitHub.
+
+- Navigate to the [new release form on GitHub.](https://github.com/rainbow-me/rainbowkit/releases/new)
+- From the dropdown labelled “Choose a tag”, select the latest version tag for `@rainbow-me/rainbowkit`.
+- Set the title to `@rainbow-me/rainbowkit@x.x.x`, substituting the latest version number.
+- Copy the Markdown content below the latest version heading from the [RainbowKit changelog.](../packages/rainbowkit/CHANGELOG.md)
+
+If at any stage you’re unsure of the formatting, you can [reference past RainbowKit releases.](https://github.com/rainbow-me/rainbowkit/releases)
+
 That’s it — you’re all done! 🎉


### PR DESCRIPTION
It looks like we can't automate GitHub releases unless we're auto-publishing from CI. I'm following up on this to be sure, but in the meantime I've manually published all existing releases to GitHub and added some documentation to our contribution guide so it's part of our release process.