### PR TITLE
docs: add codesandbox (stackblitz) link for vite in readme and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You can use the CodeSandbox links below try out RainbowKit:
 - with [Create React App](https://codesandbox.io/s/dn3rho)
 - with [Create React App (TypeScript)](https://codesandbox.io/s/ilfuoy)
 - with [Next.js](https://codesandbox.io/s/tmxcc0)
+- with [Vite](https://stackblitz.com/edit/rainbowkit-vite)
 
 ## Examples
 

--- a/site/data/docs/installation.mdx
+++ b/site/data/docs/installation.mdx
@@ -134,3 +134,4 @@ To try RainbowKit directly in your browser, check out the CodeSandbox links belo
 - with [Create React App](https://codesandbox.io/s/dn3rho)
 - with [Create React App](https://codesandbox.io/s/ilfuoy) (TypeScript)
 - with [Next.js](https://codesandbox.io/s/tmxcc0)
+- with [Vite](https://stackblitz.com/edit/rainbowkit-vite)


### PR DESCRIPTION
### Context
This PR adds a link to a [Stackblitz](https://stackblitz) container running a Vite project setup with Rainbowkit. The link has been added to the readme and the docs site where other Codesandbox links have been mentioned.

I literally couldn't find a Vite + TS template that works properly on Codesandbox so had to use Stackblitz 😅 