### PR TITLE
fix: types on transaction store context

### DIFF
--- a/.changeset/new-zoos-relax.md
+++ b/.changeset/new-zoos-relax.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Fixes type for TransactionStoreContext

--- a/.changeset/new-zoos-relax.md
+++ b/.changeset/new-zoos-relax.md
@@ -1,5 +1,0 @@
----
-'@rainbow-me/rainbowkit': patch
----
-
-Fixes type for TransactionStoreContext

--- a/packages/rainbowkit/src/transactions/TransactionStoreContext.tsx
+++ b/packages/rainbowkit/src/transactions/TransactionStoreContext.tsx
@@ -1,3 +1,4 @@
+import { BaseProvider } from '@ethersproject/providers';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { useProvider } from 'wagmi';
 import { useAddress } from '../hooks/useAddress';
@@ -17,7 +18,7 @@ export function TransactionStoreProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const provider = useProvider();
+  const provider = useProvider<BaseProvider>();
   const address = useAddress();
   const chainId = useChainId();
 


### PR DESCRIPTION
- when running `release:test` we get an error for missing types on `provider`
- adds `BaseProvider` type from ethers
- confirmed `release:test` typechecking passes now, and example runs