### PR TITLE
chore(changesets): only update peers when out of range

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }


### PR DESCRIPTION
I've noticed that we're inadvertently publishing a new version of `rainbowkit-siwe-next-auth` whenever `rainbowkit` changes, even though it still satisfies the same version range.

Hopefully this super secret Changesets config option does the trick, borrowed from [vanilla-extract's Changesets config](https://github.com/seek-oss/vanilla-extract/blob/master/.changeset/config.json) 🙏