### PR TITLE
fix: add negative margins to separators

### DIFF
--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -140,7 +140,12 @@ export function MobileOptions({ onClose }: { onClose: () => void }) {
             </Box>
           </Box>
 
-          <Box background="generalBorder" height="1" marginBottom="32" />
+          <Box
+            background="generalBorder"
+            height="1"
+            marginBottom="32"
+            marginTop="-1"
+          />
 
           <Box
             alignItems="center"

--- a/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
+++ b/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
@@ -138,7 +138,7 @@ export function ProfileDetails({
         </Box>
         {showRecentTransactions && (
           <>
-            <Box background="generalBorder" height="1" />
+            <Box background="generalBorder" height="1" marginTop="-1" />
             <Box>
               <TxList accountData={accountData} />
             </Box>

--- a/packages/rainbowkit/src/css/sprinkles.css.ts
+++ b/packages/rainbowkit/src/css/sprinkles.css.ts
@@ -72,6 +72,7 @@ export const themeVars = createGlobalThemeContract(
 );
 
 const spacing = {
+  '-1': '-1px',
   '0': '0',
   '1': '1px',
   '2': '2px',


### PR DESCRIPTION
fix for [RNBW-3085](https://linear.app/rainbow/issue/RNBW-3085/-1px-top-margin-on-the-border-between-the-top-and-bottom-sections-for).