### PR TITLE
fix: reinstate pending transaction indicator in ConnectButton

### DIFF
--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -204,6 +204,7 @@ export function ConnectButton({
                           <Avatar
                             address={account.address}
                             imageUrl={account.ensAvatar}
+                            loading={account.hasPendingTransactions}
                             size={24}
                           />
                         </Box>


### PR DESCRIPTION
Sorry, this got missed during a merge in https://github.com/rainbow-me/rainbowkit/pull/249.