### PR TITLE
chore: avoid workspace protocol for peer dependencies

### DIFF
--- a/packages/rainbowkit-siwe-next-auth/package.json
+++ b/packages/rainbowkit-siwe-next-auth/package.json
@@ -29,7 +29,7 @@
   "author": "Rainbow",
   "license": "MIT",
   "peerDependencies": {
-    "@rainbow-me/rainbowkit": "workspace:^",
+    "@rainbow-me/rainbowkit": "^0.5.0",
     "next-auth": "^4.10.2",
     "react": ">=17",
     "siwe": "^1.1.6"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+prefer-workspace-packages: true
 packages:
   - 'packages/*'
   - 'packages/create-rainbowkit/**/*-app'


### PR DESCRIPTION
This change is following on from https://github.com/rainbow-me/rainbowkit/pull/744, trying to avoid releasing `rainbowkit-siwe-next-auth` when it's not necessary.