### PR TITLE
ci: remove `typescript` from CodeQL config

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'typescript' ]
+        language: [ 'javascript' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 


### PR DESCRIPTION
Unnecessary, `javascript` also processes our TypeScript code. See slack convo and [related app PR](https://github.com/rainbow-me/rainbow/pull/3675).

Sounds like we can leave the cron too, which could catch updates to dependencies that happen in between PRs.