### PR TITLE
fix: use mainnet ENS for L2s

### DIFF
--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
@@ -30,6 +30,7 @@ import {
   useRainbowKitChainsById,
 } from '../RainbowKitProvider/RainbowKitChainContext';
 import { ShowRecentTransactionsContext } from '../RainbowKitProvider/ShowRecentTransactionsContext';
+import { chainMetadataByName } from '../RainbowKitProvider/provideRainbowKitChains';
 import { abbreviateETHBalance } from './abbreviateETHBalance';
 import { formatAddress } from './formatAddress';
 import { formatENS } from './formatENS';
@@ -82,9 +83,13 @@ export function ConnectButtonRenderer({
 
   const { data: ensAvatar } = useEnsAvatar({
     addressOrName: address,
+    chainId: chainMetadataByName.mainnet?.chainId,
   });
 
-  const { data: ensName } = useEnsName({ address });
+  const { data: ensName } = useEnsName({
+    address,
+    chainId: chainMetadataByName.mainnet?.chainId,
+  });
 
   const { data: balanceData } = useBalance({
     addressOrName: address,

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
@@ -30,7 +30,6 @@ import {
   useRainbowKitChainsById,
 } from '../RainbowKitProvider/RainbowKitChainContext';
 import { ShowRecentTransactionsContext } from '../RainbowKitProvider/ShowRecentTransactionsContext';
-import { chainMetadataByName } from '../RainbowKitProvider/provideRainbowKitChains';
 import { abbreviateETHBalance } from './abbreviateETHBalance';
 import { formatAddress } from './formatAddress';
 import { formatENS } from './formatENS';
@@ -83,12 +82,12 @@ export function ConnectButtonRenderer({
 
   const { data: ensAvatar } = useEnsAvatar({
     addressOrName: address,
-    chainId: chainMetadataByName.mainnet?.chainId,
+    chainId: 1,
   });
 
   const { data: ensName } = useEnsName({
     address,
-    chainId: chainMetadataByName.mainnet?.chainId,
+    chainId: 1,
   });
 
   const { data: balanceData } = useBalance({

--- a/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
@@ -59,7 +59,7 @@ const polygonIcon: IconMetadata = {
   iconUrl: async () => (await import('./chainIcons/polygon.svg')).default,
 };
 
-export const chainMetadataByName: Record<ChainName, ChainMetadata | null> = {
+const chainMetadataByName: Record<ChainName, ChainMetadata | null> = {
   arbitrum: { chainId: 42_161, ...arbitrumIcon },
   arbitrumRinkeby: { chainId: 421_611, ...arbitrumIcon },
   avalanche: { chainId: 43_114, ...avalancheIcon },

--- a/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
@@ -59,7 +59,7 @@ const polygonIcon: IconMetadata = {
   iconUrl: async () => (await import('./chainIcons/polygon.svg')).default,
 };
 
-const chainMetadataByName: Record<ChainName, ChainMetadata | null> = {
+export const chainMetadataByName: Record<ChainName, ChainMetadata | null> = {
   arbitrum: { chainId: 42_161, ...arbitrumIcon },
   arbitrumRinkeby: { chainId: 421_611, ...arbitrumIcon },
   avalanche: { chainId: 43_114, ...avalancheIcon },


### PR DESCRIPTION
christian noticed it was not ideal that when switching to an L2 your ENS information would go away. small fix to always pull ENS from mainnet throughout RK

<img width="520" alt="Screen Shot 2022-06-13 at 11 24 50 AM" src="https://user-images.githubusercontent.com/16931094/173391641-f15de290-c57e-4127-94da-392e2e0cf38c.png">
