### PR TITLE
fix: remove accidental transition between connect button states

### DIFF
--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -48,176 +48,182 @@ export function ConnectButton({
         const showAccountButtonBackground = isMobile()
           ? showBalanceNormalized.smallScreen
           : showBalanceNormalized.largeScreen;
-        return account ? (
+        return (
           <Box display="flex" gap="12">
-            {chain && (
-              <Box
-                alignItems="center"
-                as="button"
-                background={
-                  chain.unsupported
-                    ? 'connectButtonBackgroundError'
-                    : 'connectButtonBackground'
-                }
-                borderRadius="connectButton"
-                boxShadow="connectButton"
-                color={
-                  chain.unsupported
-                    ? 'connectButtonTextError'
-                    : 'connectButtonText'
-                }
-                display={mapResponsiveValue(chainStatus, value =>
-                  value === 'none' ? 'none' : 'flex'
+            {account ? (
+              <>
+                {chain && (
+                  <Box
+                    alignItems="center"
+                    as="button"
+                    background={
+                      chain.unsupported
+                        ? 'connectButtonBackgroundError'
+                        : 'connectButtonBackground'
+                    }
+                    borderRadius="connectButton"
+                    boxShadow="connectButton"
+                    color={
+                      chain.unsupported
+                        ? 'connectButtonTextError'
+                        : 'connectButtonText'
+                    }
+                    display={mapResponsiveValue(chainStatus, value =>
+                      value === 'none' ? 'none' : 'flex'
+                    )}
+                    fontFamily="body"
+                    fontWeight="bold"
+                    gap="6"
+                    onClick={openChainModal}
+                    paddingX="10"
+                    paddingY="8"
+                    transform={{ active: 'shrink', hover: 'grow' }}
+                    transition="default"
+                    type="button"
+                  >
+                    {chain.unsupported ? (
+                      <Box>Invalid network</Box>
+                    ) : (
+                      <Box alignItems="center" display="flex" gap="6">
+                        {chain.hasIcon ? (
+                          <Box
+                            display={mapResponsiveValue(chainStatus, value =>
+                              value === 'full' || value === 'icon'
+                                ? 'block'
+                                : 'none'
+                            )}
+                            height="24"
+                            width="24"
+                          >
+                            <AsyncImage
+                              alt={chain.name ?? 'Chain icon'}
+                              background={chain.iconBackground}
+                              borderRadius="full"
+                              height="24"
+                              src={chain.iconUrl}
+                              width="24"
+                            />
+                          </Box>
+                        ) : null}
+                        <Box
+                          display={mapResponsiveValue(chainStatus, value => {
+                            if (value === 'icon' && !chain.iconUrl) {
+                              return 'block'; // Show the chain name if there is no iconUrl
+                            }
+
+                            return value === 'full' || value === 'name'
+                              ? 'block'
+                              : 'none';
+                          })}
+                        >
+                          {chain.name ?? chain.id}
+                        </Box>
+                      </Box>
+                    )}
+                    <DropdownIcon />
+                  </Box>
                 )}
-                fontFamily="body"
-                fontWeight="bold"
-                gap="6"
-                onClick={openChainModal}
-                paddingX="10"
-                paddingY="8"
-                transform={{ active: 'shrink', hover: 'grow' }}
-                transition="default"
-                type="button"
-              >
-                {chain.unsupported ? (
-                  <Box>Invalid network</Box>
-                ) : (
-                  <Box alignItems="center" display="flex" gap="6">
-                    {chain.hasIcon ? (
+
+                <Box
+                  alignItems="center"
+                  as="button"
+                  background="connectButtonBackground"
+                  borderRadius="connectButton"
+                  boxShadow="connectButton"
+                  color="connectButtonText"
+                  display="flex"
+                  fontFamily="body"
+                  fontWeight="bold"
+                  onClick={openAccountModal}
+                  transform={{ active: 'shrink', hover: 'grow' }}
+                  transition="default"
+                  type="button"
+                >
+                  {account.displayBalance && (
+                    <Box
+                      display={mapResponsiveValue(showBalance, value =>
+                        value ? 'block' : 'none'
+                      )}
+                      padding="8"
+                      paddingLeft="12"
+                    >
+                      {account.displayBalance}
+                    </Box>
+                  )}
+                  <Box
+                    background={
+                      showAccountButtonBackground
+                        ? 'connectButtonInnerBackground'
+                        : 'connectButtonBackground'
+                    }
+                    borderColor="connectButtonBackground"
+                    borderRadius="connectButton"
+                    borderStyle="solid"
+                    borderWidth="2"
+                    color="connectButtonText"
+                    fontFamily="body"
+                    fontWeight="bold"
+                    paddingX="8"
+                    paddingY="6"
+                    transition="default"
+                  >
+                    <Box alignItems="center" display="flex" gap="6" height="24">
                       <Box
-                        display={mapResponsiveValue(chainStatus, value =>
-                          value === 'full' || value === 'icon'
+                        display={mapResponsiveValue(accountStatus, value =>
+                          value === 'full' || value === 'avatar'
                             ? 'block'
                             : 'none'
                         )}
-                        height="24"
-                        width="24"
                       >
-                        <AsyncImage
-                          alt={chain.name ?? 'Chain icon'}
-                          background={chain.iconBackground}
-                          borderRadius="full"
-                          height="24"
-                          src={chain.iconUrl}
-                          width="24"
+                        <Avatar
+                          address={account.address}
+                          imageUrl={account.ensAvatar}
+                          size={24}
                         />
                       </Box>
-                    ) : null}
-                    <Box
-                      display={mapResponsiveValue(chainStatus, value => {
-                        if (value === 'icon' && !chain.iconUrl) {
-                          return 'block'; // Show the chain name if there is no iconUrl
-                        }
 
-                        return value === 'full' || value === 'name'
-                          ? 'block'
-                          : 'none';
-                      })}
-                    >
-                      {chain.name ?? chain.id}
+                      <Box alignItems="center" display="flex" gap="6">
+                        <Box
+                          display={mapResponsiveValue(accountStatus, value =>
+                            value === 'full' || value === 'address'
+                              ? 'block'
+                              : 'none'
+                          )}
+                        >
+                          {account.displayName}
+                        </Box>
+                        <DropdownIcon />
+                      </Box>
                     </Box>
                   </Box>
-                )}
-                <DropdownIcon />
-              </Box>
-            )}
-
-            <Box
-              alignItems="center"
-              as="button"
-              background="connectButtonBackground"
-              borderRadius="connectButton"
-              boxShadow="connectButton"
-              color="connectButtonText"
-              display="flex"
-              fontFamily="body"
-              fontWeight="bold"
-              onClick={openAccountModal}
-              transform={{ active: 'shrink', hover: 'grow' }}
-              transition="default"
-              type="button"
-            >
-              {account.displayBalance && (
-                <Box
-                  display={mapResponsiveValue(showBalance, value =>
-                    value ? 'block' : 'none'
-                  )}
-                  padding="8"
-                  paddingLeft="12"
-                >
-                  {account.displayBalance}
                 </Box>
-              )}
+              </>
+            ) : (
               <Box
-                background={
-                  showAccountButtonBackground
-                    ? 'connectButtonInnerBackground'
-                    : 'connectButtonBackground'
-                }
-                borderColor="connectButtonBackground"
+                background="connectButtonBackground"
                 borderRadius="connectButton"
-                borderStyle="solid"
-                borderWidth="2"
-                color="connectButtonText"
-                fontFamily="body"
-                fontWeight="bold"
-                paddingX="8"
-                paddingY="6"
+                transform={{ active: 'shrink', hover: 'grow' }}
                 transition="default"
               >
-                <Box alignItems="center" display="flex" gap="6" height="24">
-                  <Box
-                    display={mapResponsiveValue(accountStatus, value =>
-                      value === 'full' || value === 'avatar' ? 'block' : 'none'
-                    )}
-                  >
-                    <Avatar
-                      address={account.address}
-                      imageUrl={account.ensAvatar}
-                      size={24}
-                    />
-                  </Box>
-
-                  <Box alignItems="center" display="flex" gap="6">
-                    <Box
-                      display={mapResponsiveValue(accountStatus, value =>
-                        value === 'full' || value === 'address'
-                          ? 'block'
-                          : 'none'
-                      )}
-                    >
-                      {account.displayName}
-                    </Box>
-                    <DropdownIcon />
-                  </Box>
+                <Box
+                  as="button"
+                  background="connectButtonInnerBackground"
+                  borderColor="connectButtonBackground"
+                  borderRadius="connectButton"
+                  borderStyle="solid"
+                  borderWidth="2"
+                  boxShadow="connectButton"
+                  color="connectButtonText"
+                  fontFamily="body"
+                  fontWeight="bold"
+                  onClick={openConnectModal}
+                  padding="8"
+                  type="button"
+                >
+                  Connect Wallet
                 </Box>
               </Box>
-            </Box>
-          </Box>
-        ) : (
-          <Box
-            background="connectButtonBackground"
-            borderRadius="connectButton"
-            transform={{ active: 'shrink', hover: 'grow' }}
-            transition="default"
-          >
-            <Box
-              as="button"
-              background="connectButtonInnerBackground"
-              borderColor="connectButtonBackground"
-              borderRadius="connectButton"
-              borderStyle="solid"
-              borderWidth="2"
-              boxShadow="connectButton"
-              color="connectButtonText"
-              fontFamily="body"
-              fontWeight="bold"
-              onClick={openConnectModal}
-              padding="8"
-              type="button"
-            >
-              Connect Wallet
-            </Box>
+            )}
           </Box>
         );
       }}


### PR DESCRIPTION
This was happening because the ternary in `ConnectButton` was toggling between the "Connect Wallet" button and a container element for the chain and account buttons, which was triggering a CSS transition between the two states. To fix this I've refactored the code so that the container element is always present.