### PR TITLE
docs: add remix esm note

### DIFF
--- a/site/data/docs/installation.mdx
+++ b/site/data/docs/installation.mdx
@@ -102,3 +102,5 @@ export const YourApp = () => {
 ```
 
 You're done! RainbowKit will now handle your user's wallet selection, display wallet/transaction information and handle network/wallet switching.
+
+> Note if you're using Remix remember to [add RainbowKit to its server dependencies](https://remix.run/docs/en/v1/pages/gotchas#importing-esm-packages).


### PR DESCRIPTION
Resolves RNBW-3334

A simple fix with a simple note.

<img width="774" alt="image" src="https://user-images.githubusercontent.com/372831/164235905-60272eec-9522-40b8-9489-fcc280178ab4.png">

As the docs grow, we can consider a few things to improve the information architecture:
- framework-specific guides
- "how to" blog posts
- FAQ section

