### PR TITLE
feat: return connectors from getDefaultWallets

### DIFF
--- a/.changeset/chilled-jobs-buy.md
+++ b/.changeset/chilled-jobs-buy.md
@@ -1,0 +1,34 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Make `getDefaultWallets` return an object containing `connectors` and `wallets`
+
+In order to streamline the setup process, the `getDefaultWallets` function now returns an object containing both `connectors` and `wallets` properties. This means that most consumers will no longer need to use the `connectorsForWallets` function, accessing the generated `connectors` value instead.
+
+**Migration guide**
+
+```diff
+-import { getDefaultWallets, connectorsForWallets } from '@rainbow-me/rainbowkit';
++import { getDefaultWallets } from '@rainbow-me/rainbowkit';
+
+-const wallets = getDefaultWallets({
++const { connectors } = getDefaultWallets({
+  /* ... */
+});
+
+-const connectors = connectorsForWallets(wallets);
+```
+
+If you were modifying the wallet list returned from `getDefaultWallets`, you’ll need to destructure the `wallets` property from the returned object.
+
+```diff
+import { getDefaultWallets, connectorsForWallets } from '@rainbow-me/rainbowkit';
+
+-const wallets = getDefaultWallets({
++const { wallets } = getDefaultWallets({
+  /* ... */
+});
+
+const connectors = connectorsForWallets(wallets);
+```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ import {
   RainbowKitProvider,
   Chain,
   getDefaultWallets,
-  connectorsForWallets,
 } from '@rainbow-me/rainbowkit';
 import { WagmiProvider, chain } from 'wagmi';
 import { providers } from 'ethers';
@@ -48,7 +47,7 @@ const chains: Chain[] = [
   { ...chain.arbitrumOne, name: 'Arbitrum' },
 ];
 
