### PR TITLE
fix: detect Trust Wallet in-app browser

### DIFF
--- a/.changeset/fifty-cameras-melt.md
+++ b/.changeset/fifty-cameras-melt.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Detect Trust Wallet in-app browser

--- a/packages/rainbowkit/src/wallets/walletConnectors/trust/trust.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trust/trust.ts
@@ -1,4 +1,5 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
+import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { isAndroid } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
@@ -6,9 +7,10 @@ import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface TrustOptions {
   chains: Chain[];
+  shimDisconnect?: boolean;
 }
 
-export const trust = ({ chains }: TrustOptions): Wallet => ({
+export const trust = ({ chains, shimDisconnect }: TrustOptions): Wallet => ({
   id: 'trust',
   name: 'Trust Wallet',
   iconUrl: async () => (await import('./trust.svg')).default,
@@ -20,6 +22,19 @@ export const trust = ({ chains }: TrustOptions): Wallet => ({
     qrCode: 'https://link.trustwallet.com',
   },
   createConnector: () => {
+    const inAppBrowser = Boolean(
+      typeof window !== 'undefined' && window.ethereum?.isTrust
+    );
+
+    if (inAppBrowser) {
+      return {
+        connector: new InjectedConnector({
+          chains,
+          options: { shimDisconnect },
+        }),
+      };
+    }
+
     const connector = getWalletConnectConnector({ chains });
 
     return {

--- a/site/data/docs/custom-wallet-list.mdx
+++ b/site/data/docs/custom-wallet-list.mdx
@@ -173,6 +173,7 @@ import { wallet } from '@rainbow-me/rainbowkit';
 
 wallet.trust(options: {
   chains: Chain[];
+  shimDisconnect?: boolean;
 });
 ```
 


### PR DESCRIPTION
When using the Trust Wallet in-app browser, the injected connector should be used instead of WalletConnect.