### PR TITLE
fix: ensure "onConnecting" callbacks only fire once

### DIFF
--- a/.changeset/six-moose-think.md
+++ b/.changeset/six-moose-think.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Fix bug where "onConnecting" callbacks were fired multiple times when toggling between WalletConnect-based wallets

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -68,7 +68,16 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
     setSelectedOptionId(wallet.id);
 
     if (wallet.ready) {
+      // We need to guard against "onConnecting" callbacks being fired
+      // multiple times since connector instances can be shared between
+      // wallets. Ideally wagmi would let us scope the callback to the
+      // specific "connect" call, but this will work in the meantime.
+      let callbackFired = false;
+
       wallet?.onConnecting?.(async () => {
+        if (callbackFired) return;
+        callbackFired = true;
+
         const sWallet = wallets.find(w => wallet.id === w.id);
         const uri = await sWallet?.qrCode?.getUri();
         setQrCodeUri(uri);

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -43,7 +43,16 @@ function WalletButton({ wallet }: { wallet: WalletConnector }) {
       onClick={useCallback(async () => {
         connect?.();
 
+        // We need to guard against "onConnecting" callbacks being fired
+        // multiple times since connector instances can be shared between
+        // wallets. Ideally wagmi would let us scope the callback to the
+        // specific "connect" call, but this will work in the meantime.
+        let callbackFired = false;
+
         onConnecting?.(async () => {
+          if (callbackFired) return;
+          callbackFired = true;
+
           if (getMobileUri) {
             const mobileUri = await getMobileUri();
             setWalletConnectDeepLink({ mobileUri, name });


### PR DESCRIPTION
Since we're now sharing a connector instance between WalletConnect-based wallets, we need to guard against `onConnecting` callbacks being fired multiple times.