### PR TITLE
docs: use avatar in small screen for site

### DIFF
--- a/site/components/Header/Header.tsx
+++ b/site/components/Header/Header.tsx
@@ -59,7 +59,9 @@ export function Header({
         <Box style={{ marginLeft: 'auto' }}>
           <Provider>
             <RainbowKitProvider chains={chains} theme={darkTheme()}>
-              <ConnectButton />
+              <ConnectButton
+                accountStatus={{ largeScreen: 'full', smallScreen: 'avatar' }}
+              />
             </RainbowKitProvider>{' '}
           </Provider>
         </Box>


### PR DESCRIPTION
before
<img width="372" alt="Screen Shot 2022-05-04 at 2 02 43 AM" src="https://user-images.githubusercontent.com/16931094/166629855-485b7ac0-2f72-4219-b5e0-c58de1102a98.png">

after
<img width="371" alt="Screen Shot 2022-05-04 at 2 02 56 AM" src="https://user-images.githubusercontent.com/16931094/166629873-6d52bf5e-e2c3-4ea1-97b3-371505a01db2.png">

