### PR TITLE
fix: avoid chain switch on connect if already on supported chain

### DIFF
--- a/.changeset/serious-eagles-poke.md
+++ b/.changeset/serious-eagles-poke.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Avoid switching chains after connecting if the user's wallet is already on a supported chain

--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -295,8 +295,8 @@ function App({ Component, pageProps }: AppProps) {
                           >
                             {[undefined, ...chains].map(chain => (
                               <option
-                                key={chain?.id ?? 'default'}
-                                value={chain?.id ?? 'default'}
+                                key={chain?.id ?? ''}
+                                value={chain?.id ?? ''}
                               >
                                 {chain?.name ?? 'Default'}
                               </option>

--- a/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitChainContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitChainContext.tsx
@@ -38,9 +38,7 @@ export function RainbowKitChainProvider({
         () => ({
           chains: provideRainbowKitChains(chains),
           initialChainId:
-            typeof initialChain === 'number'
-              ? initialChain
-              : initialChain?.id ?? chains[0]?.id,
+            typeof initialChain === 'number' ? initialChain : initialChain?.id,
         }),
         [chains, initialChain]
       )}


### PR DESCRIPTION
Thanks @jxom for showing me the (currently undocumented) `connector.getChainId()` API which makes this possible 🙏