### PR TITLE
fix: ensure blank tab isn't left behind after connecting on iOS

### DIFF
--- a/.changeset/shaggy-doors-grab.md
+++ b/.changeset/shaggy-doors-grab.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Fix issue on iOS in non-Safari browsers and WebViews where a blank tab is left behind after connecting via WalletConnect

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -61,7 +61,7 @@ function WalletButton({ wallet }: { wallet: WalletConnector }) {
               // Workaround for https://github.com/rainbow-me/rainbowkit/issues/524.
               // Using 'window.open' causes issues on iOS in non-Safari browsers and
               // WebViews where a blank tab is left behind after connecting.
-              // This is especially bad in some WebView scenarios (i.e. following a
+              // This is especially bad in some WebView scenarios (e.g. following a
               // link from Twitter) where the user doesn't have any mechanism for
               // closing the blank tab.
               // For whatever reason, links with a target of "_blank" don't suffer

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -58,7 +58,20 @@ function WalletButton({ wallet }: { wallet: WalletConnector }) {
             setWalletConnectDeepLink({ mobileUri, name });
 
             if (mobileUri.startsWith('http')) {
-              window.open(mobileUri, '_blank', 'noreferrer,noopener');
+              // Workaround for https://github.com/rainbow-me/rainbowkit/issues/524.
+              // Using 'window.open' causes issues on iOS in non-Safari browsers and
+              // WebViews where a blank tab is left behind after connecting.
+              // This is especially bad in some WebView scenarios (i.e. following a
+              // link from Twitter) where the user doesn't have any mechanism for
+              // closing the blank tab.
+              // For whatever reason, links with a target of "_blank" don't suffer
+              // from this problem, and programmatically clicking a detached link
+              // element with the same attributes also avoids the issue.
+              const link = document.createElement('a');
+              link.href = mobileUri;
+              link.target = '_blank';
+              link.rel = 'noreferrer noopener';
+              link.click();
             } else {
               window.location.href = mobileUri;
             }


### PR DESCRIPTION
Fixes #524.

Using `window.open` causes issues on iOS in non-Safari browsers and WebViews where a blank tab is left behind after connecting. This is especially bad in some WebView scenarios (e.g. following a link from Twitter) where the user doesn't have any mechanism for closing the blank tab.

For whatever reason, links with a target of "_blank" don't suffer from this problem, and programmatically clicking a detached link element with the same attributes also avoids the issue.

I've reproduced this issue in the following iOS contexts and confirmed that this fixes it:
- Chrome
- Brave
- Firefox
- Twitter WebView (I sent a DM to myself to test)

I've also confirmed that Android still works as expected using Chrome, Brave and Twitter in-app browser.

Here's an example before/after in Chrome on iOS:

Before:

https://user-images.githubusercontent.com/696693/175839319-78b22ec6-9dba-44d4-bedf-a80a9068ffe5.mp4

After:

https://user-images.githubusercontent.com/696693/175839327-56fec81d-480b-42bb-a360-c25fece1b197.mp4

