### PR TITLE
fix: reinstate install prompt

### DIFF
--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -53,15 +53,20 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
 
   const onSelectWallet = (wallet: WalletConnector) => {
     connectToWallet(wallet);
+    setSelectedOptionId(wallet.id);
 
-    wallet?.onConnecting?.(async () => {
-      setSelectedOptionId(wallet.id);
-      const sWallet = wallets.find(w => wallet.id === w.id);
-      const uri = await sWallet?.qrCode?.getUri();
-      setQrCodeUri(uri);
-      setSelectedWallet(sWallet);
+    if (wallet.ready) {
+      wallet?.onConnecting?.(async () => {
+        const sWallet = wallets.find(w => wallet.id === w.id);
+        const uri = await sWallet?.qrCode?.getUri();
+        setQrCodeUri(uri);
+        setSelectedWallet(sWallet);
+        setWalletStep(WalletStep.Connect);
+      });
+    } else {
+      setSelectedWallet(wallet);
       setWalletStep(WalletStep.Connect);
-    });
+    }
   };
 
   const getMobileWallet = (id: string) => {


### PR DESCRIPTION
**Note: This PR is against the `wagmi-next` branch.**

I noticed that clicking on MetaMask wasn't showing the install prompt anymore if I didn't have the extension enabled. Turns out it's because we now only switch tabs in the `onConnecting` callback which is never fired when `wallet.ready` is false.