### PR TITLE
docs: ensure create-rainbowkit commands always get latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ RainbowKit is a [React](https://reactjs.org/) library that makes it easy to add 
 You can scaffold a new RainbowKit + [wagmi](https://wagmi.sh) + [Next.js](https://nextjs.org) app with one of the following commands, using your package manager of choice:
 
 ```bash
-npm init @rainbow-me/rainbowkit
+npm init @rainbow-me/rainbowkit@latest
 # or
-yarn create @rainbow-me/rainbowkit
+yarn create @rainbow-me/rainbowkit@latest
 # or
-pnpm create @rainbow-me/rainbowkit
+pnpm create @rainbow-me/rainbowkit@latest
 ```
 
 ## Documentation

--- a/packages/create-rainbowkit/README.md
+++ b/packages/create-rainbowkit/README.md
@@ -3,11 +3,11 @@
 Scaffold a new RainbowKit project.
 
 ```bash
-npm init @rainbow-me/rainbowkit
+npm init @rainbow-me/rainbowkit@latest
 # or
-yarn create @rainbow-me/rainbowkit
+yarn create @rainbow-me/rainbowkit@latest
 # or
-pnpm create @rainbow-me/rainbowkit
+pnpm create @rainbow-me/rainbowkit@latest
 ```
 
 ## License

--- a/site/data/docs/installation.mdx
+++ b/site/data/docs/installation.mdx
@@ -12,11 +12,11 @@ description: Get up and running with RainbowKit
 You can scaffold a new RainbowKit + [wagmi](https://wagmi.sh) + [Next.js](https://nextjs.org) app with one of the following commands, using your package manager of choice:
 
 ```bash
-npm init @rainbow-me/rainbowkit
+npm init @rainbow-me/rainbowkit@latest
 # or
-yarn create @rainbow-me/rainbowkit
+yarn create @rainbow-me/rainbowkit@latest
 # or
-pnpm create @rainbow-me/rainbowkit
+pnpm create @rainbow-me/rainbowkit@latest
 ```
 
 This will prompt you for a project name, generate a new directory containing a boilerplate project, and install all required dependencies.

--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -308,7 +308,7 @@ export default function Home() {
 
 function InstallScript() {
   const [requestCopy, setRequestCopy] = useState(false);
-  const code = 'npm init @rainbow-me/rainbowkit';
+  const code = 'npm init @rainbow-me/rainbowkit@latest';
   const ref = useCoolMode('/rainbow.svg') as Ref<HTMLButtonElement>;
 
   React.useEffect(() => {


### PR DESCRIPTION
These commands sometimes hang on to cached copies of create-rainbowkit that may be out of date, so this is a good way to ensure that the cache is never used when scaffolding a new app.