### PR TITLE
fix: automatically connect to first configured chain

### DIFF
--- a/.changeset/small-guests-thank.md
+++ b/.changeset/small-guests-thank.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Automatically connect to the first chain in the `chains` array to avoid presenting the "Wrong network" state immediately after connecting

--- a/examples/with-create-react-app/package.json
+++ b/examples/with-create-react-app/package.json
@@ -16,7 +16,7 @@
     "react": "^18.1.0",
     "typescript": "^4.7.2",
     "util": "0.12.4",
-    "wagmi": "^0.4.2",
+    "wagmi": "^0.4.7",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/examples/with-next-custom-button/package.json
+++ b/examples/with-next-custom-button/package.json
@@ -14,7 +14,7 @@
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "wagmi": "^0.4.2"
+    "wagmi": "^0.4.7"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next-mint-nft/package.json
+++ b/examples/with-next-mint-nft/package.json
@@ -15,7 +15,7 @@
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "wagmi": "^0.4.2"
+    "wagmi": "^0.4.7"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next/package.json
+++ b/examples/with-next/package.json
@@ -14,7 +14,7 @@
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "wagmi": "^0.4.2"
+    "wagmi": "^0.4.7"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-remix/package.json
+++ b/examples/with-remix/package.json
@@ -16,7 +16,7 @@
     "ethers": "^5.0.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "wagmi": "^0.4.2"
