### PR TITLE
fix: ensure ConnectButton matches between client and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ export const YourApp = () => {
               })}
             >
               {(() => {
-                if (!account || !chain) {
+                if (!mounted || !account || !chain) {
                   return (
                     <button onClick={openConnectModal} type="button">
                       Connect Wallet

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -94,7 +94,6 @@ const Example = () => {
   const [isMounted, setIsMounted] = useState(false);
   useEffect(() => setIsMounted(true), []);
 
-  if (!isMounted) return null;
   return (
     <div
       style={{
@@ -132,14 +131,24 @@ const Example = () => {
           {({
             account,
             chain,
+            mounted,
             openAccountModal,
             openChainModal,
             openConnectModal,
           }) => {
             return (
-              <div>
+              <div
+                {...(!mounted && {
+                  'aria-hidden': true,
+                  'style': {
+                    opacity: 0,
+                    pointerEvents: 'none',
+                    userSelect: 'none',
+                  },
+                })}
+              >
                 {(() => {
-                  if (!chain || !account) {
+                  if (!mounted || !chain || !account) {
                     return (
                       <button onClick={openConnectModal} type="button">
                         Connect Wallet
@@ -200,155 +209,161 @@ const Example = () => {
         </ConnectButton.Custom>
       </div>
 
-      <div style={{ fontFamily: 'sans-serif' }}>
-        <h3>Example Actions {!accountData && <span>(not connected)</span>}</h3>
-        <div style={{ display: 'flex', gap: 12, paddingBottom: 12 }}>
-          <button
-            disabled={!accountData}
-            onClick={() => sendTransaction()}
-            type="button"
-          >
-            Send Transaction
-          </button>
-          <button
-            disabled={!accountData}
-            onClick={() => signMessage()}
-            type="button"
-          >
-            Sign Message
-          </button>
-          <button
-            disabled={!accountData || activeChain?.id !== 1}
-            onClick={() => signTypedData()}
-            type="button"
-          >
-            Sign Typed Data
-          </button>
-        </div>
-        <div>
-          {transactionData && (
-            <div>Transaction: {JSON.stringify(transactionData)}</div>
-          )}
-          {transactionError && <div>Error sending transaction</div>}
-          {signingData && <div>Data Signature: {signingData}</div>}
-          {signingError && <div>Error signing message</div>}
-          {typedData && <div>Typed Data Signature: {typedData}</div>}
-          {typedError && <div>Error signing typed message</div>}
-        </div>
-      </div>
+      {isMounted && (
+        <>
+          <div style={{ fontFamily: 'sans-serif' }}>
+            <h3>
+              Example Actions {!accountData && <span>(not connected)</span>}
+            </h3>
+            <div style={{ display: 'flex', gap: 12, paddingBottom: 12 }}>
+              <button
+                disabled={!accountData}
+                onClick={() => sendTransaction()}
+                type="button"
+              >
+                Send Transaction
+              </button>
+              <button
+                disabled={!accountData}
+                onClick={() => signMessage()}
+                type="button"
+              >
+                Sign Message
+              </button>
+              <button
+                disabled={!accountData || activeChain?.id !== 1}
+                onClick={() => signTypedData()}
+                type="button"
+              >
+                Sign Typed Data
+              </button>
+            </div>
+            <div>
+              {transactionData && (
+                <div>Transaction: {JSON.stringify(transactionData)}</div>
+              )}
+              {transactionError && <div>Error sending transaction</div>}
+              {signingData && <div>Data Signature: {signingData}</div>}
+              {signingError && <div>Error signing message</div>}
+              {typedData && <div>Typed Data Signature: {typedData}</div>}
+              {typedError && <div>Error signing typed message</div>}
+            </div>
+          </div>
 
-      <div style={{ fontFamily: 'sans-serif' }}>
-        <h3>ConnectButton props</h3>
-        <table cellSpacing={12}>
-          <thead>
-            <tr>
-              <th>Prop</th>
-              <th>smallScreen</th>
-              <th>largeScreen</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <label htmlFor="accountStatus">accountStatus</label>
-              </td>
-              <td>
-                <select
-                  id="accountStatus"
-                  onChange={event =>
-                    setAccountStatusSmallScreen(
-                      event.currentTarget.value as AccountStatus
-                    )
-                  }
-                  value={accountStatusSmallScreen}
-                >
-                  <option>full</option>
-                  <option>avatar</option>
-                  <option>address</option>
-                </select>
-              </td>
-              <td>
-                <select
-                  id="accountStatus"
-                  onChange={event =>
-                    setAccountStatusLargeScreen(
-                      event.currentTarget.value as AccountStatus
-                    )
-                  }
-                  value={accountStatusLargeScreen}
-                >
-                  <option>full</option>
-                  <option>avatar</option>
-                  <option>address</option>
-                </select>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <label htmlFor="showBalance">showBalance</label>
-              </td>
-              <td>
-                <input
-                  checked={showBalanceSmallScreen}
-                  id="showBalance"
-                  onChange={event => {
-                    setShowBalanceSmallScreen(event.currentTarget.checked);
-                  }}
-                  type="checkbox"
-                />
-              </td>
-              <td>
-                <input
-                  checked={showBalanceLargeScreen}
-                  id="showBalance"
-                  onChange={event => {
-                    setShowBalanceLargeScreen(event.currentTarget.checked);
-                  }}
-                  type="checkbox"
-                />
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <label htmlFor="chainStatus">chainStatus</label>
-              </td>
-              <td>
-                <select
-                  id="chainStatus"
-                  onChange={event =>
-                    setChainStatusSmallScreen(
-                      event.currentTarget.value as ChainStatus
-                    )
-                  }
-                  value={chainStatusSmallScreen}
-                >
-                  <option>full</option>
-                  <option>icon</option>
-                  <option>name</option>
-                  <option>none</option>
-                </select>
-              </td>
-              <td>
-                <select
-                  id="chainStatus"
-                  onChange={event =>
-                    setChainStatusLargeScreen(
-                      event.currentTarget.value as ChainStatus
-                    )
-                  }
-                  value={chainStatusLargeScreen}
-                >
-                  <option>full</option>
-                  <option>icon</option>
-                  <option>name</option>
-                  <option>none</option>
-                </select>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      {accountData ? <ManageTransactions /> : null}
+          <div style={{ fontFamily: 'sans-serif' }}>
+            <h3>ConnectButton props</h3>
+            <table cellSpacing={12}>
+              <thead>
+                <tr>
+                  <th>Prop</th>
+                  <th>smallScreen</th>
+                  <th>largeScreen</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <label htmlFor="accountStatus">accountStatus</label>
+                  </td>
+                  <td>
+                    <select
+                      id="accountStatus"
+                      onChange={event =>
+                        setAccountStatusSmallScreen(
+                          event.currentTarget.value as AccountStatus
+                        )
+                      }
+                      value={accountStatusSmallScreen}
+                    >
+                      <option>full</option>
+                      <option>avatar</option>
+                      <option>address</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select
+                      id="accountStatus"
+                      onChange={event =>
+                        setAccountStatusLargeScreen(
+                          event.currentTarget.value as AccountStatus
+                        )
+                      }
+                      value={accountStatusLargeScreen}
+                    >
+                      <option>full</option>
+                      <option>avatar</option>
+                      <option>address</option>
+                    </select>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <label htmlFor="showBalance">showBalance</label>
+                  </td>
+                  <td>
+                    <input
+                      checked={showBalanceSmallScreen}
+                      id="showBalance"
+                      onChange={event => {
+                        setShowBalanceSmallScreen(event.currentTarget.checked);
+                      }}
+                      type="checkbox"
+                    />
+                  </td>
+                  <td>
+                    <input
+                      checked={showBalanceLargeScreen}
+                      id="showBalance"
+                      onChange={event => {
+                        setShowBalanceLargeScreen(event.currentTarget.checked);
+                      }}
+                      type="checkbox"
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <label htmlFor="chainStatus">chainStatus</label>
+                  </td>
+                  <td>
+                    <select
+                      id="chainStatus"
+                      onChange={event =>
+                        setChainStatusSmallScreen(
+                          event.currentTarget.value as ChainStatus
+                        )
+                      }
+                      value={chainStatusSmallScreen}
+                    >
+                      <option>full</option>
+                      <option>icon</option>
+                      <option>name</option>
+                      <option>none</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select
+                      id="chainStatus"
+                      onChange={event =>
+                        setChainStatusLargeScreen(
+                          event.currentTarget.value as ChainStatus
+                        )
+                      }
+                      value={chainStatusLargeScreen}
+                    >
+                      <option>full</option>
+                      <option>icon</option>
+                      <option>name</option>
+                      <option>none</option>
+                    </select>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          {accountData ? <ManageTransactions /> : null}
+        </>
+      )}
     </div>
   );
 };

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -50,7 +50,6 @@ export function ConnectButton({
           <Box
             display="flex"
             gap="12"
-            transition="default"
             {...(!mounted && {
               'aria-hidden': true,
               'style': {

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -39,6 +39,7 @@ export function ConnectButton({
       {({
         account,
         chain,
+        mounted,
         openAccountModal,
         openChainModal,
         openConnectModal,
@@ -46,8 +47,20 @@ export function ConnectButton({
         const unsupportedChain = chain?.unsupported ?? false;
 
         return (
-          <Box display="flex" gap="12" transition="default">
-            {account ? (
+          <Box
+            display="flex"
+            gap="12"
+            transition="default"
+            {...(!mounted && {
+              'aria-hidden': true,
+              'style': {
+                opacity: 0,
+                pointerEvents: 'none',
+                userSelect: 'none',
+              },
+            })}
+          >
+            {mounted && account ? (
               <>
                 {chain && (chains.length > 1 || unsupportedChain) && (
                   <Box

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
@@ -13,6 +13,7 @@ import {
   useEnsName,
   useNetwork,
 } from 'wagmi';
+import { useIsMounted } from '../../hooks/useIsMounted';
 import { useRecentTransactions } from '../../transactions/useRecentTransactions';
 import { isMobile } from '../../utils/isMobile';
 import { isNotNullish } from '../../utils/isNotNullish';
@@ -59,6 +60,7 @@ export interface ConnectButtonRendererProps {
       name?: string;
       unsupported?: boolean;
     };
+    mounted: boolean;
     openAccountModal: () => void;
     openChainModal: () => void;
     openConnectModal: () => void;
@@ -71,6 +73,8 @@ export interface ConnectButtonRendererProps {
 export function ConnectButtonRenderer({
   children,
 }: ConnectButtonRendererProps) {
+  const mounted = useIsMounted();
+
   const { data: accountData } = useAccount();
 
   const { data: ensAvatar } = useEnsAvatar();
@@ -183,6 +187,7 @@ export function ConnectButtonRenderer({
           : undefined,
         chainModalOpen,
         connectModalOpen,
+        mounted,
         openAccountModal,
         openChainModal,
         openConnectModal,

--- a/packages/rainbowkit/src/hooks/useIsMounted.ts
+++ b/packages/rainbowkit/src/hooks/useIsMounted.ts
@@ -1,0 +1,7 @@
+import { useEffect, useReducer } from 'react';
+
+export const useIsMounted = () => {
+  const [mounted, setMounted] = useReducer(() => true, false);
+  useEffect(setMounted, []);
+  return mounted;
+};

--- a/packages/rainbowkit/src/hooks/useIsMounted.ts
+++ b/packages/rainbowkit/src/hooks/useIsMounted.ts
@@ -2,6 +2,6 @@ import { useEffect, useReducer } from 'react';
 
 export const useIsMounted = () => {
   const [mounted, setMounted] = useReducer(() => true, false);
-  useEffect(setMounted, []);
+  useEffect(setMounted, [setMounted]);
   return mounted;
 };


### PR DESCRIPTION
**Note: This PR is against the `wagmi-next` branch.**

Currently in the `wagmi-next` branch, rendering ConnectButton during SSR causes a mismatch between client and server. This is because wagmi now caches on the client, which means that the first render can be in a connected state — something the server can never do.

The workaround for this in `wagmi-next` was for consumers to guard the rendering of ConnectButton behind an `isMounted` check, but this is technically a breaking change, and also reintroduces the potential for jank during page load that was addressed in https://github.com/rainbow-me/rainbowkit/pull/248 since the button space isn't being reserved anymore. Instead, this PR reinstates the same user experience that we have in the main branch, ensuring that the initial render always matches the server and then making the elements visible on mount.