### PR TITLE
chore: add dedicated dev:example and dev:site scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "postinstall": "husky install",
     "dev": "pnpm --recursive --parallel dev",
+    "dev:lib": "pnpm --filter @rainbow-me/rainbowkit dev",
+    "dev:example": "pnpm dev:lib & pnpm --filter example dev",
+    "dev:site": "pnpm dev:lib & pnpm --filter site dev",
     "start": "pnpm dev",
     "lint": "eslint . --ext=js,jsx,mjs,ts,cjs,tsx && pnpm format:check && pnpm --recursive typecheck",
     "lint:fix": "eslint . --ext=js,jsx,mjs,ts,cjs,tsx --fix && pnpm format:fix",


### PR DESCRIPTION
Since the `dev` script runs both the example app and the site, and the site is a lot heavier than the example app, these new scripts allow you to target the specific project you're working on.