### PR TITLE
fix: store WalletConnect deep link choice for custom URL schemes

### DIFF
--- a/.changeset/tame-humans-rhyme.md
+++ b/.changeset/tame-humans-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Fix WalletConnect deep linking for wallets with custom URL schemes

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -21,6 +21,7 @@ import * as styles from './MobileOptions.css';
 function WalletButton({ wallet }: { wallet: WalletConnector }) {
   const {
     connect,
+    connector,
     iconBackground,
     iconUrl,
     id,
@@ -55,7 +56,10 @@ function WalletButton({ wallet }: { wallet: WalletConnector }) {
 
           if (getMobileUri) {
             const mobileUri = await getMobileUri();
-            setWalletConnectDeepLink({ mobileUri, name });
+
+            if (connector.id === 'walletConnect') {
+              setWalletConnectDeepLink({ mobileUri, name });
+            }
 
             if (mobileUri.startsWith('http')) {
               // Workaround for https://github.com/rainbow-me/rainbowkit/issues/524.
@@ -77,7 +81,7 @@ function WalletButton({ wallet }: { wallet: WalletConnector }) {
             }
           }
         });
-      }, [connect, getMobileUri, onConnecting, name])}
+      }, [connector, connect, getMobileUri, onConnecting, name])}
       ref={coolModeRef}
       style={{ overflow: 'visible', textAlign: 'center' }}
       type="button"

--- a/packages/rainbowkit/src/components/RainbowKitProvider/walletConnectDeepLink.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/walletConnectDeepLink.ts
@@ -7,18 +7,13 @@ export function setWalletConnectDeepLink({
   mobileUri: string;
   name: string;
 }) {
-  if (
-    mobileUri.startsWith('wc:') || // Android
-    (mobileUri.startsWith('http') && mobileUri.includes('?uri=')) // iOS
-  ) {
-    localStorage.setItem(
-      storageKey,
-      JSON.stringify({
-        href: mobileUri.split('?')[0],
-        name,
-      })
-    );
-  }
+  localStorage.setItem(
+    storageKey,
+    JSON.stringify({
+      href: mobileUri.split('?')[0],
+      name,
+    })
+  );
 }
 
 export function clearWalletConnectDeepLink() {


### PR DESCRIPTION
Instead of trying to detect WalletConnect URLs by inspecting the string in isolation, we now check that the wallet's connector ID is `"walletConnect"`. This fixes an issue where custom URL schemes (e.g. `imtokenv2://wc?uri=...`) weren't being detected correctly.