### PR TITLE
fix: if chain switching is not support by mobile wallet, show message to end user

### DIFF
--- a/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
+++ b/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
@@ -15,7 +15,7 @@ export interface ChainModalProps {
   onClose: () => void;
   networkData: ReturnType<typeof useNetwork>[0]['data'];
   networkError: ReturnType<typeof useNetwork>[0]['error'];
-  onSwitchNetwork?: any;
+  onSwitchNetwork?: (chainId: number) => unknown | undefined;
 }
 
 export function ChainModal({
@@ -57,8 +57,6 @@ export function ChainModal({
     return null;
   }
 
-  console.log('onSwitchNetwork', onSwitchNetwork);
-
   return (
     <Dialog onClose={onClose} open={open} titleId={titleId}>
       <DialogContent bottomSheetOnMobile>
@@ -83,7 +81,7 @@ export function ChainModal({
             <CloseButton onClose={onClose} />
           </Box>
           <Box display="flex" flexDirection="column" gap="4" padding="2">
-            {true &&
+            {onSwitchNetwork ? (
               networkData.chains.map((chain, idx) => {
                 const isCurrentChain = chain.id === networkData.chain?.id;
                 const switching = chain.id === switchingToChain;
@@ -190,7 +188,12 @@ export function ChainModal({
                     )}
                   </Fragment>
                 );
-              })}
+              })
+            ) : (
+              <Text color="modalText" size="14" weight="medium">
+                Your wallet doesn&apos;t support switching networks.
+              </Text>
+            )}
           </Box>
         </Box>
       </DialogContent>

--- a/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
+++ b/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
@@ -57,6 +57,8 @@ export function ChainModal({
     return null;
   }
 
+  console.log('onSwitchNetwork', onSwitchNetwork);
+
   return (
     <Dialog onClose={onClose} open={open} titleId={titleId}>
       <DialogContent bottomSheetOnMobile>

--- a/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
+++ b/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
@@ -191,7 +191,7 @@ export function ChainModal({
               })
             ) : (
               <Text color="modalText" size="14" weight="medium">
-                Your wallet doesn&apos;t support switching networks.
+                Your wallet does not support switching networks.
               </Text>
             )}
           </Box>

--- a/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
+++ b/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
@@ -15,7 +15,7 @@ export interface ChainModalProps {
   onClose: () => void;
   networkData: ReturnType<typeof useNetwork>[0]['data'];
   networkError: ReturnType<typeof useNetwork>[0]['error'];
-  onSwitchNetwork?: (chainId: number) => unknown;
+  onSwitchNetwork?: any;
 }
 
 export function ChainModal({
@@ -83,7 +83,7 @@ export function ChainModal({
             <CloseButton onClose={onClose} />
           </Box>
           <Box display="flex" flexDirection="column" gap="4" padding="2">
-            {onSwitchNetwork &&
+            {true &&
               networkData.chains.map((chain, idx) => {
                 const isCurrentChain = chain.id === networkData.chain?.id;
                 const switching = chain.id === switchingToChain;


### PR DESCRIPTION
- Some wallets do not support programmatic chain switching
  - to check for this, we need to see if `switchNetwork` (from wagmi) is `undefined`
  - if so, we need to show a message to users in the chain switch modal that their wallet is not able to switch chains
  - this feels like a better approach than hiding the chain switching modal, because users might want to know their wallet is not using all possible capabilities.
- need better designed state here