### PR TITLE
fix: ssr render provider component

### DIFF
--- a/site/components/Provider/Provider.tsx
+++ b/site/components/Provider/Provider.tsx
@@ -3,7 +3,7 @@ import {
   configureChains,
   getDefaultWallets,
 } from '@rainbow-me/rainbowkit';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { chain, createClient, Provider as WagmiProvider } from 'wagmi';
 
 const alchemyId = '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC';
@@ -25,9 +25,5 @@ const wagmiClient = createClient({
 });
 
 export function Provider({ children }) {
-  const [isMounted, setIsMounted] = useState(false);
-  useEffect(() => setIsMounted(true), []);
-
-  if (!isMounted) return null;
   return <WagmiProvider client={wagmiClient}>{children}</WagmiProvider>;
 }


### PR DESCRIPTION
Resolves RNBW-3536

We moved the `Provider` higher up the tree, so we could detect when a wallet was connected in order to show the rainbow shower. But the `Provider` was set to not mount in SSR (I actually dont remember why). Anyway, all sorted now.