### PR TITLE
bug: update `connectButtonTextError` color in `lightTheme`

### DIFF
--- a/packages/rainbowkit/src/themes/lightTheme.ts
+++ b/packages/rainbowkit/src/themes/lightTheme.ts
@@ -35,7 +35,7 @@ export const lightTheme = ({
     connectButtonInnerBackground:
       'linear-gradient(0deg, rgba(0, 0, 0, 0.03), rgba(0, 0, 0, 0.06))',
     connectButtonText: '#25292E',
-    connectButtonTextError: '#FFF',
+    connectButtonTextError: '#FF494A',
     connectionIndicator: '#30E000',
     error: '#FF494A',
     generalBorder: 'rgba(0, 0, 0, 0.06)',


### PR DESCRIPTION
resolves #400 

used the same hex color as used for `error` (L40)