### PR TITLE
docs: add marketing video to intro page

### DIFF
--- a/site/components/MdxComponents/MdxComponents.tsx
+++ b/site/components/MdxComponents/MdxComponents.tsx
@@ -169,4 +169,16 @@ export const components = {
   },
   PropsTable: props => <PropsTable aria-label="Component Props" {...props} />,
   ul: props => <Box as="ul" marginBottom="5" paddingLeft="3" {...props} />,
+  Video: props => (
+    <Box
+      as="video"
+      autoPlay
+      controls
+      marginBottom="5"
+      muted
+      playsInline
+      style={{ display: 'block', width: '100%' }}
+      {...props}
+    />
+  ),
 };

--- a/site/data/docs/introduction.mdx
+++ b/site/data/docs/introduction.mdx
@@ -7,7 +7,7 @@ description: The best way to connect a wallet 🌈
 
 ## The best way to connect a wallet 🌈
 
-<Img src="/hero-docs.png" width="2916" height="1704" priority />
+<Video src="https://rainbowme-res.cloudinary.com/video/upload/v1657717102/rainbowkit/site-assets/rainbowkit-video-final-3_dehldu.mp4" />
 
 RainbowKit is a [React](https://reactjs.org/) library that makes it easy to add wallet connection to your dapp. It's intuitive, responsive and customizable.
 


### PR DESCRIPTION
I thought it would be a good idea to embed our RainbowKit video on the Introduction page, as that gives people a good visual overview of how RainbowKit works and how they can benefit from it.

Previously, we were using the same image we use on the homepage.

I uploaded the video to rainbow's cloudinary account, in a new folder called "rainbowkit"

