### PR TITLE
Allow internal column scrolling on shorter screens

### DIFF
--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -182,7 +182,11 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
   }
 
   return (
-    <Box display="flex" flexDirection="row" style={{ maxHeight: 504 }}>
+    <Box
+      display="flex"
+      flexDirection="row"
+      style={{ maxHeight: '100vh', overflowY: 'auto' }}
+    >
       <Box
         className={sidebar}
         display="flex"
@@ -287,16 +291,16 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
               <CloseButton onClose={onClose} />
             </Box>
             <Box
+              className={ScrollClassName}
               display="flex"
               flexDirection="column"
-              style={{ minHeight: 432 }}
+              marginTop="16"
             >
               <Box
                 alignItems="center"
                 display="flex"
                 flexDirection="column"
                 gap="6"
-                height="full"
                 justifyContent="center"
                 marginX="8"
               >


### PR DESCRIPTION
Minor css rework to allow the connect modal internals to scroll when the screen is shorter than the fixed modal height.

Before (clipping off-screen):
<img width="1281" alt="Screen Shot 2022-08-16 at 2 36 28 pm" src="https://user-images.githubusercontent.com/10325/184798854-46cf1891-a9ae-4641-993f-3fbb3cd2869d.png">

After (internal column scrolling):
<img width="1371" alt="Screen Shot 2022-08-16 at 2 41 35 pm" src="https://user-images.githubusercontent.com/10325/184799319-b505319e-b394-49da-bcd1-0a7c8244855b.png">

https://user-images.githubusercontent.com/10325/184798611-9b42b40e-e2cf-41e5-acc4-b694e95dcd47.mov


