### PR TITLE
fix: explicit textAlign center

### DIFF
--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -66,7 +66,7 @@ function WalletButton({ wallet }: { wallet: WalletConnector }) {
             width="60"
           />
         </Box>
-        <Box display="flex" flexDirection="column" gap="1">
+        <Box display="flex" flexDirection="column" gap="1" textAlign="center">
           <Text
             as="h2"
             color={wallet.ready ? 'modalText' : 'modalTextSecondary'}
@@ -150,7 +150,12 @@ export function MobileOptions({ onClose }: { onClose: () => void }) {
             paddingX="32"
             style={{ textAlign: 'center' }}
           >
-            <Box display="flex" flexDirection="column" gap="8">
+            <Box
+              display="flex"
+              flexDirection="column"
+              gap="8"
+              textAlign="center"
+            >
               <Text color="modalText" size="16" weight="bold">
                 What is a Wallet?
               </Text>
@@ -263,7 +268,12 @@ export function MobileOptions({ onClose }: { onClose: () => void }) {
             paddingX="36"
             style={{ textAlign: 'center' }}
           >
-            <Box display="flex" flexDirection="column" gap="12">
+            <Box
+              display="flex"
+              flexDirection="column"
+              gap="12"
+              textAlign="center"
+            >
               <Text color="modalText" size="16" weight="bold">
                 Not what you&rsquo;re looking for?
               </Text>
@@ -326,7 +336,7 @@ export function MobileOptions({ onClose }: { onClose: () => void }) {
             </Box>
           )}
 
-          <Box marginTop="4" style={{ textAlign: 'center' }} width="full">
+          <Box marginTop="4" textAlign="center" width="full">
             <Text
               as="h1"
               color="modalText"

--- a/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
+++ b/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
@@ -82,8 +82,13 @@ export function ProfileDetails({
                 size={mobile ? 82 : 74}
               />
             </Box>
-            <Box display="flex" flexDirection="column" gap={mobile ? '4' : '0'}>
-              <Box>
+            <Box
+              display="flex"
+              flexDirection="column"
+              gap={mobile ? '4' : '0'}
+              textAlign="center"
+            >
+              <Box textAlign="center">
                 <Text
                   as="h1"
                   color="modalText"
@@ -94,21 +99,19 @@ export function ProfileDetails({
                   {accountName}
                 </Text>
               </Box>
-              <Box>
-                {balanceData && (
-                  <Box>
-                    <Text
-                      as="h1"
-                      color="modalTextSecondary"
-                      id={titleId}
-                      size={mobile ? '16' : '14'}
-                      weight="semibold"
-                    >
-                      {balance} {balanceData.symbol}
-                    </Text>
-                  </Box>
-                )}
-              </Box>
+              {balanceData && (
+                <Box textAlign="center">
+                  <Text
+                    as="h1"
+                    color="modalTextSecondary"
+                    id={titleId}
+                    size={mobile ? '16' : '14'}
+                    weight="semibold"
+                  >
+                    {balance} {balanceData.symbol}
+                  </Text>
+                </Box>
+              )}
             </Box>
           </Box>
           <Box

--- a/packages/rainbowkit/src/components/Text/Text.tsx
+++ b/packages/rainbowkit/src/components/Text/Text.tsx
@@ -24,6 +24,7 @@ export type TextProps = {
   weight?: BoxProps['fontWeight'];
   className?: string;
   tabIndex?: number;
+  textAlign?: BoxProps['textAlign'];
 };
 
 export const Text = React.forwardRef(
@@ -37,6 +38,7 @@ export const Text = React.forwardRef(
       id,
       size = '16',
       tabIndex,
+      textAlign = 'inherit',
       weight = 'regular',
     }: TextProps,
     ref: React.Ref<HTMLElement>
@@ -52,6 +54,7 @@ export const Text = React.forwardRef(
         id={id}
         ref={ref}
         tabIndex={tabIndex}
+        textAlign={textAlign}
       >
         {children}
       </Box>

--- a/packages/rainbowkit/src/css/sprinkles.css.ts
+++ b/packages/rainbowkit/src/css/sprinkles.css.ts
@@ -116,7 +116,7 @@ const dimensions = {
 
 const flexAlignment = ['flex-start', 'flex-end', 'center'] as const;
 
-const textAlignments = ['left', 'center', 'inherit'];
+const textAlignments = ['left', 'center', 'inherit'] as const;
 
 const interactionProperties = defineProperties({
   conditions: {

--- a/packages/rainbowkit/src/css/sprinkles.css.ts
+++ b/packages/rainbowkit/src/css/sprinkles.css.ts
@@ -116,6 +116,8 @@ const dimensions = {
 
 const flexAlignment = ['flex-start', 'flex-end', 'center'] as const;
 
+const textAlignments = ['left', 'center', 'inherit'];
+
 const interactionProperties = defineProperties({
   conditions: {
     base: {},
@@ -204,6 +206,7 @@ const unresponsiveProperties = defineProperties({
     gap: spacing,
     height: dimensions,
     justifyContent: [...flexAlignment, 'space-between'],
+    textAlign: textAlignments,
     marginBottom: spacing,
     marginLeft: spacing,
     marginRight: spacing,


### PR DESCRIPTION
fixes a mobile bug i introduced on friday trying to normalize textAlign

@markdalgleish thoughts on the `inherit` default for the `Text` component? Since `Text` wraps `Box` this was one way I could get `Text` components to actually inherit from a parent with `textAlign="center"`