### PR TITLE
docs: fix typo in ConnectButton example

### DIFF
--- a/site/data/docs/connect-button.mdx
+++ b/site/data/docs/connect-button.mdx
@@ -116,7 +116,7 @@ On small screens, only show account icon. But on large screens, show icon and ad
 ```tsx
 <ConnectButton
   accountStatus={{
-    smallScreen: 'icon',
+    smallScreen: 'avatar',
     largeScreen: 'full',
   }}
 />


### PR DESCRIPTION
In the responsive example section for ConnectButton, `"icon"` is not a valid enum value for `accountStatus`. 🙂