### PR TITLE
fix: update connect button styles to fix layout shift

### DIFF
--- a/.changeset/swift-houses-float.md
+++ b/.changeset/swift-houses-float.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Update connect button height to be consistent between states.

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -248,10 +248,10 @@ export function ConnectButton({
                 color="accentColorForeground"
                 fontFamily="body"
                 fontWeight="bold"
+                height="40"
                 key="connect"
                 onClick={openConnectModal}
                 paddingX="14"
-                paddingY="10"
                 transition="default"
                 type="button"
               >


### PR DESCRIPTION
Currently, the `ConnectButton`'s height in the disconnected state is about 1px shorter than the connected state's height (which is always fixed at 40px). This PR slightly modifies the connect button's styles to match the 40px height and fix the layout shift.

**Before**

Connecting and disconnecting shifts the text below:

![before-button](https://user-images.githubusercontent.com/17259768/175085479-e8538db0-de74-4b10-8307-f75f33a4d875.gif)

**After**

Set at 40px:

![after-button](https://user-images.githubusercontent.com/17259768/175085448-3246e6cb-ea4f-4199-b8d6-ca0313f9f60c.gif)



