### PR TITLE
docs: add background color to mesh gradient

### DIFF
--- a/site/components/MeshGradient/MeshGradient.jsx
+++ b/site/components/MeshGradient/MeshGradient.jsx
@@ -219,7 +219,7 @@ function Mesh(props) {
   );
 }
 
-export function MeshGradient({ u_c1, u_c2, u_c3 }) {
+export function MeshGradient({ backgroundColor, u_c1, u_c2, u_c3 }) {
   const [devicePixelRatio, setDevicePixelRatio] = useState(null);
 
   useEffect(() => {
@@ -229,12 +229,31 @@ export function MeshGradient({ u_c1, u_c2, u_c3 }) {
     }
   }, []);
 
-  return devicePixelRatio ? (
-    <Canvas
-      camera={{ fov: 90, near: 0.1, position: [0, 0, 0] }}
-      dpr={devicePixelRatio}
+  return (
+    <div
+      style={{
+        backgroundColor,
+        height: '100%',
+        width: '100%',
+      }}
     >
-      <Mesh transitionSpeed={0.025} u_c1={u_c1} u_c2={u_c2} u_c3={u_c3} />
-    </Canvas>
-  ) : null;
+      <div
+        style={{
+          height: '100%',
+          opacity: devicePixelRatio ? 1 : 0,
+          transition: 'opacity 5s ease',
+          width: '100%',
+        }}
+      >
+        {devicePixelRatio ? (
+          <Canvas
+            camera={{ fov: 90, near: 0.1, position: [0, 0, 0] }}
+            dpr={devicePixelRatio}
+          >
+            <Mesh transitionSpeed={0.025} u_c1={u_c1} u_c2={u_c2} u_c3={u_c3} />
+          </Canvas>
+        ) : null}
+      </div>
+    </div>
+  );
 }

--- a/site/components/Playground/Playground.tsx
+++ b/site/components/Playground/Playground.tsx
@@ -32,8 +32,7 @@ type ThemeOptions = Parameters<typeof lightTheme>[0];
 type Accents = ThemeOptions['accentColor'];
 type Radii = ThemeOptions['borderRadius'];
 
-type AccentsWithoutYellow = Exclude<Accents, 'yellow'>;
-const gradientColors: Record<AccentsWithoutYellow, any> = {
+const gradientColors: Record<Accents, any> = {
   blue: [
     [29, 100, 192],
     [47, 9, 148],
@@ -95,6 +94,7 @@ export function Playground() {
         style={{ height: '100%', width: '100%' }}
       >
         <MeshGradient
+          backgroundColor="#1f4fcc"
           u_c1={gradient[0]}
           u_c2={gradient[1]}
           u_c3={gradient[2]}


### PR DESCRIPTION
When the marketing page loads, you can briefly see a black background before react-three kicks in. This adds a static background colour to improve the perceived performance, fading in the canvas once it's ready.