### PR TITLE
Add Ankr as RPC provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,27 +176,23 @@ const { provider, chains } = configureChains(
 
 #### Ankr
 
-To use Ankr, use the `apiProvider.jsonRpc` provider with an Ankr Public RPC.
+To use Ankr, use the `apiProvider.jsonRpc` provider with an [Ankr Public RPC](https://ankr.com/protocol/public).
 
 ```tsx
 const { chains, provider } = configureChains(
   [chain.mainnet],
-  [
-    apiProvider.jsonRpc(chain => ({
+  [apiProvider.jsonRpc(chain => ({
       rpcUrl: `https://rpc.ankr.com/eth`,
-    })),
-  ]
+    }))]
 );
 ```
 
 ```tsx
 const { chains, provider } = configureChains(
   [chain.polygon],
-  [
-    apiProvider.jsonRpc(chain => ({
+  [apiProvider.jsonRpc(chain => ({
       rpcUrl: `https://rpc.ankr.com/polygon`,
-    })),
-  ]
+    }))]
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ To configure the chains with Ankr configuration, use the `apiProvider.jsonRpc` p
 const { chains, provider } = configureChains(
   [chain.mainnet],
   [apiProvider.jsonRpc(chain => ({
-      rpcUrl: `https://rpc.ankr.com/eth`,}))]
+      rpcUrl: `https://rpc.ankr.com/eth`}))]
 );
 ```
 
@@ -190,7 +190,7 @@ const { chains, provider } = configureChains(
 const { chains, provider } = configureChains(
   [chain.polygon],
   [apiProvider.jsonRpc(chain => ({
-      rpcUrl: `https://rpc.ankr.com/polygon`,}))]
+      rpcUrl: `https://rpc.ankr.com/polygon`}))]
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ const { provider, chains } = configureChains(
 
 #### Ankr
 
-To use Ankr, use the `apiProvider.jsonRpc` provider with an [Ankr Public RPC](https://ankr.com/protocol/public).
+To configure the chains with Ankr configuration, use the `apiProvider.jsonRpc` provider with an [Ankr Public RPC](https://ankr.com/protocol/public).
 
 ```tsx
 const { chains, provider } = configureChains(

--- a/README.md
+++ b/README.md
@@ -174,6 +174,32 @@ const { provider, chains } = configureChains(
 );
 ```
 
+#### Ankr
+
+To use Ankr, use the `apiProvider.jsonRpc` provider with an Ankr Public RPC.
+
+```tsx
+const { chains, provider } = configureChains(
+  [chain.mainnet],
+  [
+    __apiProvider.jsonRpc__(chain => ({
+      rpcUrl: `https://rpc.ankr.com/eth`,
+    })),
+  ]
+);
+```
+
+```tsx
+const { chains, provider } = configureChains(
+  [chain.polygon],
+  [
+    __apiProvider.jsonRpc__(chain => ({
+      rpcUrl: `https://rpc.ankr.com/polygon`,
+    })),
+  ]
+);
+```
+
 #### JSON RPC
 
 To configure the chains with your own RPC URLs, provide `apiProvider.jsonRpc` to `configureChains` with the chain's RPC URLs.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ To use Ankr, use the `apiProvider.jsonRpc` provider with an Ankr Public RPC.
 const { chains, provider } = configureChains(
   [chain.mainnet],
   [
-    __apiProvider.jsonRpc__(chain => ({
+    apiProvider.jsonRpc(chain => ({
       rpcUrl: `https://rpc.ankr.com/eth`,
     })),
   ]
@@ -193,7 +193,7 @@ const { chains, provider } = configureChains(
 const { chains, provider } = configureChains(
   [chain.polygon],
   [
-    __apiProvider.jsonRpc__(chain => ({
+    apiProvider.jsonRpc(chain => ({
       rpcUrl: `https://rpc.ankr.com/polygon`,
     })),
   ]

--- a/README.md
+++ b/README.md
@@ -182,8 +182,7 @@ To use Ankr, use the `apiProvider.jsonRpc` provider with an [Ankr Public RPC](ht
 const { chains, provider } = configureChains(
   [chain.mainnet],
   [apiProvider.jsonRpc(chain => ({
-      rpcUrl: `https://rpc.ankr.com/eth`,
-    }))]
+      rpcUrl: `https://rpc.ankr.com/eth`,}))]
 );
 ```
 
@@ -191,8 +190,7 @@ const { chains, provider } = configureChains(
 const { chains, provider } = configureChains(
   [chain.polygon],
   [apiProvider.jsonRpc(chain => ({
-      rpcUrl: `https://rpc.ankr.com/polygon`,
-    }))]
+      rpcUrl: `https://rpc.ankr.com/polygon`,}))]
 );
 ```
 

--- a/site/data/docs/api-providers.mdx
+++ b/site/data/docs/api-providers.mdx
@@ -76,27 +76,23 @@ const { chains, provider } = configureChains(
 
 #### Ankr
 
-To use Ankr, use the `apiProvider.jsonRpc` provider with an Ankr Public RPC.
+To use Ankr, use the `apiProvider.jsonRpc` provider with an [Ankr Public RPC](https://ankr.com/protocol/public).
 
 ```tsx
 const { chains, provider } = configureChains(
   [chain.mainnet],
-  [
-    apiProvider.jsonRpc(chain => ({
+  [apiProvider.jsonRpc(chain => ({
       rpcUrl: `https://rpc.ankr.com/eth`,
-    })),
-  ]
+    }))]
 );
 ```
 
 ```tsx
 const { chains, provider } = configureChains(
   [chain.polygon],
-  [
-    apiProvider.jsonRpc(chain => ({
+  [apiProvider.jsonRpc(chain => ({
       rpcUrl: `https://rpc.ankr.com/polygon`,
-    })),
-  ]
+    }))]
 );
 ```
 

--- a/site/data/docs/api-providers.mdx
+++ b/site/data/docs/api-providers.mdx
@@ -82,7 +82,7 @@ To use Ankr, use the `apiProvider.jsonRpc` provider with an Ankr Public RPC.
 const { chains, provider } = configureChains(
   [chain.mainnet],
   [
-    __apiProvider.jsonRpc__(chain => ({
+    apiProvider.jsonRpc(chain => ({
       rpcUrl: `https://rpc.ankr.com/eth`,
     })),
   ]
