### PR TITLE
fix: update rainbowkit examples url to monorepo repo

### DIFF
--- a/packages/create-rainbowkit/generated-test-app/pages/index.tsx
+++ b/packages/create-rainbowkit/generated-test-app/pages/index.tsx
@@ -40,7 +40,7 @@ const Home: NextPage = () => {
           </a>
 
           <a
-            href="https://github.com/rainbow-me/rainbowkit-examples"
+            href="https://github.com/rainbow-me/rainbowkit/tree/main/examples"
             className={styles.card}
           >
             <h2>RainbowKit Examples &rarr;</h2>

--- a/packages/create-rainbowkit/templates/next-app/pages/index.tsx
+++ b/packages/create-rainbowkit/templates/next-app/pages/index.tsx
@@ -40,7 +40,7 @@ const Home: NextPage = () => {
           </a>
 
           <a
-            href="https://github.com/rainbow-me/rainbowkit-examples"
+            href="https://github.com/rainbow-me/rainbowkit/tree/main/examples"
             className={styles.card}
           >
             <h2>RainbowKit Examples &rarr;</h2>

--- a/site/data/docs/installation.mdx
+++ b/site/data/docs/installation.mdx
@@ -127,7 +127,7 @@ For more detail, view the [wagmi documentation.](https://wagmi.sh)
 
 ### Further examples
 
-To see some running examples of RainbowKit, or even use them to automatically scaffold a new project, check out the official [rainbowkit-examples](https://github.com/rainbow-me/rainbowkit-examples) repository.
+To see some running examples of RainbowKit, or even use them to automatically scaffold a new project, check out the [official examples](https://github.com/rainbow-me/rainbowkit/tree/main/examples).
 
 To try RainbowKit directly in your browser, check out the CodeSandbox links below:
 


### PR DESCRIPTION
replacing URLs referencing the old [rainbowkit-examples](https://github.com/rainbow-me/rainbowkit-examples) repo to the examples folder of this repo.