### PR TITLE
fix: ensure create-rainbowkit can be run within node_modules

### DIFF
--- a/.changeset/eight-jeans-yawn.md
+++ b/.changeset/eight-jeans-yawn.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/create-rainbowkit': patch
+---
+
+Ensure files are copied correctly when template source directory is nested within a path containing `node_modules`

--- a/packages/create-rainbowkit/src/cli.ts
+++ b/packages/create-rainbowkit/src/cli.ts
@@ -144,10 +144,14 @@ async function run() {
       )
     );
 
-    const ignore: string[] = ['node_modules', '.next', 'CHANGELOG.md'];
+    const ignoreList: string[] = ['node_modules', '.next', 'CHANGELOG.md'];
 
     await cpy(path.join(selectedTemplatePath, '**', '*'), targetPath, {
-      filter: src => ignore.every(i => !src.path.includes(i)),
+      filter: src =>
+        ignoreList.every(ignore => {
+          const relativePath = path.relative(selectedTemplatePath, src.path);
+          return !relativePath.includes(ignore);
+        }),
       rename: name => name.replace(/^_dot_/, '.'),
     });
 


### PR DESCRIPTION
When copying files we currently filter ignored files/folders like this: `!src.path.includes(i)`

The problem is that one of our ignored folders is `node_modules`, so when create-rainbowkit is downloaded and executed within a path containing `node_modules` (e.g. `.../node_modules/@rainbow-me/create-rainbowkit/...`) it results in _every_ file being ignored.

To fix this, we first get the path relative to the template source directory before checking for ignored file/folder names.