### PR TITLE
fix: avoid rendering avatar image when URL is not present

### DIFF
--- a/packages/rainbowkit/src/components/Avatar/Avatar.tsx
+++ b/packages/rainbowkit/src/components/Avatar/Avatar.tsx
@@ -47,14 +47,16 @@ export function Avatar({ address, imageUrl, loading, size }: AvatarProps) {
         }}
         userSelect="none"
       >
-        <Box
-          backgroundSize="cover"
-          borderRadius="full"
-          height="full"
-          position="absolute"
-          style={{ backgroundImage: `url(${imageUrl})` }}
-          width="full"
-        />
+        {imageUrl ? (
+          <Box
+            backgroundSize="cover"
+            borderRadius="full"
+            height="full"
+            position="absolute"
+            style={{ backgroundImage: `url(${imageUrl})` }}
+            width="full"
+          />
+        ) : null}
         {emoji}
       </Box>
       {typeof loading === 'boolean' && (


### PR DESCRIPTION
This fixes an issue where requests were being made to `/undefined` because the background image style was being resolved as `url(undefined)`.