### PR TITLE
fix: action button text alignment

### DIFF
--- a/.changeset/khaki-lobsters-bow.md
+++ b/.changeset/khaki-lobsters-bow.md
@@ -1,5 +1,0 @@
----
-'@rainbow-me/rainbowkit': patch
----
-
-Update ActionButton text alignment to be centered

--- a/.changeset/khaki-lobsters-bow.md
+++ b/.changeset/khaki-lobsters-bow.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Update ActionButton text alignment to be centered

--- a/packages/rainbowkit/src/components/Button/ActionButton.tsx
+++ b/packages/rainbowkit/src/components/Button/ActionButton.tsx
@@ -70,6 +70,7 @@ export function ActionButton({
       paddingX={paddingX}
       paddingY={paddingY}
       style={{ willChange: 'transform' }}
+      textAlign="center"
       transform={{ active: 'shrinkSm', hover: 'grow' }}
       transition="default"
       {...(background ? { background } : {})}

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -170,6 +170,9 @@ export function MobileOptions({ onClose }: { onClose: () => void }) {
                 create new accounts and passwords on&nbsp;every&nbsp;website.
               </Text>
             </Box>
+          </Box>
+
+          <Box paddingTop="32" paddingX="20">
             <Box display="flex" gap="14" justifyContent="center">
               <ActionButton
                 label="Get a Wallet"


### PR DESCRIPTION
Resolves RNBW-3438

I collab'd with Jeremy on this, and what we ended up doing is:
- center the text in action buttons, in case they wrap, the text is centered - and doesnt look as bad
- reduce the horizontal padding of the container wrapping the buttons in `MobileOptions` since it didn't need that much
<img width="359" alt="CleanShot 2022-04-28 at 23 05 52@2x" src="https://user-images.githubusercontent.com/372831/165845737-9b65df20-1377-4861-92be-fc899a6ba130.png">
