### PR TITLE
fix: dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "postinstall": "husky install",
-    "dev": "pnpm --recursive --parallel --filter \"!*-app\" dev",
+    "dev": "pnpm dev:lib && pnpm dev:example",
     "dev:lib": "pnpm --filter @rainbow-me/rainbowkit dev",
     "dev:example": "pnpm dev:lib & pnpm --filter example dev",
     "dev:site": "pnpm dev:lib & pnpm --filter site dev",


### PR DESCRIPTION
Resolves RNBW-3848

The `dev` script was picking up all the packages in `/examples`. This PR updates the dev script to only start `dev:lib` and `dev:example`, which is the rainbowkit lib and the examples (kitchensink) app

