### PR TITLE
fix: support filtering provider chains

### DIFF
--- a/.changeset/lemon-lemons-yawn.md
+++ b/.changeset/lemon-lemons-yawn.md
@@ -1,0 +1,25 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Support filtering chains before passing them to `RainbowKitProvider`.
+
+This is particularly useful if you're building an L2-only project and you want mainnet to be available for resolving ENS details but you don't want it to be listed in the chain selector.
+
+**Example usage**
+
+This example uses Polygon while supporting ENS from mainnet.
+
+```tsx
+const {
+  chains: [, ...chains], // Omit first chain (mainnet), get the rest
+  provider,
+  webSocketProvider,
+} = configureChains(
+  [chain.mainnet, chain.polygon],
+  [
+    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
+    publicProvider(),
+  ]
+);
+```

--- a/packages/rainbowkit/src/hooks/useMainnet.ts
+++ b/packages/rainbowkit/src/hooks/useMainnet.ts
@@ -1,13 +1,17 @@
-import { chain } from 'wagmi';
-import { useRainbowKitChains } from '../components/RainbowKitProvider/RainbowKitChainContext';
+import { Chain, useProvider, chain as wagmiChains } from 'wagmi';
 
 export function useMainnet() {
-  const rainbowKitChains = useRainbowKitChains();
+  const chainId = wagmiChains.mainnet.id;
 
-  const chainId = chain.mainnet.id;
-  const enabled = rainbowKitChains.some(
-    rainbowKitChain => rainbowKitChain.id === chainId
-  );
+  // Because the generic for 'useProvider' is defaulting to 'unknown'
+  // and the return type is being resolved as 'any', we're having to
+  // manually define the Provider type, so this code is more defensive
+  // than necessary in case the manual typing is ever incorrect.
+  // If we're unable to resolve a list of chains, or the chains are
+  // an invalid type, we'll silently bail out.
+  const provider = useProvider<{ chains?: Chain[] }>();
+  const chains = Array.isArray(provider.chains) ? provider.chains : [];
+  const enabled = chains?.some(chain => chain?.id === chainId);
 
   return { chainId, enabled };
 }


### PR DESCRIPTION
Fixes #631.

The main use case for this is to let you configure mainnet for ENS while excluding it from the list of chains available to users when building an L2-only project.

This currently isn't possible because we're using the `chains` prop on `RainbowKitProvider` as the source of truth for whether mainnet has been configured. If you omit mainnet from the chains array passed to RainbowKit then we assume mainnet hasn't been configured in wagmi and bail out on trying to resolve ENS details.

Instead, this PR uses the wagmi provider as the source of truth, getting the list of chains from the provider via the `useProvider` Hook. This allows the list of chains presented in the UI to differ from the chains available to wagmi under the hood.

cc @tmm @jxom I came up with a pretty terse way to manage this without an API change to wagmi, but you still might want to have a look.