### PR TITLE
fix: modal height moved due to scrollbox

### DIFF
--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.css.ts
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.css.ts
@@ -11,7 +11,7 @@ export const ScrollClassName = style([
     paddingX: '18',
   }),
   {
-    maxHeight: 464,
+    maxHeight: 454,
     overflowY: 'auto',
   },
 ]);


### PR DESCRIPTION
fix this extra spacing

<img width="769" alt="Screen Shot 2022-05-23 at 12 54 18 PM" src="https://user-images.githubusercontent.com/16931094/169870259-8a47e8df-42d8-4a39-a59d-599a11707ef9.png">
