### PR TITLE
chore: restrict pnpm to v6

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ It's never a fun experience to have your pull request declined after investing a
 
 ## Prerequisites
 
-This project uses [`pnpm`](https://pnpm.io) as a package manager.
+This project uses [`pnpm`](https://pnpm.io) version 6 as a package manager.
 
 ## Development environment
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
     "vitest": "^0.5.0",
     "wagmi": "^0.3.5"
   },
+  "engines": {
+    "pnpm": "<=6"
+  },
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"


### PR DESCRIPTION
Setting up the project for first time and I had `v7` globally installed and no dev scripts run. This will give useful error to someone to downgrade.

