### PR TITLE
Remove Avalanche from list of supported wagmi chains

### DIFF
--- a/site/data/docs/chains.mdx
+++ b/site/data/docs/chains.mdx
@@ -24,8 +24,6 @@ RainbowKit is designed to integrate with [wagmi’s `chain` object](https://wagm
 - `chain.polygonMumbai`
 - `chain.arbitrum`
 - `chain.arbitrumRinkeby`
-- `chain.avalanche`
-- `chain.avalancheFuji`
 - `chain.localhost`
 - `chain.hardhat`
 


### PR DESCRIPTION
Avalanche and Avalanche Fuji were removed from wagmi in version `0.3.0`.

This PR is to update the public facing documentation for RainbowKit to delist Avalanche and testnet from supported wagmi chains.