### PR TITLE
chore: change rainbowkit-siwe-next-auth version to 0.1.0

### DIFF
--- a/packages/rainbowkit-siwe-next-auth/CHANGELOG.md
+++ b/packages/rainbowkit-siwe-next-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @rainbow-me/rainbowkit-siwe-next-auth
 
-## 1.0.0
+## 0.1.0
 ### Minor Changes
 
 - 737a1d6: Initial release.

--- a/packages/rainbowkit-siwe-next-auth/package.json
+++ b/packages/rainbowkit-siwe-next-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainbow-me/rainbowkit-siwe-next-auth",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "RainbowKit authentication adapter for Sign-In with Ethereum and NextAuth.js",
   "files": [
     "dist"


### PR DESCRIPTION
Just noticed Changesets wanted to publish as v1 even though it was marked as minor. This PR manually drops the version, after which it should publish as v0.1.0.