@@ -93,7 +93,7 @@ const { chains, provider } = configureChains(
 const { chains, provider } = configureChains(
   [chain.polygon],
   [
-    __apiProvider.jsonRpc__(chain => ({
+    apiProvider.jsonRpc(chain => ({
       rpcUrl: `https://rpc.ankr.com/polygon`,
     })),
   ]

--- a/site/data/docs/api-providers.mdx
+++ b/site/data/docs/api-providers.mdx
@@ -82,7 +82,7 @@ To configure the chains with Ankr configuration, use the `apiProvider.jsonRpc` p
 const { chains, provider } = configureChains(
   [chain.mainnet],
   [apiProvider.jsonRpc(chain => ({
-      rpcUrl: `https://rpc.ankr.com/eth`,}))]
+      rpcUrl: `https://rpc.ankr.com/eth`}))]
 );
 ```
 
@@ -90,7 +90,7 @@ const { chains, provider } = configureChains(
 const { chains, provider } = configureChains(
   [chain.polygon],
   [apiProvider.jsonRpc(chain => ({
-      rpcUrl: `https://rpc.ankr.com/polygon`,}))]
+      rpcUrl: `https://rpc.ankr.com/polygon`}))]
 );
 ```
 

--- a/site/data/docs/api-providers.mdx
+++ b/site/data/docs/api-providers.mdx
@@ -74,6 +74,32 @@ const { chains, provider } = configureChains(
 );
 ```
 
+#### Ankr
+
+To use Ankr, use the `apiProvider.jsonRpc` provider with an Ankr Public RPC.
+
+```tsx
+const { chains, provider } = configureChains(
+  [chain.mainnet],
+  [
+    __apiProvider.jsonRpc__(chain => ({
+      rpcUrl: `https://rpc.ankr.com/eth`,
+    })),
+  ]
+);
+```
+
+```tsx
+const { chains, provider } = configureChains(
+  [chain.polygon],
+  [
+    __apiProvider.jsonRpc__(chain => ({
+      rpcUrl: `https://rpc.ankr.com/polygon`,
+    })),
+  ]
+);
+```
+
 #### JSON RPC
 
 To use your own RPC URLs, use the `apiProvider.jsonRpc` provider to configure chains with its RPC URLs.

--- a/site/data/docs/api-providers.mdx
+++ b/site/data/docs/api-providers.mdx
@@ -82,8 +82,7 @@ To use Ankr, use the `apiProvider.jsonRpc` provider with an [Ankr Public RPC](ht
 const { chains, provider } = configureChains(
   [chain.mainnet],
   [apiProvider.jsonRpc(chain => ({
-      rpcUrl: `https://rpc.ankr.com/eth`,
-    }))]
+      rpcUrl: `https://rpc.ankr.com/eth`,}))]
 );
 ```
 
@@ -91,8 +90,7 @@ const { chains, provider } = configureChains(
 const { chains, provider } = configureChains(
   [chain.polygon],
   [apiProvider.jsonRpc(chain => ({
-      rpcUrl: `https://rpc.ankr.com/polygon`,
-    }))]
+      rpcUrl: `https://rpc.ankr.com/polygon`,}))]
 );
 ```
 

--- a/site/data/docs/api-providers.mdx
+++ b/site/data/docs/api-providers.mdx
@@ -76,7 +76,7 @@ const { chains, provider } = configureChains(
 
 #### Ankr
 
-To use Ankr, use the `apiProvider.jsonRpc` provider with an [Ankr Public RPC](https://ankr.com/protocol/public).
+To configure the chains with Ankr configuration, use the `apiProvider.jsonRpc` provider with an [Ankr Public RPC](https://ankr.com/protocol/public).
 
 ```tsx
 const { chains, provider } = configureChains(


### PR DESCRIPTION
This is a PR to add Ankr's RPCs for ETH Mainnet and Polygon.