### PR TITLE
chore: upgrade @wagmi/core to ^0.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@typescript-eslint/parser": "^5.5.0",
     "@vanilla-extract/esbuild-plugin": "^2.0.0",
     "@vanilla-extract/vite-plugin": "^3.1.2",
-    "@wagmi/core": "^0.3.2",
+    "@wagmi/core": "^0.3.7",
     "autoprefixer": "^10.4.0",
     "esbuild": "^0.14.39",
     "eslint": "7.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
       '@typescript-eslint/parser': ^5.5.0
       '@vanilla-extract/esbuild-plugin': ^2.0.0
       '@vanilla-extract/vite-plugin': ^3.1.2
-      '@wagmi/core': ^0.3.2
+      '@wagmi/core': ^0.3.7
       autoprefixer: ^10.4.0
       esbuild: ^0.14.39
       eslint: 7.32.0
@@ -61,7 +61,7 @@ importers:
       '@typescript-eslint/parser': 5.11.0_r6wgjs2cmdapk4bysm6dglulo4
       '@vanilla-extract/esbuild-plugin': 2.0.2
       '@vanilla-extract/vite-plugin': 3.1.2
-      '@wagmi/core': 0.3.2_react@18.1.0
+      '@wagmi/core': 0.3.7_react@18.1.0
       autoprefixer: 10.4.2_postcss@8.4.6
       esbuild: 0.14.39
       eslint: 7.32.0
@@ -3555,7 +3555,7 @@ packages:
   /@types/bn.js/4.11.6:
     resolution: {integrity: sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==}
     dependencies:
-      '@types/node': 17.0.35
+      '@types/node': 17.0.41
     dev: true
 
   /@types/chai-subset/1.3.3:
@@ -3661,6 +3661,10 @@ packages:
 
   /@types/node/17.0.35:
     resolution: {integrity: sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==}
+    dev: true
+
+  /@types/node/17.0.41:
+    resolution: {integrity: sha512-xA6drNNeqb5YyV5fO3OAEsnXLfO7uF0whiOfPTz5AeDo8KeZFmODKnvwPymMNO8qE/an8pVY/O50tig2SQCrGw==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -4159,10 +4163,10 @@ packages:
       - supports-color
     dev: false
 
-  /@wagmi/core/0.3.2_react@18.1.0:
-    resolution: {integrity: sha512-BIOvGO3IL6DCunInhsGKh+MxeaFaizcRrr7IVsvf7zvVj9SaS3HjbW2DXwnyqXojtwA1RTMinRgkQZSL2r8DMA==}
+  /@wagmi/core/0.3.7_react@18.1.0:
+    resolution: {integrity: sha512-RJAaypcQK0OA/ezpgNz4Smk4rUUMf9IXapLR2PtDLUWjJxI2Xw5l+Pq4t6xOvJt6fNO1GKM0iRjUaUN37py0+w==}
     peerDependencies:
-      '@coinbase/wallet-sdk': '>=3.0.6'
+      '@coinbase/wallet-sdk': '>=3.2.0'
       '@walletconnect/ethereum-provider': '>=1.7.5'
       ethers: '>=5.5.1'
     peerDependenciesMeta:
@@ -4178,10 +4182,10 @@ packages:
       - react
     dev: true
 
-  /@wagmi/core/0.3.2_utolcgjyvhkw4h7cciuyjcki44:
-    resolution: {integrity: sha512-BIOvGO3IL6DCunInhsGKh+MxeaFaizcRrr7IVsvf7zvVj9SaS3HjbW2DXwnyqXojtwA1RTMinRgkQZSL2r8DMA==}
+  /@wagmi/core/0.3.7_utolcgjyvhkw4h7cciuyjcki44:
+    resolution: {integrity: sha512-RJAaypcQK0OA/ezpgNz4Smk4rUUMf9IXapLR2PtDLUWjJxI2Xw5l+Pq4t6xOvJt6fNO1GKM0iRjUaUN37py0+w==}
     peerDependencies:
-      '@coinbase/wallet-sdk': '>=3.0.6'
+      '@coinbase/wallet-sdk': '>=3.2.0'
       '@walletconnect/ethereum-provider': '>=1.7.5'
       ethers: '>=5.5.1'
     peerDependenciesMeta:
@@ -4977,6 +4981,7 @@ packages:
   /chalk/5.0.1:
     resolution: {integrity: sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: false
 
   /character-entities-html4/2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -11055,7 +11060,7 @@ packages:
       react: '>=17.0.0'
     dependencies:
       '@coinbase/wallet-sdk': 3.1.0_@babel+core@7.17.2
-      '@wagmi/core': 0.3.2_utolcgjyvhkw4h7cciuyjcki44
+      '@wagmi/core': 0.3.7_utolcgjyvhkw4h7cciuyjcki44
       '@walletconnect/ethereum-provider': 1.7.8
       react: 18.1.0
       react-query: 4.0.0-beta.12_ef5jwxihqo6n7gxfmzogljlgcm


### PR DESCRIPTION
### Context

The latest @wagmi/core version (0.3.7) allow specifying an ensAddress when you create a custom chain. To support that, I upgraded the package to the latest version.


Thanks for reviewing this 🙏