### PR TITLE
fix: ensure click events are triggered on button edges

### DIFF
--- a/.changeset/slow-clocks-marry.md
+++ b/.changeset/slow-clocks-marry.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Fix bug where click events were ignored on the edges of links/buttons due to scale transforms during hover/active states

--- a/packages/rainbowkit/src/components/Button/ActionButton.tsx
+++ b/packages/rainbowkit/src/components/Button/ActionButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
+import { increaseHitAreaForHoverTransform } from '../../css/increaseHitAreaForHoverTransform.css';
 import { isMobile } from '../../utils/isMobile';
 import { Box, BoxProps } from '../Box/Box';
 import { Text, TextProps } from '../Text/Text';
@@ -65,7 +65,7 @@ export function ActionButton({
       {...(href
         ? { as: 'a', href, rel, target }
         : { as: 'button', type: 'button' })}
-      className={increaseHitAreaOnActive.grow}
+      className={increaseHitAreaForHoverTransform.grow}
       display="block"
       onClick={onClick}
     >

--- a/packages/rainbowkit/src/components/Button/ActionButton.tsx
+++ b/packages/rainbowkit/src/components/Button/ActionButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
 import { isMobile } from '../../utils/isMobile';
 import { Box, BoxProps } from '../Box/Box';
 import { Text, TextProps } from '../Text/Text';
@@ -36,6 +37,7 @@ export function ActionButton({
   href,
   label,
   onClick,
+  rel = 'noreferrer noopener',
   size = 'medium',
   target = '_blank',
   type = 'primary',
@@ -43,6 +45,7 @@ export function ActionButton({
   href?: string;
   label: string;
   onClick?: () => void;
+  rel?: string;
   size?: Size;
   target?: string;
   type?: 'primary' | 'secondary';
@@ -60,37 +63,41 @@ export function ActionButton({
   return (
     <Box
       {...(href
-        ? { as: 'a', href, rel: 'noreferrer noopener', target }
+        ? { as: 'a', href, rel, target }
         : { as: 'button', type: 'button' })}
-      {...(hasBorder
-        ? {
-            borderColor:
-              mobile && !isNotLarge && !isPrimary
-                ? 'actionButtonBorderMobile'
-                : 'actionButtonBorder',
-            borderStyle: 'solid',
-            borderWidth: '1',
-          }
-        : {})}
-      borderRadius="actionButton"
+      className={increaseHitAreaOnActive.grow}
       display="block"
       onClick={onClick}
-      paddingX={paddingX}
-      paddingY={paddingY}
-      style={{ willChange: 'transform' }}
-      textAlign="center"
-      transform={{ active: 'shrinkSm', hover: 'grow' }}
-      transition="default"
-      {...(background ? { background } : {})}
-      {...(height ? { height } : {})}
     >
-      <Text
-        color={isPrimary ? 'accentColorForeground' : 'accentColor'}
-        size={fontSize}
-        weight="bold"
+      <Box
+        {...(hasBorder
+          ? {
+              borderColor:
+                mobile && !isNotLarge && !isPrimary
+                  ? 'actionButtonBorderMobile'
+                  : 'actionButtonBorder',
+              borderStyle: 'solid',
+              borderWidth: '1',
+            }
+          : {})}
+        borderRadius="actionButton"
+        paddingX={paddingX}
+        paddingY={paddingY}
+        style={{ willChange: 'transform' }}
+        textAlign="center"
+        transform={{ active: 'shrinkSm', hover: 'grow' }}
+        transition="default"
+        {...(background ? { background } : {})}
+        {...(height ? { height } : {})}
       >
-        {label}
-      </Text>
+        <Text
+          color={isPrimary ? 'accentColorForeground' : 'accentColor'}
+          size={fontSize}
+          weight="bold"
+        >
+          {label}
+        </Text>
+      </Box>
     </Box>
   );
 }

--- a/packages/rainbowkit/src/components/Button/ActionButton.tsx
+++ b/packages/rainbowkit/src/components/Button/ActionButton.tsx
@@ -65,8 +65,9 @@ export function ActionButton({
       {...(href
         ? { as: 'a', href, rel, target }
         : { as: 'button', type: 'button' })}
+      borderRadius="actionButton"
       className={increaseHitAreaForHoverTransform.grow}
-      display="block"
+      display="flex"
       onClick={onClick}
     >
       <Box

--- a/packages/rainbowkit/src/components/CloseButton/CloseButton.tsx
+++ b/packages/rainbowkit/src/components/CloseButton/CloseButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
+import { increaseHitAreaForHoverTransform } from '../../css/increaseHitAreaForHoverTransform.css';
 import { isMobile } from '../../utils/isMobile';
 import { Box } from '../Box/Box';
 import { CloseIcon } from '../Icons/Close';
@@ -9,7 +9,7 @@ export const CloseButton = ({ onClose }: { onClose: () => void }) => {
   return (
     <Box
       as="button"
-      className={increaseHitAreaOnActive.growLg}
+      className={increaseHitAreaForHoverTransform.growLg}
       height={mobile ? '30' : '28'}
       onClick={onClose}
       type="button"

--- a/packages/rainbowkit/src/components/CloseButton/CloseButton.tsx
+++ b/packages/rainbowkit/src/components/CloseButton/CloseButton.tsx
@@ -1,36 +1,38 @@
 import React from 'react';
+import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
 import { isMobile } from '../../utils/isMobile';
 import { Box } from '../Box/Box';
 import { CloseIcon } from '../Icons/Close';
 
-export const CloseButton = ({
-  onClose,
-  style,
-}: {
-  onClose: () => void;
-  style?: React.CSSProperties;
-}) => {
+export const CloseButton = ({ onClose }: { onClose: () => void }) => {
   const mobile = isMobile();
   return (
     <Box
-      alignItems="center"
       as="button"
-      background="closeButtonBackground"
-      borderColor="actionButtonBorder"
-      borderRadius="full"
-      borderStyle="solid"
-      borderWidth={mobile ? '0' : '1'}
-      color="closeButton"
-      display="flex"
+      className={increaseHitAreaOnActive.growLg}
       height={mobile ? '30' : '28'}
-      justifyContent="center"
       onClick={onClose}
-      style={{ willChange: 'transform', ...(style ?? {}) }}
-      transform={{ active: 'shrinkSm', hover: 'growLg' }}
-      transition="default"
+      type="button"
       width={mobile ? '30' : '28'}
     >
-      <CloseIcon />
+      <Box
+        alignItems="center"
+        background="closeButtonBackground"
+        borderColor="actionButtonBorder"
+        borderRadius="full"
+        borderStyle="solid"
+        borderWidth={mobile ? '0' : '1'}
+        color="closeButton"
+        display="flex"
+        height="full"
+        justifyContent="center"
+        style={{ willChange: 'transform' }}
+        transform={{ active: 'shrinkSm', hover: 'growLg' }}
+        transition="default"
+        width="full"
+      >
+        <CloseIcon />
+      </Box>
     </Box>
   );
 };

--- a/packages/rainbowkit/src/components/CloseButton/CloseButton.tsx
+++ b/packages/rainbowkit/src/components/CloseButton/CloseButton.tsx
@@ -9,7 +9,9 @@ export const CloseButton = ({ onClose }: { onClose: () => void }) => {
   return (
     <Box
       as="button"
+      borderRadius="full"
       className={increaseHitAreaForHoverTransform.growLg}
+      display="flex"
       height={mobile ? '30' : '28'}
       onClick={onClose}
       type="button"

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
 import {
   mapResponsiveValue,
   normalizeResponsiveValue,
@@ -63,162 +64,172 @@ export function ConnectButton({
               <>
                 {chain && (chains.length > 1 || unsupportedChain) && (
                   <Box
-                    alignItems="center"
                     as="button"
-                    background={
-                      unsupportedChain
-                        ? 'connectButtonBackgroundError'
-                        : 'connectButtonBackground'
-                    }
-                    borderRadius="connectButton"
-                    boxShadow="connectButton"
-                    color={
-                      unsupportedChain
-                        ? 'connectButtonTextError'
-                        : 'connectButtonText'
-                    }
-                    display={mapResponsiveValue(chainStatus, value =>
-                      value === 'none' ? 'none' : 'flex'
-                    )}
-                    fontFamily="body"
-                    fontWeight="bold"
-                    gap="6"
+                    className={increaseHitAreaOnActive.grow}
                     key={unsupportedChain ? 'unsupported' : 'supported'} // Force re-mount to prevent CSS transition
                     onClick={openChainModal}
-                    paddingX="10"
-                    paddingY="8"
-                    transform={{ active: 'shrink', hover: 'grow' }}
-                    transition="default"
                     type="button"
                   >
-                    {unsupportedChain ? (
-                      <Box
-                        alignItems="center"
-                        display="flex"
-                        height="24"
-                        paddingX="4"
-                      >
-                        Wrong network
-                      </Box>
-                    ) : (
-                      <Box alignItems="center" display="flex" gap="6">
-                        {chain.hasIcon ? (
-                          <Box
-                            display={mapResponsiveValue(chainStatus, value =>
-                              value === 'full' || value === 'icon'
-                                ? 'block'
-                                : 'none'
-                            )}
-                            height="24"
-                            width="24"
-                          >
-                            <AsyncImage
-                              alt={chain.name ?? 'Chain icon'}
-                              background={chain.iconBackground}
-                              borderRadius="full"
-                              height="24"
-                              src={chain.iconUrl}
-                              width="24"
-                            />
-                          </Box>
-                        ) : null}
+                    <Box
+                      alignItems="center"
+                      background={
+                        unsupportedChain
+                          ? 'connectButtonBackgroundError'
+                          : 'connectButtonBackground'
+                      }
+                      borderRadius="connectButton"
+                      boxShadow="connectButton"
+                      color={
+                        unsupportedChain
+                          ? 'connectButtonTextError'
+                          : 'connectButtonText'
+                      }
+                      display={mapResponsiveValue(chainStatus, value =>
+                        value === 'none' ? 'none' : 'flex'
+                      )}
+                      fontFamily="body"
+                      fontWeight="bold"
+                      gap="6"
+                      paddingX="10"
+                      paddingY="8"
+                      transform={{ active: 'shrink', hover: 'grow' }}
+                      transition="default"
+                    >
+                      {unsupportedChain ? (
                         <Box
-                          display={mapResponsiveValue(chainStatus, value => {
-                            if (value === 'icon' && !chain.iconUrl) {
-                              return 'block'; // Show the chain name if there is no iconUrl
-                            }
-
-                            return value === 'full' || value === 'name'
-                              ? 'block'
-                              : 'none';
-                          })}
+                          alignItems="center"
+                          display="flex"
+                          height="24"
+                          paddingX="4"
                         >
-                          {chain.name ?? chain.id}
+                          Wrong network
                         </Box>
-                      </Box>
-                    )}
-                    <DropdownIcon />
+                      ) : (
+                        <Box alignItems="center" display="flex" gap="6">
+                          {chain.hasIcon ? (
+                            <Box
+                              display={mapResponsiveValue(chainStatus, value =>
+                                value === 'full' || value === 'icon'
+                                  ? 'block'
+                                  : 'none'
+                              )}
+                              height="24"
+                              width="24"
+                            >
+                              <AsyncImage
+                                alt={chain.name ?? 'Chain icon'}
+                                background={chain.iconBackground}
+                                borderRadius="full"
+                                height="24"
+                                src={chain.iconUrl}
+                                width="24"
+                              />
+                            </Box>
+                          ) : null}
+                          <Box
+                            display={mapResponsiveValue(chainStatus, value => {
+                              if (value === 'icon' && !chain.iconUrl) {
+                                return 'block'; // Show the chain name if there is no iconUrl
+                              }
+
+                              return value === 'full' || value === 'name'
+                                ? 'block'
+                                : 'none';
+                            })}
+                          >
+                            {chain.name ?? chain.id}
+                          </Box>
+                        </Box>
+                      )}
+                      <DropdownIcon />
+                    </Box>
                   </Box>
                 )}
 
                 {!unsupportedChain && (
                   <Box
-                    alignItems="center"
                     as="button"
-                    background="connectButtonBackground"
-                    borderRadius="connectButton"
-                    boxShadow="connectButton"
-                    color="connectButtonText"
-                    display="flex"
-                    fontFamily="body"
-                    fontWeight="bold"
+                    className={increaseHitAreaOnActive.grow}
                     onClick={openAccountModal}
-                    transform={{ active: 'shrink', hover: 'grow' }}
-                    transition="default"
                     type="button"
                   >
-                    {account.displayBalance && (
-                      <Box
-                        display={mapResponsiveValue(showBalance, value =>
-                          value ? 'block' : 'none'
-                        )}
-                        padding="8"
-                        paddingLeft="12"
-                      >
-                        {account.displayBalance}
-                      </Box>
-                    )}
                     <Box
-                      background={
-                        normalizeResponsiveValue(showBalance)[
-                          isMobile() ? 'smallScreen' : 'largeScreen'
-                        ]
-                          ? 'connectButtonInnerBackground'
-                          : 'connectButtonBackground'
-                      }
-                      borderColor="connectButtonBackground"
+                      alignItems="center"
+                      background="connectButtonBackground"
                       borderRadius="connectButton"
-                      borderStyle="solid"
-                      borderWidth="2"
+                      boxShadow="connectButton"
                       color="connectButtonText"
+                      display="flex"
                       fontFamily="body"
                       fontWeight="bold"
-                      paddingX="8"
-                      paddingY="6"
+                      transform={{ active: 'shrink', hover: 'grow' }}
                       transition="default"
                     >
+                      {account.displayBalance && (
+                        <Box
+                          display={mapResponsiveValue(showBalance, value =>
+                            value ? 'block' : 'none'
+                          )}
+                          padding="8"
+                          paddingLeft="12"
+                        >
+                          {account.displayBalance}
+                        </Box>
+                      )}
                       <Box
-                        alignItems="center"
-                        display="flex"
-                        gap="6"
-                        height="24"
+                        background={
+                          normalizeResponsiveValue(showBalance)[
+                            isMobile() ? 'smallScreen' : 'largeScreen'
+                          ]
+                            ? 'connectButtonInnerBackground'
+                            : 'connectButtonBackground'
+                        }
+                        borderColor="connectButtonBackground"
+                        borderRadius="connectButton"
+                        borderStyle="solid"
+                        borderWidth="2"
+                        color="connectButtonText"
+                        fontFamily="body"
+                        fontWeight="bold"
+                        paddingX="8"
+                        paddingY="6"
+                        transition="default"
                       >
                         <Box
-                          display={mapResponsiveValue(accountStatus, value =>
-                            value === 'full' || value === 'avatar'
-                              ? 'block'
-                              : 'none'
-                          )}
+                          alignItems="center"
+                          display="flex"
+                          gap="6"
+                          height="24"
                         >
-                          <Avatar
-                            address={account.address}
-                            imageUrl={account.ensAvatar}
-                            loading={account.hasPendingTransactions}
-                            size={24}
-                          />
-                        </Box>
-
-                        <Box alignItems="center" display="flex" gap="6">
                           <Box
                             display={mapResponsiveValue(accountStatus, value =>
-                              value === 'full' || value === 'address'
+                              value === 'full' || value === 'avatar'
                                 ? 'block'
                                 : 'none'
                             )}
                           >
-                            {account.displayName}
+                            <Avatar
+                              address={account.address}
+                              imageUrl={account.ensAvatar}
+                              loading={account.hasPendingTransactions}
+                              size={24}
+                            />
                           </Box>
-                          <DropdownIcon />
+
+                          <Box alignItems="center" display="flex" gap="6">
+                            <Box
+                              display={mapResponsiveValue(
+                                accountStatus,
+                                value =>
+                                  value === 'full' || value === 'address'
+                                    ? 'block'
+                                    : 'none'
+                              )}
+                            >
+                              {account.displayName}
+                            </Box>
+                            <DropdownIcon />
+                          </Box>
                         </Box>
                       </Box>
                     </Box>
@@ -227,23 +238,23 @@ export function ConnectButton({
               </>
             ) : (
               <Box
-                background="connectButtonBackground"
-                borderRadius="connectButton"
-                transform={{ active: 'shrink', hover: 'grow' }}
-                transition="default"
+                as="button"
+                className={increaseHitAreaOnActive.grow}
+                key="connect"
+                onClick={openConnectModal}
+                type="button"
               >
                 <Box
-                  as="button"
                   background="accentColor"
                   borderRadius="connectButton"
                   boxShadow="connectButton"
                   color="accentColorForeground"
                   fontFamily="body"
                   fontWeight="bold"
-                  onClick={openConnectModal}
                   paddingX="14"
                   paddingY="10"
-                  type="button"
+                  transform={{ active: 'shrink', hover: 'grow' }}
+                  transition="default"
                 >
                   Connect Wallet
                 </Box>

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
+import { increaseHitAreaForHoverTransform } from '../../css/increaseHitAreaForHoverTransform.css';
 import {
   mapResponsiveValue,
   normalizeResponsiveValue,
@@ -65,7 +65,7 @@ export function ConnectButton({
                 {chain && (chains.length > 1 || unsupportedChain) && (
                   <Box
                     as="button"
-                    className={increaseHitAreaOnActive.grow}
+                    className={increaseHitAreaForHoverTransform.grow}
                     key={unsupportedChain ? 'unsupported' : 'supported'} // Force re-mount to prevent CSS transition
                     onClick={openChainModal}
                     type="button"
@@ -149,7 +149,7 @@ export function ConnectButton({
                 {!unsupportedChain && (
                   <Box
                     as="button"
-                    className={increaseHitAreaOnActive.grow}
+                    className={increaseHitAreaForHoverTransform.grow}
                     onClick={openAccountModal}
                     type="button"
                   >
@@ -239,7 +239,7 @@ export function ConnectButton({
             ) : (
               <Box
                 as="button"
-                className={increaseHitAreaOnActive.grow}
+                className={increaseHitAreaForHoverTransform.grow}
                 key="connect"
                 onClick={openConnectModal}
                 type="button"

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -65,7 +65,9 @@ export function ConnectButton({
                 {chain && (chains.length > 1 || unsupportedChain) && (
                   <Box
                     as="button"
+                    borderRadius="connectButton"
                     className={increaseHitAreaForHoverTransform.grow}
+                    display="flex"
                     key={unsupportedChain ? 'unsupported' : 'supported'} // Force re-mount to prevent CSS transition
                     onClick={openChainModal}
                     type="button"
@@ -149,7 +151,9 @@ export function ConnectButton({
                 {!unsupportedChain && (
                   <Box
                     as="button"
+                    borderRadius="connectButton"
                     className={increaseHitAreaForHoverTransform.grow}
+                    display="flex"
                     onClick={openAccountModal}
                     type="button"
                   >
@@ -239,7 +243,9 @@ export function ConnectButton({
             ) : (
               <Box
                 as="button"
+                borderRadius="connectButton"
                 className={increaseHitAreaForHoverTransform.grow}
+                display="flex"
                 key="connect"
                 onClick={openConnectModal}
                 type="button"

--- a/packages/rainbowkit/src/components/ConnectModal/ConnectModalIntro.tsx
+++ b/packages/rainbowkit/src/components/ConnectModal/ConnectModalIntro.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
 import { Box } from '../Box/Box';
 import { ActionButton } from '../Button/ActionButton';
 import { AssetsIcon } from '../Icons/Assets';
@@ -71,18 +72,23 @@ export function ConnectModalIntro({ getWallet }: { getWallet: () => void }) {
           <ActionButton label="Get a Wallet" onClick={getWallet} />
           <Box
             as="a"
+            className={increaseHitAreaOnActive.grow}
+            display="block"
             href={learnMoreUrl}
-            paddingX="12"
-            paddingY="4"
             rel="noreferrer"
-            style={{ willChange: 'transform' }}
             target="_blank"
-            transform={{ active: 'shrink', hover: 'grow' }}
-            transition="default"
           >
-            <Text color="accentColor" size="14" weight="bold">
-              Learn More
-            </Text>
+            <Box
+              paddingX="12"
+              paddingY="4"
+              style={{ willChange: 'transform' }}
+              transform={{ active: 'shrink', hover: 'grow' }}
+              transition="default"
+            >
+              <Text color="accentColor" size="14" weight="bold">
+                Learn More
+              </Text>
+            </Box>
           </Box>
         </Box>
       </Box>

--- a/packages/rainbowkit/src/components/ConnectModal/ConnectModalIntro.tsx
+++ b/packages/rainbowkit/src/components/ConnectModal/ConnectModalIntro.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
+import { increaseHitAreaForHoverTransform } from '../../css/increaseHitAreaForHoverTransform.css';
 import { Box } from '../Box/Box';
 import { ActionButton } from '../Button/ActionButton';
 import { AssetsIcon } from '../Icons/Assets';
@@ -72,7 +72,7 @@ export function ConnectModalIntro({ getWallet }: { getWallet: () => void }) {
           <ActionButton label="Get a Wallet" onClick={getWallet} />
           <Box
             as="a"
-            className={increaseHitAreaOnActive.grow}
+            className={increaseHitAreaForHoverTransform.grow}
             display="block"
             href={learnMoreUrl}
             rel="noreferrer"

--- a/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useEffect } from 'react';
-import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
+import { increaseHitAreaForHoverTransform } from '../../css/increaseHitAreaForHoverTransform.css';
 import { useWindowSize } from '../../hooks/useWindowSize';
 import { isSafari } from '../../utils/browsers';
 import { InstructionStepName } from '../../wallets/Wallet';
@@ -459,7 +459,7 @@ export function InstructionDetail({
         />
         <Box
           as="a"
-          className={increaseHitAreaOnActive.grow}
+          className={increaseHitAreaForHoverTransform.grow}
           display="block"
           href={wallet?.qrCode?.instructions?.learnMoreUrl}
           rel="noreferrer"

--- a/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
@@ -1,4 +1,5 @@
-import React, { ElementType, ReactNode, useEffect } from 'react';
+import React, { ReactNode, useEffect } from 'react';
+import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
 import { useWindowSize } from '../../hooks/useWindowSize';
 import { isSafari } from '../../utils/browsers';
 import { InstructionStepName } from '../../wallets/Wallet';
@@ -23,15 +24,6 @@ export function GetDetail({
 }) {
   const wallets = useWalletConnectors();
   const shownWallets = wallets.splice(0, 5);
-
-  const linkProps = (
-    link: string
-  ): { as: ElementType; href: string; rel: string; target: string } => ({
-    as: 'a',
-    href: link,
-    rel: 'noreferrer',
-    target: '_blank',
-  });
 
   return (
     <Box
@@ -96,18 +88,14 @@ export function GetDetail({
                     </Text>
                   </Box>
                 </Box>
-                <Box
-                  display="flex"
-                  flexDirection="column"
-                  gap="4"
-                  onClick={() => hasMobileCompanionApp && getMobileWallet(id)}
-                  {...(!hasMobileCompanionApp && downloadUrls?.browserExtension
-                    ? linkProps(downloadUrls.browserExtension)
-                    : {})}
-                >
+                <Box display="flex" flexDirection="column" gap="4">
                   <ActionButton
                     label="GET"
-                    onClick={() => {}}
+                    onClick={() => hasMobileCompanionApp && getMobileWallet(id)}
+                    {...(!hasMobileCompanionApp &&
+                    downloadUrls?.browserExtension
+                      ? { as: 'a', href: downloadUrls.browserExtension }
+                      : {})}
                     type="secondary"
                   />
                 </Box>
@@ -471,18 +459,23 @@ export function InstructionDetail({
         />
         <Box
           as="a"
+          className={increaseHitAreaOnActive.grow}
+          display="block"
           href={wallet?.qrCode?.instructions?.learnMoreUrl}
-          paddingX="12"
-          paddingY="4"
           rel="noreferrer"
-          style={{ willChange: 'transform' }}
           target="_blank"
-          transform={{ active: 'shrink', hover: 'grow' }}
-          transition="default"
         >
-          <Text color="accentColor" size="14" weight="bold">
-            Learn More
-          </Text>
+          <Box
+            paddingX="12"
+            paddingY="4"
+            style={{ willChange: 'transform' }}
+            transform={{ active: 'shrink', hover: 'grow' }}
+            transition="default"
+          >
+            <Text color="accentColor" size="14" weight="bold">
+              Learn More
+            </Text>
+          </Box>
         </Box>
       </Box>
     </Box>

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useEffect, useState } from 'react';
-import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
+import { increaseHitAreaForHoverTransform } from '../../css/increaseHitAreaForHoverTransform.css';
 import { isSafari } from '../../utils/browsers';
 import { groupBy } from '../../utils/groupBy';
 import { isMobile } from '../../utils/isMobile';
@@ -212,7 +212,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
                 {headerBackButtonLink && (
                   <Box
                     as="button"
-                    className={increaseHitAreaOnActive.growLg}
+                    className={increaseHitAreaForHoverTransform.growLg}
                     onClick={() =>
                       headerBackButtonLink &&
                       setWalletStep(headerBackButtonLink)

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment, useEffect, useState } from 'react';
+import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
 import { isSafari } from '../../utils/browsers';
 import { groupBy } from '../../utils/groupBy';
 import { isMobile } from '../../utils/isMobile';
@@ -211,22 +212,30 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
                 {headerBackButtonLink && (
                   <Box
                     as="button"
-                    color="accentColor"
+                    className={increaseHitAreaOnActive.growLg}
                     onClick={() =>
                       headerBackButtonLink &&
                       setWalletStep(headerBackButtonLink)
                     }
-                    paddingX="8"
-                    paddingY="4"
-                    style={{
-                      boxSizing: 'content-box',
-                      height: 17,
-                      willChange: 'transform',
-                    }}
-                    transform={{ active: 'shrinkSm', hover: 'growLg' }}
-                    transition="default"
+                    type="button"
                   >
-                    <BackIcon />
+                    <Box
+                      color="accentColor"
+                      paddingX="8"
+                      paddingY="4"
+                      style={{
+                        boxSizing: 'content-box',
+                        height: 17,
+                        willChange: 'transform',
+                      }}
+                      transform={{
+                        active: 'shrinkSm',
+                        hover: 'growLg',
+                      }}
+                      transition="default"
+                    >
+                      <BackIcon />
+                    </Box>
                   </Box>
                 )}
               </Box>

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useContext, useState } from 'react';
+import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
 import { isIOS } from '../../utils/isMobile';
 import {
   useWalletConnectors,
@@ -327,19 +328,24 @@ export function MobileOptions({ onClose }: { onClose: () => void }) {
               }}
             >
               <Box
-                alignItems="center"
                 as="button"
-                color="accentColor"
-                display="flex"
-                marginLeft="4"
-                marginTop="20"
+                className={increaseHitAreaOnActive.growLg}
                 onClick={() => setWalletStep(headerBackButtonLink!)}
-                padding="16"
-                style={{ height: 17, willChange: 'transform' }}
-                transform={{ active: 'shrinkSm', hover: 'growLg' }}
-                transition="default"
+                type="button"
               >
-                <BackIcon />
+                <Box
+                  alignItems="center"
+                  color="accentColor"
+                  display="flex"
+                  marginLeft="4"
+                  marginTop="20"
+                  padding="16"
+                  style={{ height: 17, willChange: 'transform' }}
+                  transform={{ active: 'shrinkSm', hover: 'growLg' }}
+                  transition="default"
+                >
+                  <BackIcon />
+                </Box>
               </Box>
             </Box>
           )}

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useState } from 'react';
-import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
+import { increaseHitAreaForHoverTransform } from '../../css/increaseHitAreaForHoverTransform.css';
 import { isIOS } from '../../utils/isMobile';
 import {
   useWalletConnectors,
@@ -329,7 +329,7 @@ export function MobileOptions({ onClose }: { onClose: () => void }) {
             >
               <Box
                 as="button"
-                className={increaseHitAreaOnActive.growLg}
+                className={increaseHitAreaForHoverTransform.growLg}
                 onClick={() => setWalletStep(headerBackButtonLink!)}
                 type="button"
               >

--- a/packages/rainbowkit/src/components/MenuButton/MenuButton.css.ts
+++ b/packages/rainbowkit/src/components/MenuButton/MenuButton.css.ts
@@ -1,11 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
-export const unsetBackgroundOnHover = style([
-  {
-    selectors: {
-      '&:hover': {
-        background: 'unset',
-      },
-    },
+export const unsetBackgroundOnHover = style({
+  ':hover': {
+    background: 'unset',
   },
-]);
+});

--- a/packages/rainbowkit/src/components/MenuButton/MenuButton.css.ts
+++ b/packages/rainbowkit/src/components/MenuButton/MenuButton.css.ts
@@ -1,25 +1,6 @@
 import { style } from '@vanilla-extract/css';
-import { sprinkles } from '../../css/sprinkles.css';
 
-export const MenuButtonClassName = style([
-  sprinkles({
-    background: {
-      hover: 'menuItemBackground',
-    },
-    borderRadius: 'menuButton',
-    color: 'modalText',
-    padding: '6',
-    transform: {
-      active: 'shrink',
-    },
-    transition: 'default',
-  }),
-]);
-
-export const MobileMenuButtonClassName = style([
-  sprinkles({
-    padding: '8',
-  }),
+export const unsetBackgroundOnHover = style([
   {
     selectors: {
       '&:hover': {
@@ -27,17 +8,4 @@ export const MobileMenuButtonClassName = style([
       },
     },
   },
-]);
-
-export const SelectedMenuButtonClassName = style([
-  sprinkles({
-    background: 'accentColor',
-    borderColor: 'selectedOptionBorder',
-    borderRadius: 'menuButton',
-    borderStyle: 'solid',
-    borderWidth: '1',
-    boxShadow: 'selectedOption',
-    color: 'accentColorForeground',
-    padding: '6',
-  }),
 ]);

--- a/packages/rainbowkit/src/components/MenuButton/MenuButton.tsx
+++ b/packages/rainbowkit/src/components/MenuButton/MenuButton.tsx
@@ -1,44 +1,52 @@
 import React from 'react';
 import { isMobile } from '../../utils/isMobile';
 import { Box } from '../Box/Box';
-import {
-  MenuButtonClassName,
-  MobileMenuButtonClassName,
-  SelectedMenuButtonClassName,
-} from './MenuButton.css';
+import * as styles from './MenuButton.css';
 
 type Props = {
   children?: React.ReactNode;
   onClick?: React.MouseEventHandler<HTMLElement> | undefined;
-  as?: React.ElementType<any>;
   currentlySelected?: boolean;
 };
 
 export const MenuButton = React.forwardRef(
   (
-    {
-      as = 'button',
-      children,
-      currentlySelected = false,
-      onClick,
-      ...urlProps
-    }: Props,
+    { children, currentlySelected = false, onClick, ...urlProps }: Props,
     ref: React.Ref<HTMLElement>
   ) => {
     const mobile = isMobile();
     return (
       <Box
-        as={as}
-        className={[
-          currentlySelected ? SelectedMenuButtonClassName : MenuButtonClassName,
-          mobile ? MobileMenuButtonClassName : null,
-        ]}
+        as="button"
         disabled={currentlySelected}
         onClick={onClick}
         ref={ref}
-        {...urlProps}
+        type="button"
       >
-        {children}
+        <Box
+          borderRadius="menuButton"
+          className={mobile ? styles.unsetBackgroundOnHover : undefined}
+          padding={mobile ? '8' : '6'}
+          transition="default"
+          {...(currentlySelected
+            ? {
+                background: 'accentColor',
+                borderColor: 'selectedOptionBorder',
+                borderStyle: 'solid',
+                borderWidth: '1',
+                boxShadow: 'selectedOption',
+                color: 'accentColorForeground',
+              }
+            : {
+                background: { hover: 'menuItemBackground' },
+                color: 'modalText',
+                transform: { active: 'shrink' },
+                transition: 'default',
+              })}
+          {...urlProps}
+        >
+          {children}
+        </Box>
       </Box>
     );
   }

--- a/packages/rainbowkit/src/components/MenuButton/MenuButton.tsx
+++ b/packages/rainbowkit/src/components/MenuButton/MenuButton.tsx
@@ -18,7 +18,9 @@ export const MenuButton = React.forwardRef(
     return (
       <Box
         as="button"
+        borderRadius="menuButton"
         disabled={currentlySelected}
+        display="flex"
         onClick={onClick}
         ref={ref}
         type="button"
@@ -28,6 +30,7 @@ export const MenuButton = React.forwardRef(
           className={mobile ? styles.unsetBackgroundOnHover : undefined}
           padding={mobile ? '8' : '6'}
           transition="default"
+          width="full"
           {...(currentlySelected
             ? {
                 background: 'accentColor',

--- a/packages/rainbowkit/src/components/ModalSelection/ModalSelection.css.ts
+++ b/packages/rainbowkit/src/components/ModalSelection/ModalSelection.css.ts
@@ -1,34 +1,3 @@
 import { style } from '@vanilla-extract/css';
-import { sprinkles } from '../../css/sprinkles.css';
 
-export const HoverClassName = style([
-  sprinkles({
-    background: {
-      hover: 'menuItemBackground',
-    },
-    borderRadius: 'menuButton',
-    borderStyle: 'solid',
-    borderWidth: '1',
-    paddingX: '5',
-    paddingY: '5',
-    transform: {
-      active: 'shrink',
-    },
-    transition: 'default',
-  }),
-  { borderColor: 'transparent' },
-]);
-
-export const SelectedClassName = style([
-  sprinkles({
-    background: 'accentColor',
-    borderColor: 'selectedOptionBorder',
-    borderRadius: 'menuButton',
-    borderStyle: 'solid',
-    borderWidth: '1',
-    boxShadow: 'selectedWallet',
-    paddingX: '5',
-    paddingY: '5',
-    transition: 'default',
-  }),
-]);
+export const transparentBorder = style({ borderColor: 'transparent' });

--- a/packages/rainbowkit/src/components/ModalSelection/ModalSelection.tsx
+++ b/packages/rainbowkit/src/components/ModalSelection/ModalSelection.tsx
@@ -35,7 +35,13 @@ export const ModalSelection = ({
       onMouseLeave={() => setIsMouseOver(false)}
       ref={coolModeRef}
     >
-      <Box as={as} disabled={currentlySelected} onClick={onClick}>
+      <Box
+        as={as}
+        borderRadius="menuButton"
+        disabled={currentlySelected}
+        display="flex"
+        onClick={onClick}
+      >
         <Box
           borderRadius="menuButton"
           borderStyle="solid"
@@ -43,6 +49,7 @@ export const ModalSelection = ({
           padding="5"
           style={{ willChange: 'transform' }}
           transition="default"
+          width="full"
           {...(currentlySelected
             ? {
                 background: 'accentColor',

--- a/packages/rainbowkit/src/components/ModalSelection/ModalSelection.tsx
+++ b/packages/rainbowkit/src/components/ModalSelection/ModalSelection.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { AsyncImage } from '../AsyncImage/AsyncImage';
 import { Box } from '../Box/Box';
 import { useCoolMode } from '../RainbowKitProvider/useCoolMode';
-import { HoverClassName, SelectedClassName } from './ModalSelection.css';
+import * as styles from './ModalSelection.css';
 
 type Props = {
   onClick?: React.MouseEventHandler<HTMLElement> | undefined;
@@ -35,32 +35,51 @@ export const ModalSelection = ({
       onMouseLeave={() => setIsMouseOver(false)}
       ref={coolModeRef}
     >
-      <Box
-        as={as}
-        className={currentlySelected ? SelectedClassName : HoverClassName}
-        disabled={currentlySelected}
-        onClick={onClick}
-        style={{ willChange: 'transform' }}
-        {...urlProps}
-      >
+      <Box as={as} disabled={currentlySelected} onClick={onClick}>
         <Box
-          color={currentlySelected ? 'accentColorForeground' : 'modalText'}
-          disabled={!ready}
-          fontFamily="body"
-          fontSize="16"
-          fontWeight="bold"
+          borderRadius="menuButton"
+          borderStyle="solid"
+          borderWidth="1"
+          padding="5"
+          style={{ willChange: 'transform' }}
           transition="default"
+          {...(currentlySelected
+            ? {
+                background: 'accentColor',
+                borderColor: 'selectedOptionBorder',
+                boxShadow: 'selectedWallet',
+              }
+            : {
+                background: { hover: 'menuItemBackground' },
+                className: styles.transparentBorder,
+                transform: { active: 'shrink' },
+              })}
+          {...urlProps}
         >
-          <Box alignItems="center" display="flex" flexDirection="row" gap="12">
-            <AsyncImage
-              background={iconBackground}
-              {...(isMouseOver ? {} : { borderColor: 'actionButtonBorder' })}
-              borderRadius="6"
-              height="28"
-              src={iconUrl}
-              width="28"
-            />
-            <div>{name}</div>
+          <Box
+            color={currentlySelected ? 'accentColorForeground' : 'modalText'}
+            disabled={!ready}
+            fontFamily="body"
+            fontSize="16"
+            fontWeight="bold"
+            transition="default"
+          >
+            <Box
+              alignItems="center"
+              display="flex"
+              flexDirection="row"
+              gap="12"
+            >
+              <AsyncImage
+                background={iconBackground}
+                {...(isMouseOver ? {} : { borderColor: 'actionButtonBorder' })}
+                borderRadius="6"
+                height="28"
+                src={iconUrl}
+                width="28"
+              />
+              <div>{name}</div>
+            </Box>
           </Box>
         </Box>
       </Box>

--- a/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
+++ b/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
@@ -75,15 +75,16 @@ export function ProfileDetails({
             margin="8"
             style={{ textAlign: 'center' }}
           >
-            <CloseButton
-              onClose={onClose}
+            <Box
               style={{
                 position: 'absolute',
                 right: 16,
                 top: 16,
                 willChange: 'transform',
               }}
-            />{' '}
+            >
+              <CloseButton onClose={onClose} />
+            </Box>{' '}
             <Box marginTop={mobile ? '24' : '0'}>
               <Avatar
                 address={accountData.address}

--- a/packages/rainbowkit/src/components/ProfileDetails/ProfileDetailsAction.tsx
+++ b/packages/rainbowkit/src/components/ProfileDetails/ProfileDetailsAction.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
 import { isMobile } from '../../utils/isMobile';
 import { Box } from '../Box/Box';
 import { Text } from '../Text/Text';
@@ -27,36 +28,47 @@ export function ProfileDetailsAction({
   return (
     <Box
       as={url ? 'a' : 'button'}
+      className={!mobile ? increaseHitAreaOnActive.grow : undefined}
+      display="block"
       onClick={action}
-      {...urlProps}
-      background={{
-        base: 'profileAction',
-        ...(!mobile ? { hover: 'profileActionHover' } : {}),
-      }}
-      borderRadius="menuButton"
-      boxShadow="profileDetailsAction"
-      padding={mobile ? '8' : '10'}
-      style={{ flexBasis: 0, flexGrow: 1, willChange: 'transform' }}
-      transform={{
-        active: 'shrinkSm',
-        ...(!mobile ? { hover: 'grow' } : {}),
-      }}
-      transition="default"
+      style={{ flexBasis: 0, flexGrow: 1 }}
+      type={!url ? 'button' : undefined}
     >
       <Box
-        alignItems="center"
-        display="flex"
-        flexDirection="column"
-        gap="2"
-        justifyContent="center"
+        {...urlProps}
+        background={{
+          base: 'profileAction',
+          ...(!mobile ? { hover: 'profileActionHover' } : {}),
+        }}
+        borderRadius="menuButton"
+        boxShadow="profileDetailsAction"
+        padding={mobile ? '8' : '10'}
+        style={{ willChange: 'transform' }}
+        transform={{
+          active: 'shrinkSm',
+          ...(!mobile ? { hover: 'grow' } : {}),
+        }}
+        transition="default"
       >
-        <Box color="modalText" height="max">
-          {icon}
-        </Box>
-        <Box>
-          <Text color="modalText" size={mobile ? '12' : '13'} weight="semibold">
-            {label}
-          </Text>
+        <Box
+          alignItems="center"
+          display="flex"
+          flexDirection="column"
+          gap="2"
+          justifyContent="center"
+        >
+          <Box color="modalText" height="max">
+            {icon}
+          </Box>
+          <Box>
+            <Text
+              color="modalText"
+              size={mobile ? '12' : '13'}
+              weight="semibold"
+            >
+              {label}
+            </Text>
+          </Box>
         </Box>
       </Box>
     </Box>

--- a/packages/rainbowkit/src/components/ProfileDetails/ProfileDetailsAction.tsx
+++ b/packages/rainbowkit/src/components/ProfileDetails/ProfileDetailsAction.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
+import { increaseHitAreaForHoverTransform } from '../../css/increaseHitAreaForHoverTransform.css';
 import { isMobile } from '../../utils/isMobile';
 import { Box } from '../Box/Box';
 import { Text } from '../Text/Text';
@@ -28,7 +28,7 @@ export function ProfileDetailsAction({
   return (
     <Box
       as={url ? 'a' : 'button'}
-      className={!mobile ? increaseHitAreaOnActive.grow : undefined}
+      className={!mobile ? increaseHitAreaForHoverTransform.grow : undefined}
       display="block"
       onClick={action}
       style={{ flexBasis: 0, flexGrow: 1 }}

--- a/packages/rainbowkit/src/components/ProfileDetails/ProfileDetailsAction.tsx
+++ b/packages/rainbowkit/src/components/ProfileDetails/ProfileDetailsAction.tsx
@@ -28,8 +28,9 @@ export function ProfileDetailsAction({
   return (
     <Box
       as={url ? 'a' : 'button'}
+      borderRadius="menuButton"
       className={!mobile ? increaseHitAreaForHoverTransform.grow : undefined}
-      display="block"
+      display="flex"
       onClick={action}
       style={{ flexBasis: 0, flexGrow: 1 }}
       type={!url ? 'button' : undefined}
@@ -49,6 +50,7 @@ export function ProfileDetailsAction({
           ...(!mobile ? { hover: 'grow' } : {}),
         }}
         transition="default"
+        width="full"
       >
         <Box
           alignItems="center"

--- a/packages/rainbowkit/src/components/Txs/TxItem.tsx
+++ b/packages/rainbowkit/src/components/Txs/TxItem.tsx
@@ -46,7 +46,6 @@ export function TxItem({ tx }: TxProps) {
   return (
     <>
       <Box
-        display="flex"
         {...(explorerLink
           ? {
               as: 'a',
@@ -57,6 +56,7 @@ export function TxItem({ tx }: TxProps) {
               target: '_blank',
             }
           : {})}
+        display="flex"
       >
         <Box
           {...(explorerLink

--- a/packages/rainbowkit/src/components/Txs/TxItem.tsx
+++ b/packages/rainbowkit/src/components/Txs/TxItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNetwork } from 'wagmi';
-import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
+import { increaseHitAreaForHoverTransform } from '../../css/increaseHitAreaForHoverTransform.css';
 import { Transaction } from '../../transactions/transactionStore';
 import { chainToExplorerUrl } from '../../utils/chainToExplorerUrl';
 import { isMobile } from '../../utils/isMobile';
@@ -49,7 +49,7 @@ export function TxItem({ tx }: TxProps) {
         {...(explorerLink
           ? {
               as: 'a',
-              className: increaseHitAreaOnActive.grow,
+              className: increaseHitAreaForHoverTransform.grow,
               href: `${explorerLink}/tx/${tx.hash}`,
               rel: 'noreferrer',
               target: '_blank',

--- a/packages/rainbowkit/src/components/Txs/TxItem.tsx
+++ b/packages/rainbowkit/src/components/Txs/TxItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useNetwork } from 'wagmi';
+import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
 import { Transaction } from '../../transactions/transactionStore';
 import { chainToExplorerUrl } from '../../utils/chainToExplorerUrl';
 import { isMobile } from '../../utils/isMobile';
@@ -48,68 +49,76 @@ export function TxItem({ tx }: TxProps) {
         {...(explorerLink
           ? {
               as: 'a',
-              background: { hover: 'profileForeground' },
-              borderRadius: 'menuButton',
+              className: increaseHitAreaOnActive.grow,
               href: `${explorerLink}/tx/${tx.hash}`,
               rel: 'noreferrer',
               target: '_blank',
-              transform: { active: 'shrink', hover: 'grow' },
-              transition: 'default',
             }
           : {})}
-        color="modalText"
-        display="flex"
-        flexDirection="row"
-        justifyContent="space-between"
-        padding="8"
       >
         <Box
-          alignItems="center"
+          {...(explorerLink
+            ? {
+                background: { hover: 'profileForeground' },
+                borderRadius: 'menuButton',
+                transform: { active: 'shrink', hover: 'grow' },
+                transition: 'default',
+              }
+            : {})}
+          color="modalText"
           display="flex"
           flexDirection="row"
-          gap={mobile ? '16' : '14'}
+          justifyContent="space-between"
+          padding="8"
         >
-          <Box color={color}>
-            <Icon />
-          </Box>
-          <Box display="flex" flexDirection="column" gap={mobile ? '4' : '2'}>
-            <Box>
-              <Text
-                color="modalText"
-                font="body"
-                size={mobile ? '16' : '14'}
-                weight="bold"
-              >
-                {tx?.description}
-              </Text>
+          <Box
+            alignItems="center"
+            display="flex"
+            flexDirection="row"
+            gap={mobile ? '16' : '14'}
+          >
+            <Box color={color}>
+              <Icon />
             </Box>
-            <Box>
-              <Text
-                color={tx.status === 'pending' ? 'modalTextSecondary' : color}
-                font="body"
-                size="14"
-                weight={mobile ? 'medium' : 'regular'}
-              >
-                {confirmationStatus}
-              </Text>
+            <Box display="flex" flexDirection="column" gap={mobile ? '4' : '2'}>
+              <Box>
+                <Text
+                  color="modalText"
+                  font="body"
+                  size={mobile ? '16' : '14'}
+                  weight="bold"
+                >
+                  {tx?.description}
+                </Text>
+              </Box>
+              <Box>
+                <Text
+                  color={tx.status === 'pending' ? 'modalTextSecondary' : color}
+                  font="body"
+                  size="14"
+                  weight={mobile ? 'medium' : 'regular'}
+                >
+                  {confirmationStatus}
+                </Text>
+              </Box>
             </Box>
           </Box>
+          {explorerLink && (
+            <Box alignItems="center" color="modalTextDim" display="flex">
+              <ExternalLinkIcon />
+            </Box>
+          )}
         </Box>
-        {explorerLink && (
-          <Box alignItems="center" color="modalTextDim" display="flex">
-            <ExternalLinkIcon />
-          </Box>
+        {mobile && (
+          <Box
+            background="generalBorderDim"
+            height="1"
+            marginLeft="44"
+            marginRight="8"
+            marginY="2"
+          />
         )}
       </Box>
-      {mobile && (
-        <Box
-          background="generalBorderDim"
-          height="1"
-          marginLeft="44"
-          marginRight="8"
-          marginY="2"
-        />
-      )}
     </>
   );
 }

--- a/packages/rainbowkit/src/components/Txs/TxItem.tsx
+++ b/packages/rainbowkit/src/components/Txs/TxItem.tsx
@@ -46,9 +46,11 @@ export function TxItem({ tx }: TxProps) {
   return (
     <>
       <Box
+        display="flex"
         {...(explorerLink
           ? {
               as: 'a',
+              borderRadius: 'menuButton',
               className: increaseHitAreaForHoverTransform.grow,
               href: `${explorerLink}/tx/${tx.hash}`,
               rel: 'noreferrer',
@@ -70,6 +72,7 @@ export function TxItem({ tx }: TxProps) {
           flexDirection="row"
           justifyContent="space-between"
           padding="8"
+          width="full"
         >
           <Box
             alignItems="center"

--- a/packages/rainbowkit/src/components/Txs/TxList.tsx
+++ b/packages/rainbowkit/src/components/Txs/TxList.tsx
@@ -63,7 +63,9 @@ export function TxList({ accountData }: TxListProps) {
               >
                 <Box
                   as="button"
+                  borderRadius="actionButton"
                   className={increaseHitAreaForHoverTransform.grow}
+                  display="flex"
                   onClick={clearRecentTransactions}
                   type="button"
                 >
@@ -123,8 +125,9 @@ export function TxList({ accountData }: TxListProps) {
         <Box paddingBottom="18" paddingX={mobile ? '8' : '18'}>
           <Box
             as="a"
+            borderRadius="menuButton"
             className={increaseHitAreaForHoverTransform.grow}
-            display="block"
+            display="flex"
             href={`${explorerLink}/address/${address}`}
             rel="noreferrer"
             target="_blank"
@@ -145,6 +148,7 @@ export function TxList({ accountData }: TxListProps) {
                 hover: 'grow',
               }}
               transition="default"
+              width="full"
               {...(mobile ? { paddingLeft: '12' } : {})}
             >
               <Text

--- a/packages/rainbowkit/src/components/Txs/TxList.tsx
+++ b/packages/rainbowkit/src/components/Txs/TxList.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { useAccount, useNetwork } from 'wagmi';
-import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
+import { increaseHitAreaForHoverTransform } from '../../css/increaseHitAreaForHoverTransform.css';
 import { useClearRecentTransactions } from '../../transactions/useClearRecentTransactions';
 import { useRecentTransactions } from '../../transactions/useRecentTransactions';
 import { chainToExplorerUrl } from '../../utils/chainToExplorerUrl';
@@ -63,7 +63,7 @@ export function TxList({ accountData }: TxListProps) {
               >
                 <Box
                   as="button"
-                  className={increaseHitAreaOnActive.grow}
+                  className={increaseHitAreaForHoverTransform.grow}
                   onClick={clearRecentTransactions}
                   type="button"
                 >
@@ -123,7 +123,7 @@ export function TxList({ accountData }: TxListProps) {
         <Box paddingBottom="18" paddingX={mobile ? '8' : '18'}>
           <Box
             as="a"
-            className={increaseHitAreaOnActive.grow}
+            className={increaseHitAreaForHoverTransform.grow}
             display="block"
             href={`${explorerLink}/address/${address}`}
             rel="noreferrer"

--- a/packages/rainbowkit/src/components/Txs/TxList.tsx
+++ b/packages/rainbowkit/src/components/Txs/TxList.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { useAccount, useNetwork } from 'wagmi';
+import { increaseHitAreaOnActive } from '../../css/increaseHitAreaOnActive.css';
 import { useClearRecentTransactions } from '../../transactions/useClearRecentTransactions';
 import { useRecentTransactions } from '../../transactions/useRecentTransactions';
 import { chainToExplorerUrl } from '../../utils/chainToExplorerUrl';
@@ -53,34 +54,41 @@ export function TxList({ accountData }: TxListProps) {
                 Recent Transactions
               </Text>
               <Box
-                as="button"
-                background={{
-                  hover: 'profileForeground',
-                }}
-                borderRadius="actionButton"
-                onClick={clearRecentTransactions}
-                padding="6"
-                paddingX="10"
                 style={{
                   marginBottom: -6,
                   marginLeft: -10,
                   marginRight: -10,
                   marginTop: -6,
                 }}
-                transform={{
-                  active: 'shrink',
-                  hover: 'grow',
-                }}
-                transition="default"
-                type="button"
               >
-                <Text
-                  color="modalTextSecondary"
-                  size={mobile ? '16' : '14'}
-                  weight="semibold"
+                <Box
+                  as="button"
+                  className={increaseHitAreaOnActive.grow}
+                  onClick={clearRecentTransactions}
+                  type="button"
                 >
-                  Clear All
-                </Text>
+                  <Box
+                    background={{
+                      hover: 'profileForeground',
+                    }}
+                    borderRadius="actionButton"
+                    padding="6"
+                    paddingX="10"
+                    transform={{
+                      active: 'shrink',
+                      hover: 'grow',
+                    }}
+                    transition="default"
+                  >
+                    <Text
+                      color="modalTextSecondary"
+                      size={mobile ? '16' : '14'}
+                      weight="semibold"
+                    >
+                      Clear All
+                    </Text>
+                  </Box>
+                </Box>
               </Box>
             </Box>
           </Box>
@@ -114,36 +122,41 @@ export function TxList({ accountData }: TxListProps) {
       {explorerLink && (
         <Box paddingBottom="18" paddingX={mobile ? '8' : '18'}>
           <Box
-            alignItems="center"
             as="a"
-            background={{ hover: 'profileForeground' }}
-            borderRadius="menuButton"
-            color="modalTextDim"
-            display="flex"
-            flexDirection="row"
+            className={increaseHitAreaOnActive.grow}
+            display="block"
             href={`${explorerLink}/address/${address}`}
-            justifyContent="space-between"
-            paddingX="8"
-            paddingY="12"
             rel="noreferrer"
-            style={{ willChange: 'transform' }}
             target="_blank"
-            transform={{
-              active: 'shrink',
-              hover: 'grow',
-            }}
-            transition="default"
-            {...(mobile ? { paddingLeft: '12' } : {})}
           >
-            <Text
-              color="modalText"
-              font="body"
-              size={mobile ? '16' : '14'}
-              weight={mobile ? 'semibold' : 'bold'}
+            <Box
+              alignItems="center"
+              background={{ hover: 'profileForeground' }}
+              borderRadius="menuButton"
+              color="modalTextDim"
+              display="flex"
+              flexDirection="row"
+              justifyContent="space-between"
+              paddingX="8"
+              paddingY="12"
+              style={{ willChange: 'transform' }}
+              transform={{
+                active: 'shrink',
+                hover: 'grow',
+              }}
+              transition="default"
+              {...(mobile ? { paddingLeft: '12' } : {})}
             >
-              View more on Explorer
-            </Text>
-            <ExternalLinkIcon />
+              <Text
+                color="modalText"
+                font="body"
+                size={mobile ? '16' : '14'}
+                weight={mobile ? 'semibold' : 'bold'}
+              >
+                View more on Explorer
+              </Text>
+              <ExternalLinkIcon />
+            </Box>
           </Box>
         </Box>
       )}

--- a/packages/rainbowkit/src/css/increaseHitAreaForHoverTransform.css.ts
+++ b/packages/rainbowkit/src/css/increaseHitAreaForHoverTransform.css.ts
@@ -18,7 +18,7 @@ const base = style({
   },
 });
 
-export const increaseHitAreaOnActive = styleVariants(
+export const increaseHitAreaForHoverTransform = styleVariants(
   growTransforms,
   transform => [base, { selectors: { [activePseudo]: { transform } } }]
 );

--- a/packages/rainbowkit/src/css/increaseHitAreaOnActive.css.ts
+++ b/packages/rainbowkit/src/css/increaseHitAreaOnActive.css.ts
@@ -1,0 +1,24 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+import { growTransforms } from './sprinkles.css';
+
+const activePseudo = '&:active::after';
+
+const base = style({
+  position: 'relative',
+  selectors: {
+    [activePseudo]: {
+      bottom: 0,
+      content: '""',
+      display: 'block',
+      left: 0,
+      position: 'absolute',
+      right: 0,
+      top: 0,
+    },
+  },
+});
+
+export const increaseHitAreaOnActive = styleVariants(
+  growTransforms,
+  transform => [base, { selectors: { [activePseudo]: { transform } } }]
+);

--- a/packages/rainbowkit/src/css/sprinkles.css.ts
+++ b/packages/rainbowkit/src/css/sprinkles.css.ts
@@ -116,6 +116,21 @@ const flexAlignment = ['flex-start', 'flex-end', 'center'] as const;
 
 const textAlignments = ['left', 'center', 'inherit'] as const;
 
+export const growTransforms = {
+  grow: 'scale(1.025)',
+  growLg: 'scale(1.1)',
+} as const;
+
+const shrinkTransforms = {
+  shrink: 'scale(0.95)',
+  shrinkSm: 'scale(0.9)',
+} as const;
+
+const transforms = {
+  ...growTransforms,
+  ...shrinkTransforms,
+} as const;
+
 const interactionProperties = defineProperties({
   conditions: {
     base: {},
@@ -124,12 +139,7 @@ const interactionProperties = defineProperties({
   },
   defaultCondition: 'base',
   properties: {
-    transform: {
-      grow: 'scale(1.025)',
-      growLg: 'scale(1.1)',
-      shrink: 'scale(0.95)',
-      shrinkSm: 'scale(0.9)',
-    },
+    transform: transforms,
     transition: {
       default: '0.125s ease',
     },


### PR DESCRIPTION
Fixes #317.

To fix the issue, all scale transforms are now applied to child elements of buttons/links rather than the interactive elements themselves. This ensures that hit areas remain consistent during transforms.

One additional case that needed to be handled is when elements become larger on hover, increasing their hit area. If the user moves their mouse to the edge of the enlarged hit area and then attempts to click, the click event isn't fired. To fix this case, this PR also introduces a set of CSS utils called `increaseHitAreaForHoverTransform` which has a class for each transform value, e.g. `increaseHitAreaForHoverTransform.grow`. This class is applied to the containing button/link element so its hit area becomes larger when it is active. This is done using an absolutely-positioned pseudo element that sits outside the bounds of the original hit area using the same scale as the nested element.

I resisted the urge to create an abstraction for this since it's not clear to me it would be an improvement, running the risk of obfuscating what's happening in the DOM. We may revisit this in the future.