-const wallets = getDefaultWallets({
+const { connectors } = getDefaultWallets({
   chains,
   infuraId,
   appName: 'My RainbowKit App',
@@ -56,8 +55,6 @@ const wallets = getDefaultWallets({
     chains.find(x => x.id === chainId)?.rpcUrls?.[0] ??
     chain.mainnet.rpcUrls[0],
 });
-
-const connectors = connectorsForWallets(wallets);
 
 const App = () => {
   return (
@@ -778,7 +775,7 @@ An "Injected Wallet" fallback is also provided if `window.ethereum` exists and h
 All built-in wallets are available via the `wallet` object which allows you to rearrange/omit wallets as needed.
 
 ```tsx
-import { wallet, WalletList } from '@rainbow-me/rainbowkit';
+import { connectorsForWallets, wallet } from '@rainbow-me/rainbowkit';
 
 const needsInjectedWalletFallback =
   typeof window !== 'undefined' &&
@@ -786,7 +783,7 @@ const needsInjectedWalletFallback =
   !window.ethereum.isMetaMask &&
   !window.ethereum.isCoinbaseWallet;
 
-const wallets: WalletList = [
+const connectors = connectorsForWallets([
   {
     groupName: 'Suggested',
     wallets: [
@@ -803,7 +800,7 @@ const wallets: WalletList = [
       ...(needsInjectedWalletFallback ? [wallet.injected({ chains })] : []),
     ],
   },
-];
+]);
 ```
 
 ### Built-in wallets
@@ -857,7 +854,7 @@ wallet.injected(options: {
 This shouldn’t be used if another injected wallet is available. For example, when combined with MetaMask and Coinbase Wallet:
 
 ```tsx
-import { wallet, WalletList } from '@rainbow-me/rainbowkit';
+import { connectorsForWallets, wallet } from '@rainbow-me/rainbowkit';
 
 const needsInjectedWalletFallback =
   typeof window !== 'undefined' &&
@@ -865,7 +862,7 @@ const needsInjectedWalletFallback =
   !window.ethereum.isMetaMask &&
   !window.ethereum.isCoinbaseWallet;
 
-const wallets: WalletList = [
+const connectors = connectorsForWallets([
   {
     groupName: 'Suggested',
     wallets: [
@@ -882,7 +879,7 @@ const wallets: WalletList = [
       ...(needsInjectedWalletFallback ? [wallet.injected({ chains })] : []),
     ],
   },
-];
+]);
 ```
 
 #### MetaMask

--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -35,7 +35,7 @@ const chains: Chain[] = [
     : []),
 ];
 
-const wallets = getDefaultWallets({
+const { wallets } = getDefaultWallets({
   appName: 'RainbowKit demo',
   chains,
   infuraId,

--- a/packages/rainbowkit/src/wallets/getDefaultWallets.ts
+++ b/packages/rainbowkit/src/wallets/getDefaultWallets.ts
@@ -1,5 +1,6 @@
 import { Chain as WagmiChain } from 'wagmi';
 import { WalletList } from './Wallet';
+import { connectorsForWallets } from './connectorsForWallets';
 import {
   coinbase,
   CoinbaseOptions,
@@ -19,7 +20,10 @@ export const getDefaultWallets = ({
   infuraId?: string;
   appName: CoinbaseOptions['appName'];
   jsonRpcUrl: CoinbaseOptions['jsonRpcUrl'];
-}): WalletList => {
+}): {
+  connectors: ReturnType<typeof connectorsForWallets>;
+  wallets: WalletList;
+} => {
   const needsInjectedWalletFallback =
     typeof window !== 'undefined' &&
     // @ts-expect-error
@@ -29,7 +33,7 @@ export const getDefaultWallets = ({
     // @ts-expect-error
     !window.ethereum.isCoinbaseWallet;
 
-  return [
+  const wallets: WalletList = [
     {
       groupName: 'Popular',
       wallets: [
@@ -43,4 +47,9 @@ export const getDefaultWallets = ({
       ],
     },
   ];
+
+  return {
+    connectors: connectorsForWallets(wallets),
+    wallets,
+  };
 };

--- a/site/components/Provider/Provider.tsx
+++ b/site/components/Provider/Provider.tsx
@@ -1,8 +1,4 @@
-import {
-  Chain,
-  connectorsForWallets,
-  getDefaultWallets,
-} from '@rainbow-me/rainbowkit';
+import { Chain, getDefaultWallets } from '@rainbow-me/rainbowkit';
 import { providers } from 'ethers';
 import React from 'react';
 import { chain, Provider as WagmiProvider } from 'wagmi';
@@ -25,7 +21,7 @@ export const chains: Chain[] = [
   { ...chain.arbitrumOne, name: 'Arbitrum' },
 ];
 
-const wallets = getDefaultWallets({
+const { connectors: defaultConnectors } = getDefaultWallets({
   appName: 'RainbowKit site',
   chains,
   infuraId,
@@ -35,8 +31,6 @@ const wallets = getDefaultWallets({
       chain.mainnet.rpcUrls[0]
     }/${infuraId}`,
 });
-
-const defaultConnectors = connectorsForWallets(wallets);
 
 export function Provider({ children, connectors = defaultConnectors }) {
   return (

--- a/site/data/docs/custom-wallet-list.mdx
+++ b/site/data/docs/custom-wallet-list.mdx
@@ -9,14 +9,14 @@ description: Customizing the wallet list
 
 > Note: This API is unstable and likely to change in the near future. We recommend avoiding changes to the wallet list for now.
 
-You can use the `wallet` object and the `Wallet` TypeScript type to build your own list of wallets. This way you have full control over which wallets to display, and in which order.
+You can use the `wallet` object and the `connectorsForWallets` function to build your own list of wallets and generate the necessary connectors. This way you have full control over which wallets to display, and in which order.
 
 For example, you can choose to only show Rainbow and WalletConnect.
 
 ```tsx
-import { wallet, WalletList } from '@rainbow-me/rainbowkit';
+import { connectorsForWallets, wallet } from '@rainbow-me/rainbowkit';
 
-const wallets: WalletList = [
+const connectors = connectorsForWallets([
   {
     groupName: 'Recommended',
     wallets: [
@@ -24,25 +24,15 @@ const wallets: WalletList = [
       wallet.walletConnect({ chains, infuraId }),
     ],
   },
-];
+]);
 ```
 
-You can then use your `wallets` object to create the neccessary connectors by using the `connectorsForWallets` function.
-
-```tsx line=5
-import { wallet, WalletList, __connectorsForWallets__ } from '@rainbow-me/rainbowkit';
-
-const wallets: WalletList = [...];
-
-const connectors = connectorsForWallets(wallets);
-```
-
-Finally, you can now pass your custom wallets to `WagmiProvider`'s `connectors` prop.
+You can then pass your connectors to `WagmiProvider`'s `connectors` prop.
 
 ```tsx line=1,4-11
-import { WagmiProvider, chain } from 'wagmi';
+import { WagmiProvider } from 'wagmi';
 ...
-const connectors = connectorsForWallets(wallets);
+const connectors = connectorsForWallets([ /* ... */ ]);
 
 const App = () => (
   <WagmiProvider connectors={connectors}>
@@ -96,7 +86,7 @@ wallet.injected(options: {
 This shouldn’t be used if another injected wallet is available. For example, when combined with MetaMask and Coinbase Wallet:
 
 ```tsx line=3-7,23-25
-import { wallet, WalletList } from '@rainbow-me/rainbowkit';
+import { connectorsForWallets, wallet } from '@rainbow-me/rainbowkit';
 
 const needsInjectedWalletFallback =
   typeof window !== 'undefined' &&
@@ -104,7 +94,7 @@ const needsInjectedWalletFallback =
   !window.ethereum.isMetaMask &&
   !window.ethereum.isCoinbaseWallet;
 
-const wallets: WalletList = [
+const connectors = connectorsForWallets([
   {
     groupName: 'Suggested',
     wallets: [
@@ -123,7 +113,7 @@ const wallets: WalletList = [
         : []),
     ],
   },
-];
+]);
 ```
 
 #### MetaMask
@@ -182,9 +172,9 @@ Here are a few examples of displaying different wallets, in different order.
 Show MetaMask and WalletConnect.
 
 ```tsx
-import { wallet, WalletList } from '@rainbow-me/rainbowkit';
+import { connectorsForWallets, wallet } from '@rainbow-me/rainbowkit';
 
-const wallets: WalletList = [
+const connectors = connectorsForWallets([
   {
     groupName: 'Recommended',
     wallets: [
@@ -192,15 +182,15 @@ const wallets: WalletList = [
       wallet.walletConnect({ chains, infuraId }),
     ],
   },
-];
+]);
 ```
 
 Show MetaMask, Rainbow and Coinbase.
 
 ```tsx
-import { wallet, WalletList } from '@rainbow-me/rainbowkit';
+import { connectorsForWallets, wallet } from '@rainbow-me/rainbowkit';
 
-const wallets: WalletList = [
+const connectors = connectorsForWallets([
   {
     groupName: 'Suggested',
     wallets: [
@@ -215,7 +205,7 @@ const wallets: WalletList = [
       }),
     ],
   },
-];
+]);
 ```
 
 > Reminder: The order of the `wallets` array defines the order in which wallets will be displayed in the UI.
@@ -227,9 +217,9 @@ You can use the `groupName` key to name different wallet groups. This is useful 
 Recommend Rainbow and MetaMask, but also offer WalletConnect and Coinbase.
 
 ```tsx
-import { wallet, WalletList } from '@rainbow-me/rainbowkit';
+import { connectorsForWallets, wallet } from '@rainbow-me/rainbowkit';
 
-const wallets: WalletList = [
+const connectors = connectorsForWallets([
   {
     groupName: 'Recommended',
     wallets: [
@@ -250,5 +240,5 @@ const wallets: WalletList = [
       }),
     ],
   },
-];
+]);
 ```

--- a/site/data/docs/installation.mdx
+++ b/site/data/docs/installation.mdx
@@ -26,7 +26,6 @@ import {
   RainbowKitProvider,
   Chain,
   getDefaultWallets,
-  connectorsForWallets,
 } from '@rainbow-me/rainbowkit';
 import { WagmiProvider, chain } from 'wagmi';
 import { providers } from 'ethers';
@@ -52,7 +51,7 @@ const chains: Chain[] = [
   { ...chain.arbitrumOne, name: 'Arbitrum' },
 ];
 
-const wallets = getDefaultWallets({
+const { connectors } = getDefaultWallets({
   chains,
   infuraId,
   appName: 'My RainbowKit App',
@@ -60,8 +59,6 @@ const wallets = getDefaultWallets({
     chains.find(x => x.id === chainId)?.rpcUrls?.[0] ??
     chain.mainnet.rpcUrls[0],
 });
-
-const connectors = connectorsForWallets(wallets);
 ```
 
 > We recommend using custom providers such as `InfuraProvider` and `AlchemyProvider`. For help generating provider ID's, see the [Infura docs](https://docs.infura.io/infura/create-a-project) and the [Alchemy docs](https://docs.alchemy.com/alchemy/introduction/getting-started).
@@ -70,10 +67,7 @@ const connectors = connectorsForWallets(wallets);
 
 Wrap your application with `RainbowKitProvider` and [`WagmiProvider`](https://wagmi-xyz.vercel.app/docs/provider).
 
-```tsx line=3-99
-...
-const connectors = connectorsForWallets(wallets);
-
+```tsx
 const App = () => {
   return (
     <WagmiProvider


### PR DESCRIPTION
In order to streamline the setup process, the `getDefaultWallets` function now returns an object containing both `connectors` and `wallets` properties. This means that most consumers will no longer need to use the `connectorsForWallets` function, accessing the generated `connectors` value instead.

This is what the cleanup looks like:

```diff
-import { getDefaultWallets, connectorsForWallets } from '@rainbow-me/rainbowkit';
+import { getDefaultWallets } from '@rainbow-me/rainbowkit';

-const wallets = getDefaultWallets({
+const { connectors } = getDefaultWallets({
  /* ... */
});

-const connectors = connectorsForWallets(wallets);
```

The wallet list is still available if you were modifying it in any way:

```diff
-const wallets = getDefaultWallets({
+const { wallets } = getDefaultWallets({
  /* ... */
});
```