### PR TITLE
fix: disable react-remove-scroll when body overflow is hidden

### DIFF
--- a/.changeset/lucky-taxis-poke.md
+++ b/.changeset/lucky-taxis-poke.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Fix error caused by attempting to prevent page scrolling when the body element's overflow is set to hidden.

--- a/packages/rainbowkit/src/components/Dialog/Dialog.tsx
+++ b/packages/rainbowkit/src/components/Dialog/Dialog.tsx
@@ -3,6 +3,7 @@ import React, {
   ReactNode,
   useCallback,
   useEffect,
+  useState,
 } from 'react';
 import { createPortal } from 'react-dom';
 import { RemoveScroll } from 'react-remove-scroll';
@@ -33,14 +34,22 @@ export function Dialog({ children, onClose, open, titleId }: DialogProps) {
     return () => document.removeEventListener('keydown', handleEscape);
   }, [open, onClose]);
 
+  const [bodyScrollable, setBodyScrollable] = useState(true);
+  useEffect(() => {
+    setBodyScrollable(
+      getComputedStyle(window.document.body).overflow !== 'hidden'
+    );
+  }, []);
+
   const handleBackdropClick = useCallback(() => onClose(), [onClose]);
   const themeRootProps = useThemeRootProps();
   const mobile = isMobile();
+
   return (
     <>
       {open
         ? createPortal(
-            <RemoveScroll>
+            <RemoveScroll enabled={bodyScrollable}>
               <Box {...themeRootProps}>
                 <Box
                   {...themeRootProps}


### PR DESCRIPTION
Fixes #632.