### PR TITLE
fix: 'jitter' caused by scrollbar of Dialog.

### DIFF
--- a/packages/rainbowkit/src/components/Dialog/Dialog.tsx
+++ b/packages/rainbowkit/src/components/Dialog/Dialog.tsx
@@ -29,7 +29,12 @@ export function Dialog({ children, onClose, open, titleId }: DialogProps) {
       open && event.key === 'Escape' && onClose();
 
     document.addEventListener('keydown', handleEscape);
-
+    /**
+     * Todo: update react-remove-scroll
+     * react-remove-scroll-bar issue temporary solution.
+     * https://github.com/theKashey/react-remove-scroll-bar/issues/31
+     */
+    document.body.style.paddingRight = open ? '0px' : '';
     return () => document.removeEventListener('keydown', handleEscape);
   }, [open, onClose]);
 


### PR DESCRIPTION
## Description 

This is [react-remove-scroll-bar](https://github.com/theKashey/react-remove-scroll-bar/issues/31#issue-1233809865)‘s issue, the page will be offset to the left due to the `paddingRight:15px` of the body when opening the dialog, this will give the user the feeling of page jitter. 

https://user-images.githubusercontent.com/37520667/169689287-7bf80d8d-bb2f-4d7d-882d-7e1fa39dd367.mov

## How

Set body padding-right 0 when opening Dialog.

## Test 

https://user-images.githubusercontent.com/37520667/169689304-f16d440b-b37e-45d5-960b-13f62724898a.mov