+    "wagmi": "^0.4.7"
   },
   "devDependencies": {
     "@remix-run/dev": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@typescript-eslint/parser": "^5.5.0",
     "@vanilla-extract/esbuild-plugin": "^2.0.0",
     "@vanilla-extract/vite-plugin": "^3.1.2",
-    "@wagmi/core": "^0.3.2",
+    "@wagmi/core": "^0.3.6",
     "autoprefixer": "^10.4.0",
     "esbuild": "^0.14.39",
     "eslint": "7.32.0",
@@ -75,7 +75,7 @@
     "recursive-readdir-files": "^2.0.7",
     "typescript": "^4.7.2",
     "vitest": "^0.5.0",
-    "wagmi": "^0.4.2"
+    "wagmi": "^0.4.7"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/create-rainbowkit/generated-test-app/package.json
+++ b/packages/create-rainbowkit/generated-test-app/package.json
@@ -14,7 +14,7 @@
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "wagmi": "^0.4.2"
+    "wagmi": "^0.4.7"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/packages/create-rainbowkit/templates/next-app/package.json
+++ b/packages/create-rainbowkit/templates/next-app/package.json
@@ -14,7 +14,7 @@
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "wagmi": "^0.4.2"
+    "wagmi": "^0.4.7"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^18.1.0"
   },
   "peerDependencies": {
-    "wagmi": "^0.4.2"
+    "wagmi": "^0.4.7"
   },
   "scripts": {
     "dev": "next dev",

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -42,7 +42,7 @@
     "ethers": ">=5.5.1",
     "react": ">=17",
     "react-dom": ">=17",
-    "wagmi": "^0.4.2"
+    "wagmi": "^0.4.7"
   },
   "devDependencies": {
     "@ethersproject/abstract-provider": "^5.5.1",

--- a/packages/rainbowkit/src/wallets/useWalletConnectors.ts
+++ b/packages/rainbowkit/src/wallets/useWalletConnectors.ts
@@ -2,6 +2,7 @@ import { Connector, useConnect } from 'wagmi';
 import { flatten } from '../utils/flatten';
 import { indexBy } from '../utils/indexBy';
 import { isNotNullish } from '../utils/isNotNullish';
+import { useRainbowKitChains } from './../components/RainbowKitProvider/RainbowKitChainContext';
 import { WalletInstance } from './Wallet';
 import { addRecentWalletId, getRecentWalletIds } from './recentWalletIds';
 
@@ -14,7 +15,10 @@ export interface WalletConnector extends WalletInstance {
 }
 
 export function useWalletConnectors(): WalletConnector[] {
-  const { connectAsync, connectors: defaultConnectors } = useConnect();
+  const chains = useRainbowKitChains();
+  const { connectAsync, connectors: defaultConnectors } = useConnect({
+    chainId: chains[0]?.id,
+  });
 
   async function connectWallet(walletId: string, connector: Connector) {
     const result = await connectAsync(connector);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
       '@typescript-eslint/parser': ^5.5.0
       '@vanilla-extract/esbuild-plugin': ^2.0.0
       '@vanilla-extract/vite-plugin': ^3.1.2
-      '@wagmi/core': ^0.3.2
+      '@wagmi/core': ^0.3.6
       autoprefixer: ^10.4.0
       esbuild: ^0.14.39
       eslint: 7.32.0
@@ -42,7 +42,7 @@ importers:
       recursive-readdir-files: ^2.0.7
       typescript: ^4.7.2
       vitest: ^0.5.0
-      wagmi: ^0.4.2
+      wagmi: ^0.4.7
     devDependencies:
       '@babel/core': 7.17.2
       '@babel/preset-env': 7.16.11_@babel+core@7.17.2
@@ -61,7 +61,7 @@ importers:
       '@typescript-eslint/parser': 5.11.0_r6wgjs2cmdapk4bysm6dglulo4
       '@vanilla-extract/esbuild-plugin': 2.0.2
       '@vanilla-extract/vite-plugin': 3.1.2
-      '@wagmi/core': 0.3.2_react@18.1.0
+      '@wagmi/core': 0.3.7_react@18.1.0
       autoprefixer: 10.4.2_postcss@8.4.6
       esbuild: 0.14.39
       eslint: 7.32.0
@@ -6907,25 +6907,6 @@ packages:
       - supports-color
     dev: false
 
-  /@wagmi/core/0.3.2_react@18.1.0:
-    resolution: {integrity: sha512-BIOvGO3IL6DCunInhsGKh+MxeaFaizcRrr7IVsvf7zvVj9SaS3HjbW2DXwnyqXojtwA1RTMinRgkQZSL2r8DMA==}
-    peerDependencies:
-      '@coinbase/wallet-sdk': '>=3.0.6'
-      '@walletconnect/ethereum-provider': '>=1.7.5'
-      ethers: '>=5.5.1'
-    peerDependenciesMeta:
-      '@coinbase/wallet-sdk':
-        optional: true
-      '@walletconnect/ethereum-provider':
-        optional: true
-    dependencies:
-      eventemitter3: 4.0.7
-      zustand: 4.0.0-rc.1_react@18.1.0
-    transitivePeerDependencies:
-      - immer
-      - react
-    dev: true
-
   /@wagmi/core/0.3.7_mx7p5gtt35d53iysednsncjuw4:
     resolution: {integrity: sha512-RJAaypcQK0OA/ezpgNz4Smk4rUUMf9IXapLR2PtDLUWjJxI2Xw5l+Pq4t6xOvJt6fNO1GKM0iRjUaUN37py0+w==}
     peerDependencies:
@@ -6940,6 +6921,25 @@ packages:
     dependencies:
       '@coinbase/wallet-sdk': 3.2.0_@babel+core@7.17.2
       '@walletconnect/ethereum-provider': 1.7.8
+      eventemitter3: 4.0.7
+      zustand: 4.0.0-rc.1_react@18.1.0
+    transitivePeerDependencies:
+      - immer
+      - react
+    dev: true
+
+  /@wagmi/core/0.3.7_react@18.1.0:
+    resolution: {integrity: sha512-RJAaypcQK0OA/ezpgNz4Smk4rUUMf9IXapLR2PtDLUWjJxI2Xw5l+Pq4t6xOvJt6fNO1GKM0iRjUaUN37py0+w==}
+    peerDependencies:
+      '@coinbase/wallet-sdk': '>=3.2.0'
+      '@walletconnect/ethereum-provider': '>=1.7.5'
+      ethers: '>=5.5.1'
+    peerDependenciesMeta:
+      '@coinbase/wallet-sdk':
+        optional: true
+      '@walletconnect/ethereum-provider':
+        optional: true
+    dependencies:
       eventemitter3: 4.0.7
       zustand: 4.0.0-rc.1_react@18.1.0
     transitivePeerDependencies:
@@ -18776,7 +18776,7 @@ packages:
     dev: true
 
   /strict-uri-encode/2.0.0:
-    resolution: {integrity: sha1-ucczDHBChi9rFC3CdLvMWGbONUY=}
+    resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
     engines: {node: '>=4'}
     dev: true
 

--- a/site/package.json
+++ b/site/package.json
@@ -43,7 +43,7 @@
     "next-contentlayer": "0.2.2"
   },
   "peerDependencies": {
-    "wagmi": "^0.4.2"
+    "wagmi": "^0.4.7"
   },
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
No more "Wrong network" after connecting 🎉

wagmi now accepts a `chainId` option on its `useConnect` hook. Internally it will either connect to the specified chain if supported, or it will immediately switch chains after connecting if it's different to the specified chain.