### PR TITLE
fix: make asyncimage work with hardocded colors

### DIFF
--- a/packages/rainbowkit/src/components/AsyncImage/AsyncImage.tsx
+++ b/packages/rainbowkit/src/components/AsyncImage/AsyncImage.tsx
@@ -27,14 +27,6 @@ export function AsyncImage({
   width,
 }: AsyncImageProps) {
   const src = useAsyncImage(srcProp);
-  const customBorderColor = typeof borderColor === 'object' &&
-    Object.keys(borderColor).includes('custom') && {
-      style: { borderColor: (borderColor as CustomBorderColor).custom },
-    };
-  const renderedBorderColor = customBorderColor || {
-    borderColor: borderColor as BoxProps['borderColor'],
-  };
-
   return (
     <Box
       aria-label={alt}
@@ -66,7 +58,9 @@ export function AsyncImage({
       />
       {borderColor ? (
         <Box
-          {...renderedBorderColor}
+          {...(typeof borderColor === 'object' && 'custom' in borderColor
+            ? { style: { borderColor: borderColor.custom } }
+            : { borderColor })}
           borderRadius={borderRadius}
           borderStyle="solid"
           borderWidth="1"

--- a/packages/rainbowkit/src/components/AsyncImage/AsyncImage.tsx
+++ b/packages/rainbowkit/src/components/AsyncImage/AsyncImage.tsx
@@ -9,7 +9,7 @@ interface AsyncImageProps {
   height: BoxProps['height'] | number;
   background?: string;
   borderRadius?: BoxProps['borderRadius'];
-  borderColor?: BoxProps['borderColor'];
+  borderColor?: BoxProps['borderColor'] | { borderColor: string };
   boxShadow?: BoxProps['boxShadow'];
 }
 
@@ -24,6 +24,7 @@ export function AsyncImage({
   width,
 }: AsyncImageProps) {
   const src = useAsyncImage(srcProp);
+  const borderColorIsObject = typeof borderColor === 'object';
 
   return (
     <Box
@@ -56,7 +57,7 @@ export function AsyncImage({
       />
       {borderColor ? (
         <Box
-          borderColor={borderColor}
+          {...(borderColorIsObject ? { style: borderColor } : { borderColor })}
           borderRadius={borderRadius}
           borderStyle="solid"
           borderWidth="1"

--- a/packages/rainbowkit/src/components/AsyncImage/AsyncImage.tsx
+++ b/packages/rainbowkit/src/components/AsyncImage/AsyncImage.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { Box, BoxProps } from '../Box/Box';
 import { AsyncImageSrc, useAsyncImage } from './useAsyncImage';
 
+type CustomBorderColor = {
+  custom: string;
+};
 interface AsyncImageProps {
   alt?: string;
   src: string | AsyncImageSrc | undefined;
@@ -9,7 +12,7 @@ interface AsyncImageProps {
   height: BoxProps['height'] | number;
   background?: string;
   borderRadius?: BoxProps['borderRadius'];
-  borderColor?: BoxProps['borderColor'] | { borderColor: string };
+  borderColor?: BoxProps['borderColor'] | CustomBorderColor;
   boxShadow?: BoxProps['boxShadow'];
 }
 
@@ -24,7 +27,13 @@ export function AsyncImage({
   width,
 }: AsyncImageProps) {
   const src = useAsyncImage(srcProp);
-  const borderColorIsObject = typeof borderColor === 'object';
+  const customBorderColor = typeof borderColor === 'object' &&
+    Object.keys(borderColor).includes('custom') && {
+      style: { borderColor: (borderColor as CustomBorderColor).custom },
+    };
+  const renderedBorderColor = customBorderColor || {
+    borderColor: borderColor as BoxProps['borderColor'],
+  };
 
   return (
     <Box
@@ -57,7 +66,7 @@ export function AsyncImage({
       />
       {borderColor ? (
         <Box
-          {...(borderColorIsObject ? { style: borderColor } : { borderColor })}
+          {...renderedBorderColor}
           borderRadius={borderRadius}
           borderStyle="solid"
           borderWidth="1"

--- a/packages/rainbowkit/src/components/QRCode/QRCode.tsx
+++ b/packages/rainbowkit/src/components/QRCode/QRCode.tsx
@@ -147,7 +147,8 @@ export function QRCode({
         >
           <AsyncImage
             background={logoBackground}
-            borderRadius="25%"
+            borderColor={{ borderColor: 'rgba(0, 0, 0, 0.04)' }}
+            borderRadius="13"
             height={logoSize}
             src={logoUrl}
             width={logoSize}

--- a/packages/rainbowkit/src/components/QRCode/QRCode.tsx
+++ b/packages/rainbowkit/src/components/QRCode/QRCode.tsx
@@ -147,7 +147,7 @@ export function QRCode({
         >
           <AsyncImage
             background={logoBackground}
-            borderColor={{ borderColor: 'rgba(0, 0, 0, 0.04)' }}
+            borderColor={{ custom: 'rgba(0, 0, 0, 0.06)' }}
             borderRadius="13"
             height={logoSize}
             src={logoUrl}


### PR DESCRIPTION
fix qr border after asyncimage updates

<img width="402" alt="Screen Shot 2022-04-07 at 6 05 07 PM" src="https://user-images.githubusercontent.com/16931094/162327404-2121592d-7ec4-498b-8bed-311db6ae9d1d.png">
