### PR TITLE
fix: dev script arg order for pnpm 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "postinstall": "husky install",
-    "dev": "pnpm --recursive dev --parallel --filter @rainbow-me/rainbowkit --filter example",
+    "dev": "pnpm --recursive --parallel --filter @rainbow-me/rainbowkit --filter example dev",
     "dev:lib": "pnpm --filter @rainbow-me/rainbowkit dev",
     "dev:example": "pnpm dev:lib & pnpm --filter example dev",
     "dev:site": "pnpm dev:lib & pnpm --filter site dev",


### PR DESCRIPTION
Evidently pnpm 7 needs the command to come last, otherwise it will pass in subsequent flags to the child processes. See [here](https://pnpm.io/cli/run#options):
> Any arguments after the command's name are added to the executed script.