### PR TITLE
fix: remove accent color border

### DIFF
--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -30,7 +30,6 @@ export function ConnectButton({
       {({
         account,
         chain,
-        connectModalOpen,
         openAccountModal,
         openChainModal,
         openConnectModal,
@@ -181,9 +180,7 @@ export function ConnectButton({
             <Box
               as="button"
               background="connectButtonInnerBackground"
-              borderColor={
-                connectModalOpen ? 'accentColor' : 'connectButtonBackground'
-              }
+              borderColor="connectButtonBackground"
               borderRadius="connectButton"
               borderStyle="solid"
               borderWidth="2"


### PR DESCRIPTION
connect button doesn't have accent button while modal is open anymore

<img width="822" alt="Screen Shot 2022-04-05 at 2 16 07 AM" src="https://user-images.githubusercontent.com/16931094/161690758-eba3c3b9-7dac-474a-a90f-fc4ec9a55a78.png">
