### PR TITLE
chore: pin `wagmi` peer dependency to 0.4.x

### DIFF
--- a/.changeset/kind-apes-hear.md
+++ b/.changeset/kind-apes-hear.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Pinned the `wagmi` peer dependency to `0.4.x`

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -42,7 +42,7 @@
     "ethers": ">=5.5.1",
     "react": ">=17",
     "react-dom": ">=17",
-    "wagmi": "^0.4.7"
+    "wagmi": "0.4.x"
   },
   "devDependencies": {
     "@ethersproject/abstract-provider": "^5.5.1",


### PR DESCRIPTION
Pinning the `wagmi` peer dependency to 0.4.x to avoid consumers running into future breaking changes in `wagmi`.