### PR TITLE
docs: rename migration guide page

### DIFF
--- a/site/data/docs/migration-guide.mdx
+++ b/site/data/docs/migration-guide.mdx
@@ -1,8 +1,8 @@
 ---
-title: Migrating to >=0.2
+title: Migration Guide
 ---
 
-# Migrating to >=0.2
+# Migration Guide
 
 ## Migrating RainbowKit
 

--- a/site/lib/docsRoutes.ts
+++ b/site/lib/docsRoutes.ts
@@ -13,7 +13,7 @@ export const docsRoutes: RouteProps[] = [
     label: 'Overview',
     pages: [
       { title: 'Introduction', slug: 'introduction' },
-      { title: 'Migrating to >=0.2', slug: 'migrating-to-02' },
+      { title: 'Migration Guide', slug: 'migration-guide' },
     ],
   },
 

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -16,6 +16,11 @@ const nextConfig = {
         destination: '/docs/introduction',
         permanent: false,
       },
+      {
+        source: '/docs/migrating-to-02',
+        destination: '/docs/migration-guide',
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
Now that we're at v0.4, it makes sense to rename the migration guide page from `Migrating to >=0.2` to `Migration Guide`.