### PR TITLE
fix: add missing chalk dependency to create-rainbowkit

### DIFF
--- a/.changeset/empty-moles-sort.md
+++ b/.changeset/empty-moles-sort.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/create-rainbowkit': patch
+---
+
+Add missing `chalk` dependency

--- a/packages/create-rainbowkit/package.json
+++ b/packages/create-rainbowkit/package.json
@@ -21,6 +21,7 @@
     "test": "pnpm test:build"
   },
   "dependencies": {
+    "chalk": "5.0.1",
     "commander": "9.2.0",
     "cpy": "9.0.1",
     "execa": "6.1.0",
@@ -31,8 +32,6 @@
   "devDependencies": {
     "@types/fs-extra": "9.0.13",
     "@types/prompts": "2.0.14",
-    "@types/validate-npm-package-name": "3.0.3",
-    "chalk": "5.0.1",
-    "prompts": "2.4.2"
+    "@types/validate-npm-package-name": "3.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,7 @@ importers:
       prompts: 2.4.2
       validate-npm-package-name: 4.0.0
     dependencies:
+      chalk: 5.0.1
       commander: 9.2.0
       cpy: 9.0.1
       execa: 6.1.0
@@ -104,7 +105,6 @@ importers:
       '@types/fs-extra': 9.0.13
       '@types/prompts': 2.0.14
       '@types/validate-npm-package-name': 3.0.3
-      chalk: 5.0.1
 
   packages/create-rainbowkit/generated-test-app:
     specifiers:
@@ -4976,7 +4976,6 @@ packages:
   /chalk/5.0.1:
     resolution: {integrity: sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: true
 
   /character-entities-html4/2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -8686,7 +8685,7 @@ packages:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   /minimalistic-crypto-utils/1.0.1:
-    resolution: {integrity: sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=}
+    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
   /minimatch/3.0.5:
     resolution: {integrity: sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==}


### PR DESCRIPTION
This was accidentally left in `devDependencies`, left over from an early experiment where I tried to bundle dependencies into the CLI.  Our `prompts` dependency was also duplicated between `dependencies` and `devDependencies`, so I cleaned that up too.