### PR TITLE
chore: add rainbowkit-siwe-next-auth to publishing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -146,16 +146,26 @@ git push --tags
 
 Once you’ve pushed the tag, you can create a new release on GitHub.
 
-- If you published `rainbowkit`:
-  - Go to [GitHub’s new release form.](https://github.com/rainbow-me/rainbowkit/releases/new)
-  - Select the latest version tag for `@rainbow-me/rainbowkit`.
-  - Set the title to `@rainbow-me/rainbowkit@x.x.x` (substituting the latest version)
-  - Copy the Markdown content below the latest version heading from [RainbowKit’s `CHANGELOG.md`](../packages/rainbowkit/CHANGELOG.md)
-- If you published `create-rainbowkit`:
-  - Go to [GitHub’s new release form.](https://github.com/rainbow-me/rainbowkit/releases/new)
-  - Select the latest version tag for `@rainbow-me/create-rainbowkit`.
-  - Set the title to `@rainbow-me/create-rainbowkit@x.x.x` (substituting the latest version)
-  - Copy the Markdown content below the latest version heading from [create-rainbowkit’s `CHANGELOG.md`](../packages/create-rainbowkit/CHANGELOG.md)
+#### If you published `rainbowkit`:
+
+- Go to [GitHub’s new release form.](https://github.com/rainbow-me/rainbowkit/releases/new)
+- Select the latest version tag for `@rainbow-me/rainbowkit`.
+- Set the title to `@rainbow-me/rainbowkit@x.x.x` (substituting the latest version)
+- Copy the Markdown content below the latest version heading from [RainbowKit’s `CHANGELOG.md`](../packages/rainbowkit/CHANGELOG.md)
+
+#### If you published `rainbowkit-siwe-next-auth`:
+
+- Go to [GitHub’s new release form.](https://github.com/rainbow-me/rainbowkit/releases/new)
+- Select the latest version tag for `@rainbow-me/rainbowkit-siwe-next-auth`.
+- Set the title to `@rainbow-me/rainbowkit-siwe-next-auth@x.x.x` (substituting the latest version)
+- Copy the Markdown content below the latest version heading from [rainbowkit-siwe-next-auth’s `CHANGELOG.md`](../packages/rainbowkit-siwe-next-auth/CHANGELOG.md)
+
+#### If you published `create-rainbowkit`:
+
+- Go to [GitHub’s new release form.](https://github.com/rainbow-me/rainbowkit/releases/new)
+- Select the latest version tag for `@rainbow-me/create-rainbowkit`.
+- Set the title to `@rainbow-me/create-rainbowkit@x.x.x` (substituting the latest version)
+- Copy the Markdown content below the latest version heading from [create-rainbowkit’s `CHANGELOG.md`](../packages/create-rainbowkit/CHANGELOG.md)
 
 If at any stage you’re unsure of the formatting, you can [reference past RainbowKit releases.](https://github.com/rainbow-me/rainbowkit/releases)
 


### PR DESCRIPTION
I realised this was missing when I went to publish and it made it a lot trickier, so I'm adding this now for next time.