### PR TITLE
fix: add missing Node shebang to CLI

### DIFF
--- a/.changeset/loud-keys-scream.md
+++ b/.changeset/loud-keys-scream.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/create-rainbowkit': patch
+---
+
+Add missing Node shebang to CLI

--- a/packages/create-rainbowkit/src/cli.ts
+++ b/packages/create-rainbowkit/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { createRequire } from 'module';
 import path from 'path';
 import { fileURLToPath } from 'url';


### PR DESCRIPTION
pnpm seems to be forgiving about this, but this was causing issues with Yarn and npm. More details: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#bin