### PR TITLE
fix: add line-height to CSS reset

### DIFF
--- a/packages/rainbowkit/src/css/reset.css.ts
+++ b/packages/rainbowkit/src/css/reset.css.ts
@@ -9,6 +9,7 @@ export const base = style({
   border: 0,
   boxSizing: 'border-box',
   fontSize: '100%',
+  lineHeight: 'normal',
   margin: 0,
   padding: 0,
   selectors: {


### PR DESCRIPTION
This is the default browser value that we've been developing against, so I've explicitly added it to override any values provided by the host app.

We may wish to revisit this when adding explicit line heights to text elements, but this will fix most style clashes in the meantime.