### PR TITLE
fix: add more wallets to site

### DIFF
--- a/site/components/Provider/Provider.tsx
+++ b/site/components/Provider/Provider.tsx
@@ -16,7 +16,7 @@ export const { chains, provider } = configureChains(
 );
 
 const { wallets } = getDefaultWallets({
-  appName: 'RainbowKit',
+  appName: 'rainbowkit.com',
   chains,
 });
 

--- a/site/components/Provider/Provider.tsx
+++ b/site/components/Provider/Provider.tsx
@@ -1,7 +1,9 @@
 import {
   apiProvider,
   configureChains,
+  connectorsForWallets,
   getDefaultWallets,
+  wallet,
 } from '@rainbow-me/rainbowkit';
 import React from 'react';
 import { chain, createClient, Provider as WagmiProvider } from 'wagmi';
@@ -13,10 +15,22 @@ export const { chains, provider } = configureChains(
   [apiProvider.alchemy(alchemyId), apiProvider.fallback()]
 );
 
-const { connectors } = getDefaultWallets({
-  appName: 'RainbowKit site',
+const { wallets } = getDefaultWallets({
+  appName: 'RainbowKit',
   chains,
 });
+
+const connectors = connectorsForWallets([
+  ...wallets,
+  {
+    groupName: 'More',
+    wallets: [
+      wallet.argent({ chains }),
+      wallet.trust({ chains }),
+      wallet.ledger({ chains }),
+    ],
+  },
+]);
 
 const wagmiClient = createClient({
   autoConnect: true,


### PR DESCRIPTION
add all our supported wallets to the site / docs. prev it was only default wallets

<img width="1027" alt="Screen Shot 2022-05-04 at 1 25 06 PM" src="https://user-images.githubusercontent.com/16931094/166744520-f21b78e3-b973-41d9-afa1-c7daf72d870e.png">
