### PR TITLE
fix: reset text align

### DIFF
--- a/packages/rainbowkit/src/css/reset.css.ts
+++ b/packages/rainbowkit/src/css/reset.css.ts
@@ -17,6 +17,7 @@ export const base = style({
       outline: 'none',
     },
   },
+  textAlign: 'left',
   verticalAlign: 'baseline',
   WebkitTapHighlightColor: 'transparent',
 });


### PR DESCRIPTION
fixes this reset gap for textalign that i noticed on a site using rainbowkit

<img width="763" alt="Screen Shot 2022-04-08 at 2 28 19 PM" src="https://user-images.githubusercontent.com/16931094/162500343-43e1bce8-68d9-4f48-ac6d-2b2645ad6e47.png">
