### PR TITLE
Replace `WagmiProvider` for `WagmiConfig`

### DIFF
--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -14,7 +14,7 @@ import {
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import React, { useEffect, useState } from 'react';
-import { chain, createClient, WagmiProvider } from 'wagmi';
+import { chain, createClient, WagmiConfig } from 'wagmi';
 
 const alchemyId = '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC';
 
@@ -109,7 +109,7 @@ function App({ Component, pageProps }: AppProps) {
       <Head>
         <title>RainbowKit Example</title>
       </Head>
-      <WagmiProvider client={wagmiClient}>
+      <WagmiConfig client={wagmiClient}>
         <RainbowKitProvider
           appInfo={demoAppInfo}
           chains={chains}
@@ -290,7 +290,7 @@ function App({ Component, pageProps }: AppProps) {
             )}
           </div>
         </RainbowKitProvider>
-      </WagmiProvider>
+      </WagmiConfig>
     </>
   );
 }

--- a/packages/rainbowkit/CHANGELOG.md
+++ b/packages/rainbowkit/CHANGELOG.md
@@ -186,20 +186,20 @@
 
   `wagmi@0.3.x` has introduced breaking changes from `0.2.x` that you will need to be aware of when upgrading. [See the migration guide to `wagmi@0.3.x` here](https://wagmi.sh/docs/migrating-to-03).
 
-  In order to use `wagmi` with RainbowKit, you will now need to create a wagmi client that you will pass to `WagmiProvider` (instead of passing configuration directly).
+  In order to use `wagmi` with RainbowKit, you will now need to create a wagmi client that you will pass to `WagmiConfig` (instead of passing configuration directly).
 
   Before:
 
   ```tsx
-  import { WagmiProvider } from 'wagmi';
+  import { WagmiConfig } from 'wagmi';
 
   const App = () => {
     return (
-      <WagmiProvider autoConnect connectors={connectors} provider={provider}>
+      <WagmiConfig autoConnect connectors={connectors} provider={provider}>
         <RainbowKitProvider chains={chains}>
           <YourApp />
         </RainbowKitProvider>
-      </WagmiProvider>
+      </WagmiConfig>
     );
   };
   ```
@@ -207,7 +207,7 @@
   After:
 
   ```tsx
-  import { createClient, WagmiProvider } from 'wagmi';
+  import { createClient, WagmiConfig } from 'wagmi';
 
   const wagmiClient = createClient({
     autoConnect: true,
@@ -217,11 +217,11 @@
 
   const App = () => {
     return (
-      <WagmiProvider client={wagmiClient}>
+      <WagmiConfig client={wagmiClient}>
         <RainbowKitProvider chains={chains}>
           <YourApp />
         </RainbowKitProvider>
-      </WagmiProvider>
+      </WagmiConfig>
     );
   };
   ```
@@ -346,7 +346,7 @@
     Chain,
     getDefaultWallets,
   } from '@rainbow-me/rainbowkit';
-  import { createClient, WagmiProvider, chain } from 'wagmi';
+  import { createClient, WagmiConfig, chain } from 'wagmi';
   import { providers } from 'ethers';
 
   const infuraId = process.env.INFURA_ID;
@@ -382,11 +382,11 @@
 
   const App = () => {
     return (
-      <WagmiProvider client={wagmiClient}>
+      <WagmiConfig client={wagmiClient}>
         <RainbowKitProvider chains={chains}>
           <YourApp />
         </RainbowKitProvider>
-      </WagmiProvider>
+      </WagmiConfig>
     );
   };
   ```
@@ -401,7 +401,7 @@
     getDefaultWallets,
     RainbowKitProvider,
   } from '@rainbow-me/rainbowkit';
-  import { createClient, WagmiProvider, chain } from 'wagmi';
+  import { createClient, WagmiConfig, chain } from 'wagmi';
   import { providers } from 'ethers';
 
   const { chains, provider } = configureChains(
@@ -422,11 +422,11 @@
 
   const App = () => {
     return (
-      <WagmiProvider client={wagmiClient}>
+      <WagmiConfig client={wagmiClient}>
         <RainbowKitProvider chains={chains}>
           <YourApp />
         </RainbowKitProvider>
-      </WagmiProvider>
+      </WagmiConfig>
     );
   };
   ```
@@ -455,7 +455,7 @@
   - The `iconUrl` property now optionally accepts an async function that returns a string (`() => Promise<string>`). This is to support bundling lazy-loadable Base64 images in JavaScript when publishing to npm. All built-in chains are now using this feature to delay loading of images until after app hydration.
   - The `iconBackground` property has been added to improve the visual appearance of chain icons while loading.
 
-- 13fa857: `RainbowKitProvider` must now be nested inside `WagmiProvider` since it now makes use of wagmi hooks internally.
+- 13fa857: `RainbowKitProvider` must now be nested inside `WagmiConfig` since it now makes use of wagmi hooks internally.
 
 ## 0.0.2
 

