### PR TITLE
docs: make cool mode events passive

### DIFF
--- a/site/lib/useCoolMode.ts
+++ b/site/lib/useCoolMode.ts
@@ -205,7 +205,9 @@ function makeElementCool(
   element.addEventListener(move, updateMousePosition, { passive: true });
   element.addEventListener(tap, tapHandler, { passive: true });
   element.addEventListener(tapEnd, disableAutoAddParticle, { passive: true });
-  element.addEventListener('mouseleave', disableAutoAddParticle, { passive: true });
+  element.addEventListener('mouseleave', disableAutoAddParticle, {
+    passive: true,
+  });
 
   return () => {
     element.removeEventListener(move, updateMousePosition);

--- a/site/lib/useCoolMode.ts
+++ b/site/lib/useCoolMode.ts
@@ -202,10 +202,10 @@ function makeElementCool(
     autoAddParticle = false;
   };
 
-  element.addEventListener(move, updateMousePosition, { passive: false });
-  element.addEventListener(tap, tapHandler);
-  element.addEventListener(tapEnd, disableAutoAddParticle);
-  element.addEventListener('mouseleave', disableAutoAddParticle);
+  element.addEventListener(move, updateMousePosition, { passive: true });
+  element.addEventListener(tap, tapHandler, { passive: true });
+  element.addEventListener(tapEnd, disableAutoAddParticle, { passive: true });
+  element.addEventListener('mouseleave', disableAutoAddParticle, { passive: true });
 
   return () => {
     element.removeEventListener(move, updateMousePosition);


### PR DESCRIPTION
Since the script doesn't call `preventDefault`, switching to `passive` event listeners seem to be improving the animations.