### PR TITLE
fix: ci release script

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "dev": "next dev --port 3001",
     "build": "INIT_CWD=$PWD next build",
-    "typecheck": "pnpm tsc --noEmit"
+    "typecheck": "INIT_CWD=$PWD contentlayer build && pnpm tsc --noEmit"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Attempt to fix `release` CI script in `main`

Spent some time exploring different solutions and this is the simplest one. Basically, we need to built the content before linting, in order to generated the `.contentlater/generated` dependency.