### PR TITLE
fix: support WalletConnect Android deep linking after connecting

### DIFF
--- a/.changeset/spotty-weeks-impress.md
+++ b/.changeset/spotty-weeks-impress.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Support deep linking of wallet interactions for WalletConnect on Android

--- a/packages/rainbowkit/src/components/RainbowKitProvider/walletConnectDeepLink.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/walletConnectDeepLink.ts
@@ -7,7 +7,10 @@ export function setWalletConnectDeepLink({
   mobileUri: string;
   name: string;
 }) {
-  if (mobileUri.startsWith('http') && mobileUri.includes('?uri=')) {
+  if (
+    mobileUri.startsWith('wc:') || // Android
+    (mobileUri.startsWith('http') && mobileUri.includes('?uri=')) // iOS
+  ) {
     localStorage.setItem(
       storageKey,
       JSON.stringify({


### PR DESCRIPTION
This PR adds detection for `wc:` URIs when usng WalletConnect-based wallets on Android so that deep linking works when performing wallet interactions after connecting.

Fixes #387