--- a/site/components/Provider/Provider.tsx
+++ b/site/components/Provider/Provider.tsx
@@ -6,7 +6,7 @@ import {
   wallet,
 } from '@rainbow-me/rainbowkit';
 import React from 'react';
-import { chain, createClient, Provider as WagmiProvider } from 'wagmi';
+import { chain, createClient, Provider as WagmiConfig } from 'wagmi';
 
 const alchemyId = '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC';
 
@@ -40,5 +40,5 @@ const wagmiClient = createClient({
 });
 
 export function Provider({ children }) {
-  return <WagmiProvider client={wagmiClient}>{children}</WagmiProvider>;
+  return <WagmiConfig client={wagmiClient}>{children}</WagmiConfig>;
 }

--- a/site/data/docs/api-providers.mdx
+++ b/site/data/docs/api-providers.mdx
@@ -41,11 +41,11 @@ const wagmiClient = createClient({
 
 const App = () => {
   return (
-    <WagmiProvider client={wagmiClient}>
+    <WagmiConfig client={wagmiClient}>
       <RainbowKitProvider chains={chains}>
         <YourApp />
       </RainbowKitProvider>
-    </WagmiProvider>
+    </WagmiConfig>
   );
 };
 ```

--- a/site/data/docs/custom-chains.mdx
+++ b/site/data/docs/custom-chains.mdx
@@ -55,11 +55,11 @@ const wagmiClient = createClient({
 
 const App = () => {
   return (
-    <WagmiProvider client={wagmiClient}>
+    <WagmiConfig client={wagmiClient}>
       <RainbowKitProvider chains={chains}>
         <YourApp />
       </RainbowKitProvider>
-    </WagmiProvider>
+    </WagmiConfig>
   );
 };
 ```

--- a/site/data/docs/custom-wallet-list.mdx
+++ b/site/data/docs/custom-wallet-list.mdx
@@ -44,7 +44,7 @@ const connectors = connectorsForWallets([
 You can then pass your connectors to `wagmi`'s `createClient`.
 
 ```tsx line=1,4-99
-import { createClient, WagmiProvider } from 'wagmi';
+import { createClient, WagmiConfig } from 'wagmi';
 ...
 const connectors = connectorsForWallets([ /* ... */ ]);
 
@@ -53,11 +53,11 @@ const wagmiClient = createClient({
 });
 
 const App = () => (
-  <WagmiProvider client={wagmiClient}>
+  <WagmiConfig client={wagmiClient}>
     <RainbowKitProvider>
       {/* Your App */}
     </RainbowKitProvider>
-  </WagmiProvider>
+  </WagmiConfig>
 );
 ```
 

--- a/site/data/docs/installation.mdx
+++ b/site/data/docs/installation.mdx
@@ -30,7 +30,7 @@ import {
   getDefaultWallets,
   RainbowKitProvider,
 } from '@rainbow-me/rainbowkit';
-import { chain, createClient, WagmiProvider } from 'wagmi';
+import { chain, createClient, WagmiConfig } from 'wagmi';
 ```
 
 ### Configure
@@ -39,7 +39,7 @@ Configure your wallets, desired chains and generate the required connectors. You
 
 ```tsx line=3-99
 ...
-import { chain, createClient, WagmiProvider } from 'wagmi';
+import { chain, createClient, WagmiConfig } from 'wagmi';
 
 const { chains, provider } = configureChains(
   [chain.mainnet, chain.polygon, chain.optimism, chain.arbitrum],
@@ -63,16 +63,16 @@ const wagmiClient = createClient({
 
 ### Wrap providers
 
-Wrap your application with `RainbowKitProvider` and [`WagmiProvider`](https://wagmi-xyz.vercel.app/docs/provider).
+Wrap your application with `RainbowKitProvider` and [`WagmiConfig`](https://wagmi-xyz.vercel.app/docs/provider).
 
 ```tsx
 const App = () => {
   return (
-    <WagmiProvider client={wagmiClient}>
+    <WagmiConfig client={wagmiClient}>
       <RainbowKitProvider chains={chains}>
         <YourApp />
       </RainbowKitProvider>
-    </WagmiProvider>
+    </WagmiConfig>
   );
 };
 ```


### PR DESCRIPTION
## Description
After submitting #404, I decided to replace all the instances of `WagmiProvider`, but some of them are just naming and some others are inside the examples folder, which is using an older `wagmi` version, so this needs some business decisions that I'm not sure if I can take.

I'm opening the PR but I'm hoping to get feedback on some questions:

Is there any plan to bump `wagmi`?
If so, the docs update make sense, and if not, we may lock the version on the `pnpm` lock file

Also, if it's going to be kept as it is, then some notes regarding that people should use `WagmiConfig` instead for `wagmi` versions >0.4.0

Fixes #404