### PR TITLE
chore: update wagmi peer dependency to include v0.6

### DIFF
--- a/.changeset/bright-mayflies-smell.md
+++ b/.changeset/bright-mayflies-smell.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Update wagmi peer dependency to include v0.6

--- a/.changeset/green-horses-kiss.md
+++ b/.changeset/green-horses-kiss.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/create-rainbowkit': patch
+---
+
+Update wagmi to v0.6

--- a/examples/with-create-react-app/package.json
+++ b/examples/with-create-react-app/package.json
@@ -16,7 +16,7 @@
     "react": "^18.1.0",
     "typescript": "^4.7.2",
     "util": "0.12.4",
-    "wagmi": "^0.5.3",
+    "wagmi": "^0.6.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/examples/with-create-react-app/src/index.tsx
+++ b/examples/with-create-react-app/src/index.tsx
@@ -21,7 +21,7 @@ const { chains, provider, webSocketProvider } = configureChains(
       : []),
   ],
   [
-    alchemyProvider({ alchemyId: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
+    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
     publicProvider(),
   ]
 );

--- a/examples/with-next-custom-button/package.json
+++ b/examples/with-next-custom-button/package.json
@@ -14,7 +14,7 @@
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "wagmi": "^0.5.3"
+    "wagmi": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next-custom-button/pages/_app.tsx
+++ b/examples/with-next-custom-button/pages/_app.tsx
@@ -22,7 +22,7 @@ const { chains, provider, webSocketProvider } = configureChains(
       : []),
   ],
   [
-    alchemyProvider({ alchemyId: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
+    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
     publicProvider(),
   ]
 );

--- a/examples/with-next-mint-nft/package.json
+++ b/examples/with-next-mint-nft/package.json
@@ -15,7 +15,7 @@
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "wagmi": "^0.5.3"
+    "wagmi": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next-mint-nft/pages/_app.tsx
+++ b/examples/with-next-mint-nft/pages/_app.tsx
@@ -19,7 +19,7 @@ const { chains, provider, webSocketProvider } = configureChains(
       : []),
   ],
   [
-    alchemyProvider({ alchemyId: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
+    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
     publicProvider(),
   ]
 );

--- a/examples/with-next-mint-nft/pages/index.tsx
+++ b/examples/with-next-mint-nft/pages/index.tsx
@@ -6,6 +6,7 @@ import {
   useAccount,
   useContractRead,
   useContractWrite,
+  usePrepareContractWrite,
   useWaitForTransaction,
 } from 'wagmi';
 import contractInterface from '../contract-abi.json';
@@ -20,13 +21,18 @@ const Home: NextPage = () => {
   const [totalMinted, setTotalMinted] = React.useState(0);
   const { isConnected } = useAccount();
 
+  const { config: contractWriteConfig } = usePrepareContractWrite({
+    ...contractConfig,
+    functionName: 'mint',
+  });
+
   const {
     data: mintData,
     write: mint,
     isLoading: isMintLoading,
     isSuccess: isMintStarted,
     error: mintError,
-  } = useContractWrite({ ...contractConfig, functionName: 'mint' });
+  } = useContractWrite(contractWriteConfig);
 
   const { data: totalSupplyData } = useContractRead({
     ...contractConfig,
@@ -34,7 +40,11 @@ const Home: NextPage = () => {
     watch: true,
   });
 
-  const { isSuccess: txSuccess, error: txError } = useWaitForTransaction({
+  const {
+    data: txData,
+    isSuccess: txSuccess,
+    error: txError,
+  } = useWaitForTransaction({
     hash: mintData?.hash,
   });
 
@@ -71,11 +81,11 @@ const Home: NextPage = () => {
             {isConnected && !isMinted && (
               <button
                 style={{ marginTop: 24 }}
-                disabled={isMintLoading || isMintStarted}
+                disabled={!mint || isMintLoading || isMintStarted}
                 className="button"
                 data-mint-loading={isMintLoading}
                 data-mint-started={isMintStarted}
-                onClick={() => mint()}
+                onClick={() => mint?.()}
               >
                 {isMintLoading && 'Waiting for approval'}
                 {isMintStarted && 'Minting...'}
@@ -120,7 +130,7 @@ const Home: NextPage = () => {
                 <p>
                   View on{' '}
                   <a
-                    href={`https://testnets.opensea.io/assets/rinkeby/${mintData?.to}/1`}
+                    href={`https://testnets.opensea.io/assets/rinkeby/${txData?.to}/1`}
                   >
                     Opensea
                   </a>

--- a/examples/with-next/package.json
+++ b/examples/with-next/package.json
@@ -14,7 +14,7 @@
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "wagmi": "^0.5.3"
+    "wagmi": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next/pages/_app.tsx
+++ b/examples/with-next/pages/_app.tsx
@@ -22,7 +22,7 @@ const { chains, provider, webSocketProvider } = configureChains(
       : []),
   ],
   [
-    alchemyProvider({ alchemyId: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
+    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
     publicProvider(),
   ]
 );

--- a/examples/with-remix/package.json
+++ b/examples/with-remix/package.json
@@ -16,7 +16,7 @@
     "ethers": "^5.0.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "wagmi": "^0.5.3"
+    "wagmi": "^0.6.0"
   },
   "devDependencies": {
     "@remix-run/dev": "^1.5.1",

--- a/examples/with-vite/package.json
+++ b/examples/with-vite/package.json
@@ -13,7 +13,7 @@
     "ethers": "^5.0.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "wagmi": "^0.5.3"
+    "wagmi": "^0.6.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.9",

--- a/examples/with-vite/src/main.tsx
+++ b/examples/with-vite/src/main.tsx
@@ -12,7 +12,7 @@ import App from './App';
 const { chains, provider } = configureChains(
   [chain.mainnet, chain.polygon, chain.optimism, chain.arbitrum],
   [
-    alchemyProvider({ alchemyId: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
+    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
     publicProvider(),
   ]
 );

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "recursive-readdir-files": "^2.0.7",
     "typescript": "^4.7.2",
     "vitest": "^0.5.0",
-    "wagmi": "^0.5.3"
+    "wagmi": "^0.6.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/create-rainbowkit/generated-test-app/package.json
+++ b/packages/create-rainbowkit/generated-test-app/package.json
@@ -14,7 +14,7 @@
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "wagmi": "^0.5.3"
+    "wagmi": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/packages/create-rainbowkit/generated-test-app/pages/_app.tsx
+++ b/packages/create-rainbowkit/generated-test-app/pages/_app.tsx
@@ -20,7 +20,7 @@ const { chains, provider, webSocketProvider } = configureChains(
     alchemyProvider({
       // This is Alchemy's default API key.
       // You can get your own at https://dashboard.alchemyapi.io
-      alchemyId: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC',
+      apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC',
     }),
     publicProvider(),
   ]

--- a/packages/create-rainbowkit/templates/next-app/package.json
+++ b/packages/create-rainbowkit/templates/next-app/package.json
@@ -14,7 +14,7 @@
     "next": "^12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "wagmi": "^0.5.3"
+    "wagmi": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/packages/create-rainbowkit/templates/next-app/pages/_app.tsx
+++ b/packages/create-rainbowkit/templates/next-app/pages/_app.tsx
@@ -20,7 +20,7 @@ const { chains, provider, webSocketProvider } = configureChains(
     alchemyProvider({
       // This is Alchemy's default API key.
       // You can get your own at https://dashboard.alchemyapi.io
-      alchemyId: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC',
+      apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC',
     }),
     publicProvider(),
   ]

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^18.1.0"
   },
   "peerDependencies": {
-    "wagmi": "^0.5.3"
+    "wagmi": "^0.6.0"
   },
   "scripts": {
     "dev": "next dev",

--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -19,7 +19,6 @@ import { chain, configureChains, createClient, WagmiConfig } from 'wagmi';
 import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 
-const alchemyId = '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC';
 const RAINBOW_TERMS = 'https://rainbow.me/terms-of-use';
 
 const avalancheChain: Chain = {
@@ -52,7 +51,10 @@ const { chains, provider, webSocketProvider } = configureChains(
       ? [chain.goerli, chain.kovan, chain.rinkeby, chain.ropsten]
       : []),
   ],
-  [alchemyProvider({ alchemyId }), publicProvider()]
+  [
+    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
+    publicProvider(),
+  ]
 );
 
 const { wallets } = getDefaultWallets({

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -10,6 +10,7 @@ import React, { ComponentProps, useEffect, useState } from 'react';
 import {
   useAccount,
   useNetwork,
+  usePrepareSendTransaction,
   useSendTransaction,
   useSignMessage,
   useSignTypedData,
@@ -47,16 +48,18 @@ const Example = () => {
 
   const { chain: activeChain } = useNetwork();
 
-  const {
-    data: transactionData,
-    error: transactionError,
-    sendTransaction,
-  } = useSendTransaction({
+  const { config: sendTransactionConfig } = usePrepareSendTransaction({
     request: {
       to: address,
       value: 0,
     },
   });
+
+  const {
+    data: transactionData,
+    error: transactionError,
+    sendTransaction,
+  } = useSendTransaction(sendTransactionConfig);
 
   const {
     data: signingData,
@@ -254,8 +257,8 @@ const Example = () => {
             </h3>
             <div style={{ display: 'flex', gap: 12, paddingBottom: 12 }}>
               <button
-                disabled={!isConnected}
-                onClick={() => sendTransaction()}
+                disabled={!isConnected && !sendTransaction}
+                onClick={() => sendTransaction?.()}
                 type="button"
               >
                 Send Transaction

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -42,7 +42,7 @@
     "ethers": ">=5.5.1",
     "react": ">=17",
     "react-dom": ">=17",
-    "wagmi": "0.5.x"
+    "wagmi": "0.5.x || 0.6.x"
   },
   "devDependencies": {
     "@ethersproject/abstract-provider": "^5.5.1",

--- a/packages/rainbowkit/src/wallets/useWalletConnectors.ts
+++ b/packages/rainbowkit/src/wallets/useWalletConnectors.ts
@@ -16,9 +16,11 @@ export interface WalletConnector extends WalletInstance {
 
 export function useWalletConnectors(): WalletConnector[] {
   const intialChainId = useInitialChainId();
-  const { connectAsync, connectors: defaultConnectors } = useConnect({
+  const { connectAsync, connectors: defaultConnectors_untyped } = useConnect({
     chainId: intialChainId,
   });
+
+  const defaultConnectors = defaultConnectors_untyped as Connector[];
 
   async function connectWallet(walletId: string, connector: Connector) {
     const result = await connectAsync({ connector });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
       recursive-readdir-files: ^2.0.7
       typescript: ^4.7.2
       vitest: ^0.5.0
-      wagmi: ^0.5.3
+      wagmi: ^0.6.0
     devDependencies:
       '@babel/core': 7.17.2
       '@babel/preset-env': 7.16.11_@babel+core@7.17.2
@@ -79,7 +79,7 @@ importers:
       recursive-readdir-files: 2.0.7
       typescript: 4.7.2
       vitest: 0.5.0
-      wagmi: 0.5.3_2ysdzk2vllwi7dl6z45r5ylxcu
+      wagmi: 0.6.0_2ysdzk2vllwi7dl6z45r5ylxcu
 
   examples/with-create-react-app:
     specifiers:
@@ -7037,27 +7037,6 @@ packages:
       - supports-color
     dev: true
 
-  /@wagmi/core/0.4.2_7zlxuwwdmng4gpy3cw52h3fypy:
-    resolution: {integrity: sha512-fd9niO/Wwr6MhaNeIjgHP3ToULAWKQ8neITgU7gAN5Q4uxbizKM8e6+i4EiffTKyaqvauMHa32Xz5zY7N+WAKA==}
-    peerDependencies:
-      '@coinbase/wallet-sdk': '>=3.3.0'
-      '@walletconnect/ethereum-provider': '>=1.7.5'
-      ethers: '>=5.5.1'
-    peerDependenciesMeta:
-      '@coinbase/wallet-sdk':
-        optional: true
-      '@walletconnect/ethereum-provider':
-        optional: true
-    dependencies:
-      '@coinbase/wallet-sdk': 3.3.0_@babel+core@7.17.2
-      '@walletconnect/ethereum-provider': 1.7.8
-      eventemitter3: 4.0.7
-      zustand: 4.0.0-rc.1_react@18.1.0
-    transitivePeerDependencies:
-      - immer
-      - react
-    dev: true
-
   /@wagmi/core/0.4.2_react@18.1.0:
     resolution: {integrity: sha512-fd9niO/Wwr6MhaNeIjgHP3ToULAWKQ8neITgU7gAN5Q4uxbizKM8e6+i4EiffTKyaqvauMHa32Xz5zY7N+WAKA==}
     peerDependencies:
@@ -7070,6 +7049,27 @@ packages:
       '@walletconnect/ethereum-provider':
         optional: true
     dependencies:
+      eventemitter3: 4.0.7
+      zustand: 4.0.0-rc.1_react@18.1.0
+    transitivePeerDependencies:
+      - immer
+      - react
+    dev: true
+
+  /@wagmi/core/0.5.0_7zlxuwwdmng4gpy3cw52h3fypy:
+    resolution: {integrity: sha512-bh4cI7WaBDtEM8E7KPCLnK5PfmBPg5iIUydTw5DTX2yo6BiRhcFIflRn/Bg9IJCFq3SGhW6Zmpu+jHHeH9ZELQ==}
+    peerDependencies:
+      '@coinbase/wallet-sdk': '>=3.3.0'
+      '@walletconnect/ethereum-provider': '>=1.7.5'
+      ethers: '>=5.5.1'
+    peerDependenciesMeta:
+      '@coinbase/wallet-sdk':
+        optional: true
+      '@walletconnect/ethereum-provider':
+        optional: true
+    dependencies:
+      '@coinbase/wallet-sdk': 3.3.0_@babel+core@7.17.2
+      '@walletconnect/ethereum-provider': 1.7.8
       eventemitter3: 4.0.7
       zustand: 4.0.0-rc.1_react@18.1.0
     transitivePeerDependencies:
@@ -17514,7 +17514,7 @@ packages:
       match-sorter: 6.3.1
       react: 18.1.0
       react-dom: 18.1.0_react@18.1.0
-      use-sync-external-store: 1.1.0_react@18.1.0
+      use-sync-external-store: 1.2.0_react@18.1.0
     dev: true
 
   /react-query/4.0.0-beta.5_ef5jwxihqo6n7gxfmzogljlgcm:
@@ -19973,6 +19973,14 @@ packages:
       react: 18.1.0
     dev: true
 
+  /use-sync-external-store/1.2.0_react@18.1.0:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.1.0
+    dev: true
+
   /use/3.1.1:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}
     engines: {node: '>=0.10.0'}
@@ -20173,18 +20181,18 @@ packages:
       xml-name-validator: 3.0.0
     dev: false
 
-  /wagmi/0.5.3_2ysdzk2vllwi7dl6z45r5ylxcu:
-    resolution: {integrity: sha512-KPdN58GQhIBe/ciyxeKtJxkHFa81Ag33I5NHm3c7YWa12rrEci8esjmOn4TOfnn/9/hKgFEYtmYDt/P7pB04Lg==}
+  /wagmi/0.6.0_2ysdzk2vllwi7dl6z45r5ylxcu:
+    resolution: {integrity: sha512-Jyj22eQNoNcs9DoLDhD+foF5skEc7XPAZjqZ7GK+rVzxWVlA6Vx+qrcAALNGnxayE6H+CYVKWGtTK8PPN/WHOw==}
     peerDependencies:
       ethers: '>=5.5.1'
       react: '>=17.0.0'
     dependencies:
       '@coinbase/wallet-sdk': 3.3.0_@babel+core@7.17.2
-      '@wagmi/core': 0.4.2_7zlxuwwdmng4gpy3cw52h3fypy
+      '@wagmi/core': 0.5.0_7zlxuwwdmng4gpy3cw52h3fypy
       '@walletconnect/ethereum-provider': 1.7.8
       react: 18.1.0
       react-query: 4.0.0-beta.23_ef5jwxihqo6n7gxfmzogljlgcm
-      use-sync-external-store: 1.1.0_react@18.1.0
+      use-sync-external-store: 1.2.0_react@18.1.0
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil

--- a/site/components/Provider/Provider.tsx
+++ b/site/components/Provider/Provider.tsx
@@ -8,11 +8,12 @@ import { chain, configureChains, createClient, WagmiConfig } from 'wagmi';
 import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 
-const alchemyId = '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC';
-
 export const { chains, provider } = configureChains(
   [chain.mainnet, chain.polygon, chain.optimism, chain.arbitrum],
-  [alchemyProvider({ alchemyId }), publicProvider()]
+  [
+    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
+    publicProvider(),
+  ]
 );
 
 const { wallets } = getDefaultWallets({

--- a/site/package.json
+++ b/site/package.json
@@ -43,7 +43,7 @@
     "next-contentlayer": "0.2.2"
   },
   "peerDependencies": {
-    "wagmi": "^0.5.3"
+    "wagmi": "^0.6.0"
   },
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
None of the breaking changes in wagmi v0.6 affect RainbowKit internals so I've marked this as a patch release and updated the peer dependency range from `0.5.x` to `0.5.x || 0.6.x`. I've also updated the version of wagmi shipped with our create-rainbowkit template.

All of the wagmi code migrations in this PR are from example apps and don't impact consumers.