### PR TITLE
fix: exclude CHANGELOG.md when copying app templates

### DIFF
--- a/.changeset/ten-cheetahs-sit.md
+++ b/.changeset/ten-cheetahs-sit.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/create-rainbowkit': patch
+---
+
+Exclude `CHANGELOG.md` when copying app templates

--- a/packages/create-rainbowkit/src/cli.ts
+++ b/packages/create-rainbowkit/src/cli.ts
@@ -144,7 +144,7 @@ async function run() {
       )
     );
 
-    const ignore: string[] = ['node_modules', '.next'];
+    const ignore: string[] = ['node_modules', '.next', 'CHANGELOG.md'];
 
     await cpy(path.join(selectedTemplatePath, '**', '*'), targetPath, {
       filter: src => ignore.every(i => !src.path.includes(i)),


### PR DESCRIPTION
Changesets is about to start generating a changelog for the Next app template, so I'm pre-emptively excluding it from the files that are copied over when scaffolding a new app.