### PR TITLE
fix: handle async image errors

### DIFF
--- a/packages/rainbowkit/src/components/AsyncImage/useAsyncImage.ts
+++ b/packages/rainbowkit/src/components/AsyncImage/useAsyncImage.ts
@@ -5,28 +5,43 @@ export type AsyncImageSrc = () => Promise<string>;
 const cachedUrls = new Map<AsyncImageSrc, string>();
 
 // Store requests in a cache so we don't fetch the same image twice
-const cachedRequestPromises = new Map<AsyncImageSrc, Promise<string>>();
+const cachedRequestPromises = new Map<AsyncImageSrc, Promise<string | void>>();
 
-async function loadAsyncImage(loadImageUrl: () => Promise<string>) {
-  const cachedRequestPromise = cachedRequestPromises.get(loadImageUrl);
+async function loadAsyncImage(asyncImage: () => Promise<string>) {
+  const cachedRequestPromise = cachedRequestPromises.get(asyncImage);
 
   // Don't fetch if we already have a request in progress / completed
   if (cachedRequestPromise) {
     return cachedRequestPromise;
   }
 
-  const requestPromise = loadImageUrl().then(async url => {
-    // Uncomment to simulate slow image loading:
-    // await new Promise(resolve =>
-    //   setTimeout(resolve, 2000 + Math.random() * 1000)
-    // );
+  const load = async () =>
+    asyncImage().then(async (url: string) => {
+      // Uncomment to simulate slow image loading:
+      // await new Promise(resolve =>
+      //   setTimeout(resolve, 2000 + Math.random() * 1000)
+      // );
 
-    cachedUrls.set(loadImageUrl, url);
+      // Uncomment to simulate random failure:
+      // if (Math.random() > 0.25) {
+      //   throw new Error();
+      // }
 
-    return url;
+      cachedUrls.set(asyncImage, url);
+
+      return url;
+    });
+
+  const requestPromise = load().catch(_err => {
+    // Retry once if the request failed
+    return load().catch(_err => {
+      // Ignore failed retry, remove failed request from
+      // promise cache so next request can try again
+      cachedRequestPromises.delete(asyncImage);
+    });
   });
 
-  cachedRequestPromises.set(loadImageUrl, requestPromise);
+  cachedRequestPromises.set(asyncImage, requestPromise);
 
   return requestPromise;
 }


### PR DESCRIPTION
Previously any failure to load an async image would result in an unhandled promise rejection, so this PR introduces some logic to handle the failure. If we fail to load an image once, we retry. If the retry fails, we ignore the error and remove the rejected promise from the cache so future image requests are allowed to try again.

To help visualise/validate this, I've also added another block of commented-out code that will trigger a random image load failure. Using this in combination with the existing slow image loading snippet is a good way to test the resiliency of the loading/caching/retrying logic while clicking around the UI.