### PR TITLE
chore: update release build script to ignore app templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clean": "rm -rf ./packages/rainbowkit/dist && rm -rf ./packages/rainbowkit/node_modules && rm -rf ./packages/create-rainbowkit/dist && pnpm install",
     "release": "pnpm release:verify-git && pnpm release:build && changeset publish",
     "release:verify-git": "git diff --exit-code && git rev-parse --abbrev-ref HEAD | grep \"main\"",
-    "release:build": "pnpm clean && pnpm lint && pnpm test && MINIFY_CSS=true pnpm --recursive build && cp README.md packages/rainbowkit/README.md",
+    "release:build": "pnpm clean && pnpm lint && pnpm test && MINIFY_CSS=true pnpm --recursive --parallel --filter \"!*-app\" build && cp README.md packages/rainbowkit/README.md",
     "release:test": "pnpm release:build && pnpm --filter example dev",
     "ci:example": "pnpm prepare --filter=@rainbow-me/rainbowkit && pnpm --filter=example build",
     "ci:site": "pnpm --filter=@rainbow-me/rainbowkit prepare && pnpm --filter=site build"


### PR DESCRIPTION
I updated the `build` script but forgot to update the `release:build` script.