### PR TITLE
docs: update `alchemyId` to `apiKey` to adhere to the new wagmi API

### DIFF
--- a/site/data/docs/chains.mdx
+++ b/site/data/docs/chains.mdx
@@ -38,7 +38,7 @@ import { publicProvider } from 'wagmi/providers/public';
 const { chains } = configureChains(
   [chain.mainnet, chain.polygon],
   [
-    alchemyProvider({ alchemyId: process.env.ALCHEMY_ID }),
+    alchemyProvider({ apiKey: process.env.ALCHEMY_ID }),
     publicProvider(),
   ]
 );
@@ -85,7 +85,7 @@ const defaultChains: Chain[] = [
 ];
 
 const { chains } = configureChains(defaultChains, [
-  alchemyProvider({ alchemyId: process.env.ALCHEMY_ID }),
+  alchemyProvider({ apiKey: process.env.ALCHEMY_ID }),
   publicProvider(),
 ]);
 ```

--- a/site/data/docs/custom-wallet-list.mdx
+++ b/site/data/docs/custom-wallet-list.mdx
@@ -22,7 +22,7 @@ import { publicProvider } from 'wagmi/providers/public';
 const { chains } = configureChains(
   [chain.mainnet],
   [
-    alchemyProvider({ alchemyId: process.env.ALCHEMY_ID }),
+    alchemyProvider({ apiKey: process.env.ALCHEMY_ID }),
     publicProvider(),
   ]
 );

--- a/site/data/docs/installation.mdx
+++ b/site/data/docs/installation.mdx
@@ -66,7 +66,7 @@ import { publicProvider } from 'wagmi/providers/public';
 const { chains, provider } = configureChains(
   [chain.mainnet, chain.polygon, chain.optimism, chain.arbitrum],
   [
-    alchemyProvider({ alchemyId: process.env.ALCHEMY_ID }),
+    alchemyProvider({ apiKey: process.env.ALCHEMY_ID }),
     publicProvider()
   ]
 );


### PR DESCRIPTION
Noticed while trying to follow the installation docs that you need to provide an `apiKey` instead of an `alchemyId` in the `configureChains` method now. Updated this in your installation docs.