### PR TITLE
fix: ensure wallets aren't duplicated in connect modal after HMR

### DIFF
--- a/.changeset/bright-paws-tan.md
+++ b/.changeset/bright-paws-tan.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Fix duplicate wallets in connect modal after hot module reloading

--- a/packages/rainbowkit/src/wallets/connectorsForWallets.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.ts
@@ -46,15 +46,22 @@ export const connectorsForWallets = (walletList: WalletList) => {
           ...connectionMethods,
         };
 
-        // Mutate connector instance to add wallet instance
-        // @ts-expect-error
-        connector._wallets = connector._wallets ?? [];
-        // @ts-expect-error
-        connector._wallets.push(walletInstance);
-
         if (!connectors.includes(connector)) {
           connectors.push(connector);
+
+          // Reset private wallet list the first time we see
+          // a connector to avoid duplicates after HMR,
+          // otherwise we'll keep pushing wallets into
+          // the old list. This is happening because we're
+          // re-using the WalletConnectConnector instance
+          // so the wallet list already exists after HMR.
+          // @ts-expect-error
+          connector._wallets = [];
         }
+
+        // Add wallet to connector's list of associated wallets
+        // @ts-expect-error
+        connector._wallets.push(walletInstance);
       });
     });
 


### PR DESCRIPTION
When making changes to `_app.tsx` in the example app, it causes `connectorsForWallets` to re-run and add the same wallets to the existing `_wallets` array on the shared `WalletConnectConnector` instance. This fixes it by resetting the wallet list the first time we see a connector for each run.

<img width="786" alt="Screen Shot 2022-07-19 at 2 57 24 pm" src="https://user-images.githubusercontent.com/696693/179668280-1cb9ff8a-88b9-42fc-9a4c-a66e514def1c.png">
