### PR TITLE
feat: adds example actions

### DIFF
--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -14,39 +14,6 @@ type ExtractString<Value> = Value extends string ? Value : never;
 type AccountStatus = ExtractString<ConnectButtonProps['accountStatus']>;
 type ChainStatus = ExtractString<ConnectButtonProps['chainStatus']>;
 
-// All properties on a domain are optional
-const domain = {
-  chainId: 1,
-  name: 'Ether Mail',
-  verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
-  version: '1',
-};
-
-// The named list of all type definitions
-const types = {
-  Mail: [
-    { name: 'from', type: 'Person' },
-    { name: 'to', type: 'Person' },
-    { name: 'contents', type: 'string' },
-  ],
-  Person: [
-    { name: 'name', type: 'string' },
-    { name: 'wallet', type: 'address' },
-  ],
-};
-
-const value = {
-  contents: 'Hello, Bob!',
-  from: {
-    name: 'Cow',
-    wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
-  },
-  to: {
-    name: 'Bob',
-    wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
-  },
-};
-
 const Example = () => {
   const [{ data: accountData }] = useAccount();
   const defaultProps = ConnectButton.__defaultProps;
@@ -85,9 +52,34 @@ const Example = () => {
 
   const [{ data: typedData, error: typedError }, signTypedData] =
     useSignTypedData({
-      domain,
-      types,
-      value,
+      domain: {
+        chainId: 1,
+        name: 'Ether Mail',
+        verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+        version: '1',
+      },
+      types: {
+        Mail: [
+          { name: 'from', type: 'Person' },
+          { name: 'to', type: 'Person' },
+          { name: 'contents', type: 'string' },
+        ],
+        Person: [
+          { name: 'name', type: 'string' },
+          { name: 'wallet', type: 'address' },
+        ],
+      },
+      value: {
+        contents: 'Hello, Bob!',
+        from: {
+          name: 'Cow',
+          wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+        },
+        to: {
+          name: 'Bob',
+          wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+        },
+      },
     });
 
   return (

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -1,4 +1,4 @@
-import { ConnectButton } from '@rainbow-me/rainbowkit';
+import { ConnectButton, useAddRecentTransaction } from '@rainbow-me/rainbowkit';
 
 import React, { ComponentProps, useState } from 'react';
 import {


### PR DESCRIPTION
This PR adds some common actions to ensure functionality is working between RainbowKit and wagmi. In the future, this will help in debugging users' issues, as it will provide minimal reproducible cases where basic functionality is/isn't working.

- Adds Send Transaction
- Adds Sign Message
- Adds Sign Typed Data

We should add some of the following to the `rainbowkit-examples` repo, especially for different chains.