### PR TITLE
feat: automatically hide Injected Wallet option

### DIFF
--- a/.changeset/angry-clocks-compete.md
+++ b/.changeset/angry-clocks-compete.md
@@ -1,0 +1,64 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Automatically hide "Injected Wallet" option if another injected wallet in the list is available
+
+**Migration guide**
+
+Previously we provided instructions for manually calculating whether the "Injected Wallet" option should be visible.
+
+```ts
+const needsInjectedWalletFallback =
+  typeof window !== 'undefined' &&
+  window.ethereum &&
+  !window.ethereum.isMetaMask &&
+  !window.ethereum.isCoinbaseWallet;
+
+const connectors = connectorsForWallets([
+  {
+    groupName: 'Suggested',
+    wallets: [
+      wallet.rainbow({ chains }),
+      wallet.metaMask({ chains }),
+      wallet.coinbase({ appName: 'My RainbowKit App', chains }),
+      wallet.metaMask({ chains }),
+      ...(needsInjectedWalletFallback ? [wallet.injected({ chains })] : []),
+    ],
+  },
+]);
+```
+
+This manual logic should no longer be needed since it's now handled automatically, meaning that the previous example could be simplified in the following way.
+
+```ts
+const connectors = connectorsForWallets([
+  {
+    groupName: 'Suggested',
+    wallets: [
+      wallet.rainbow({ chains }),
+      wallet.metaMask({ chains }),
+      wallet.coinbase({ appName: 'My RainbowKit App', chains }),
+      wallet.metaMask({ chains }),
+      wallet.injected({ chains }),
+    ],
+  },
+]);
+```
+
+In addition, since the "Injected Wallet" option is only rendered when necessary based on the end user's browser environment, it's recommended that you place it at the start of the list to ensure it's visible.
+
+```ts
+const connectors = connectorsForWallets([
+  {
+    groupName: 'Suggested',
+    wallets: [
+      wallet.injected({ chains }),
+      wallet.rainbow({ chains }),
+      wallet.metaMask({ chains }),
+      wallet.coinbase({ appName: 'My RainbowKit App', chains }),
+      wallet.metaMask({ chains }),
+    ],
+  },
+]);
+```

--- a/.changeset/hot-papayas-rhyme.md
+++ b/.changeset/hot-papayas-rhyme.md
@@ -1,0 +1,7 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Move the "Injected Wallet" fallback option to the start of the default wallet list when present
+
+This option is only presented when an injected wallet is available that isn't handled by another wallet in the list, which means that it's the option most likely to be selected by the end user. As a result, we now give it the highest priority in the list returned from `getDefaultWallets`.

--- a/.changeset/khaki-falcons-look.md
+++ b/.changeset/khaki-falcons-look.md
@@ -1,0 +1,26 @@
+---
+'@rainbow-me/rainbowkit': minor
+---
+
+Allow custom wallets to automatically hide themselves based on the availability of other wallets in the list. This can be achieved via the new optional `hidden` function on the `Wallet` type.
+
+**Example usage**
+
+This is an example of a custom wallet that hides itself if another injected connector is available.
+
+```ts
+import type Wallet from '@rainbow-me/rainbowkit';
+import { InjectedConnector } from 'wagmi/connectors/injected';
+
+const myCustomWallet: Wallet = {
+  hidden: ({ wallets }) => {
+    return wallets.some(
+      wallet =>
+        wallet.installed &&
+        (wallet.connector instanceof InjectedConnector ||
+          wallet.id === 'coinbase')
+    );
+  },
+  ...etc,
+};
+```

--- a/.changeset/tough-trainers-jog.md
+++ b/.changeset/tough-trainers-jog.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': minor
+---
+
+Add `installed` property to `wallet.coinbase` to support detecting whether Coinbase Wallet SDK's injected connector is available

--- a/.changeset/witty-shirts-return.md
+++ b/.changeset/witty-shirts-return.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Ensure TokenPocket is not detected as MetaMask

--- a/packages/rainbowkit/src/wallets/Wallet.ts
+++ b/packages/rainbowkit/src/wallets/Wallet.ts
@@ -45,12 +45,19 @@ export type Wallet<C extends Connector = Connector> = {
     browserExtension?: string;
     qrCode?: string;
   };
+  hidden?: (args: {
+    wallets: {
+      id: string;
+      connector: Connector;
+      installed?: boolean;
+    }[];
+  }) => boolean;
   createConnector: () => RainbowKitConnector<C>;
 };
 
 export type WalletList = { groupName: string; wallets: Wallet[] }[];
 
-export type WalletInstance = Omit<Wallet, 'createConnector'> &
+export type WalletInstance = Omit<Wallet, 'createConnector' | 'hidden'> &
   ReturnType<Wallet['createConnector']> & {
     index: number;
     groupName: string;

--- a/packages/rainbowkit/src/wallets/connectorsForWallets.test.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+import { chain, Connector } from 'wagmi';
+import { InjectedConnector } from 'wagmi/connectors/injected';
+import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import { connectorsForWallets, wallet } from '..';
+import { WalletInstance } from './Wallet';
+
+const getWalletInstances = (
+  connector: Connector & { _wallets?: WalletInstance[] }
+) => {
+  if (!connector._wallets) {
+    throw new Error('Wallet instances not found on connector');
+  }
+
+  return connector._wallets;
+};
+
+describe('connectorsForWallets', () => {
+  describe('injected fallback', () => {
+    it('includes injected fallback if no wallets using InjectedConnector were provided', () => {
+      const chains = [chain.mainnet];
+      const connectors = connectorsForWallets([
+        {
+          groupName: 'Test Group 1',
+          wallets: [
+            {
+              createConnector: () => ({
+                connector: new WalletConnectConnector({ chains, options: {} }),
+              }),
+              iconBackground: '#fff',
+              iconUrl: '/test.png',
+              id: 'test-walletconnect-wallet',
+              name: 'Test WalletConnect Wallet',
+            },
+            wallet.injected({ chains }),
+          ],
+        },
+      ])();
+
+      expect(connectors.length).toBe(2);
+
+      expect(getWalletInstances(connectors[0]).length).toBe(1);
+      expect(getWalletInstances(connectors[0])[0].index).toBe(0);
+      expect(getWalletInstances(connectors[0])[0].name).toBe(
+        'Test WalletConnect Wallet'
+      );
+
+      expect(getWalletInstances(connectors[1]).length).toBe(1);
+      expect(getWalletInstances(connectors[1])[0].index).toBe(1);
+      expect(getWalletInstances(connectors[1])[0].name).toBe('Injected Wallet');
+    });
+
+    it('includes injected fallback if no wallets using InjectedConnector are installed', () => {
+      const chains = [chain.mainnet];
+      const connectors = connectorsForWallets([
+        {
+          groupName: 'Test Group 1',
+          wallets: [
+            {
+              createConnector: () => ({
+                connector: new InjectedConnector(),
+              }),
+              iconBackground: '#fff',
+              iconUrl: '/test.png',
+              id: 'test-not-installed-wallet',
+              installed: false,
+              name: 'Test Not Installed Wallet',
+            },
+            {
+              createConnector: () => ({
+                connector: new WalletConnectConnector({ chains, options: {} }),
+              }),
+              iconBackground: '#fff',
+              iconUrl: '/test.png',
+              id: 'test-walletconnect-wallet',
+              name: 'Test WalletConnect Wallet',
+            },
+            wallet.injected({ chains }),
+          ],
+        },
+      ])();
+
+      expect(connectors.length).toBe(3);
+
+      expect(getWalletInstances(connectors[0]).length).toBe(1);
+      expect(getWalletInstances(connectors[0])[0].index).toBe(0);
+      expect(getWalletInstances(connectors[0])[0].name).toBe(
+        'Test Not Installed Wallet'
+      );
+
+      expect(getWalletInstances(connectors[1]).length).toBe(1);
+      expect(getWalletInstances(connectors[1])[0].index).toBe(1);
+      expect(getWalletInstances(connectors[1])[0].name).toBe(
+        'Test WalletConnect Wallet'
+      );
+
+      expect(getWalletInstances(connectors[2]).length).toBe(1);
+      expect(getWalletInstances(connectors[2])[0].index).toBe(2);
+      expect(getWalletInstances(connectors[2])[0].name).toBe('Injected Wallet');
+    });
+
+    it('includes injected fallback in the same order it was defined if no wallets using InjectedConnector are installed', () => {
+      const chains = [chain.mainnet];
+      const connectors = connectorsForWallets([
+        {
+          groupName: 'Test Group 1',
+          wallets: [
+            wallet.injected({ chains }),
+            {
+              createConnector: () => ({
+                connector: new InjectedConnector(),
+              }),
+              iconBackground: '#fff',
+              iconUrl: '/test.png',
+              id: 'test-not-installed-wallet',
+              installed: false,
+              name: 'Test Not Installed Wallet',
+            },
+          ],
+        },
+        {
+          groupName: 'Test Group 2',
+          wallets: [
+            {
+              createConnector: () => ({
+                connector: new WalletConnectConnector({ chains, options: {} }),
+              }),
+              iconBackground: '#fff',
+              iconUrl: '/test.png',
+              id: 'test-walletconnect-wallet',
+              name: 'Test WalletConnect Wallet',
+            },
+          ],
+        },
+      ])();
+
+      expect(connectors.length).toBe(3);
+
+      expect(getWalletInstances(connectors[0]).length).toBe(1);
+      expect(getWalletInstances(connectors[0])[0].index).toBe(1);
+      expect(getWalletInstances(connectors[0])[0].name).toBe(
+        'Test Not Installed Wallet'
+      );
+      expect(getWalletInstances(connectors[0])[0].groupName).toBe(
+        'Test Group 1'
+      );
+
+      expect(getWalletInstances(connectors[1]).length).toBe(1);
+      expect(getWalletInstances(connectors[1])[0].index).toBe(2);
+      expect(getWalletInstances(connectors[1])[0].name).toBe(
+        'Test WalletConnect Wallet'
+      );
+      expect(getWalletInstances(connectors[1])[0].groupName).toBe(
+        'Test Group 2'
+      );
+
+      expect(getWalletInstances(connectors[2]).length).toBe(1);
+      expect(getWalletInstances(connectors[2])[0].index).toBe(0); // Note this is now first in the list
+      expect(getWalletInstances(connectors[2])[0].name).toBe('Injected Wallet');
+      expect(getWalletInstances(connectors[2])[0].groupName).toBe(
+        'Test Group 1'
+      );
+    });
+
+    it('excludes injected fallback if another wallet using InjectedConnector is installed', () => {
+      const chains = [chain.mainnet];
+      const connectors = connectorsForWallets([
+        {
+          groupName: 'Test Group 1',
+          wallets: [
+            {
+              createConnector: () => ({
+                connector: new InjectedConnector(),
+              }),
+              iconBackground: '#fff',
+              iconUrl: '/test.png',
+              id: 'test-wallet-installed',
+              installed: true,
+              name: 'Test Wallet Installed',
+            },
+          ],
+        },
+        {
+          groupName: 'Test Group 2',
+          wallets: [
+            wallet.injected({ chains }),
+            {
+              createConnector: () => ({
+                connector: new WalletConnectConnector({ chains, options: {} }),
+              }),
+              iconBackground: '#fff',
+              iconUrl: '/test.png',
+              id: 'test-walletconnect-wallet',
+              name: 'Test WalletConnect Wallet',
+            },
+          ],
+        },
+      ])();
+
+      expect(connectors.length).toBe(2);
+
+      expect(getWalletInstances(connectors[0]).length).toBe(1);
+      expect(getWalletInstances(connectors[0])[0].index).toBe(0);
+      expect(getWalletInstances(connectors[0])[0].groupName).toBe(
+        'Test Group 1'
+      );
+      expect(getWalletInstances(connectors[0])[0].name).toBe(
+        'Test Wallet Installed'
+      );
+
+      expect(getWalletInstances(connectors[1]).length).toBe(1);
+      expect(getWalletInstances(connectors[1])[0].index).toBe(2);
+      expect(getWalletInstances(connectors[1])[0].groupName).toBe(
+        'Test Group 2'
+      );
+      expect(getWalletInstances(connectors[1])[0].name).toBe(
+        'Test WalletConnect Wallet'
+      );
+    });
+  });
+});

--- a/packages/rainbowkit/src/wallets/connectorsForWallets.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.ts
@@ -2,17 +2,76 @@ import { Connector } from 'wagmi';
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
 import { isMobile } from '../utils/isMobile';
 import { omitUndefinedValues } from '../utils/omitUndefinedValues';
-import { WalletInstance, WalletList } from './Wallet';
+import { Wallet, WalletInstance, WalletList } from './Wallet';
+
+interface WalletListItem extends Wallet {
+  index: number;
+  groupName: string;
+}
 
 export const connectorsForWallets = (walletList: WalletList) => {
   return () => {
     let index = -1;
 
     const connectors: Connector[] = [];
+    const visibleWallets: WalletListItem[] = [];
+    const potentiallyHiddenWallets: WalletListItem[] = [];
+    const walletInstances: WalletInstance[] = [];
 
+    // First collect all list items in the correct order, but keep
+    // track of which ones have a `hidden` function so we can
+    // evaluate them after all the visible wallet instances have
+    // been created. This is because the potentially hidden wallets
+    // need access to the list of resolved wallet instances so that
+    // they can decide whether or not they should be hidden,
+    // e.g. the "Injected Wallet" option hides itself if another
+    // injected wallet is available.
     walletList.forEach(({ groupName, wallets }) => {
-      wallets.forEach(({ createConnector, ...walletMeta }) => {
+      wallets.forEach(wallet => {
         index++;
+
+        const walletListItem = {
+          ...wallet,
+          groupName,
+          index,
+        };
+
+        if (typeof wallet.hidden === 'function') {
+          potentiallyHiddenWallets.push(walletListItem);
+        } else {
+          visibleWallets.push(walletListItem);
+        }
+      });
+    });
+
+    // We process the known visible wallets first so that the potentially
+    // hidden wallets have access to the complete list of resolved wallets
+    const walletListItems: WalletListItem[] = [
+      ...visibleWallets,
+      ...potentiallyHiddenWallets,
+    ];
+
+    walletListItems.forEach(
+      ({ createConnector, groupName, hidden, index, ...walletMeta }) => {
+        if (typeof hidden === 'function') {
+          // Run the function to check if the wallet needs to be hidden
+          const isHidden = hidden({
+            wallets: [
+              // Note: We only expose a subset of fields
+              // publicly to reduce API surface area
+              ...walletInstances.map(({ connector, id, installed }) => ({
+                connector,
+                id,
+                installed,
+              })),
+            ],
+          });
+
+          // If wallet is hidden, bail out and proceed to the next list item
+          if (isHidden) {
+            return;
+          }
+        }
 
         const { connector, ...connectionMethods } = omitUndefinedValues(
           createConnector()
@@ -46,6 +105,11 @@ export const connectorsForWallets = (walletList: WalletList) => {
           ...connectionMethods,
         };
 
+        // We maintain an array of all wallet instances
+        // so they can be passed to the `hidden` function
+        // used by generic fallback wallets
+        walletInstances.push(walletInstance);
+
         if (!connectors.includes(connector)) {
           connectors.push(connector);
 
@@ -62,8 +126,8 @@ export const connectorsForWallets = (walletList: WalletList) => {
         // Add wallet to connector's list of associated wallets
         // @ts-expect-error
         connector._wallets.push(walletInstance);
-      });
-    });
+      }
+    );
 
     return connectors;
   };

--- a/packages/rainbowkit/src/wallets/getDefaultWallets.ts
+++ b/packages/rainbowkit/src/wallets/getDefaultWallets.ts
@@ -4,7 +4,7 @@ import { connectorsForWallets } from './connectorsForWallets';
 import { brave } from './walletConnectors/brave/brave';
 import { coinbase } from './walletConnectors/coinbase/coinbase';
 import { injected } from './walletConnectors/injected/injected';
-import { isMetaMask, metaMask } from './walletConnectors/metaMask/metaMask';
+import { metaMask } from './walletConnectors/metaMask/metaMask';
 import { rainbow } from './walletConnectors/rainbow/rainbow';
 import { walletConnect } from './walletConnectors/walletConnect/walletConnect';
 
@@ -18,25 +18,16 @@ export const getDefaultWallets = ({
   connectors: ReturnType<typeof connectorsForWallets>;
   wallets: WalletList;
 } => {
-  const needsInjectedWalletFallback =
-    typeof window !== 'undefined' &&
-    window.ethereum &&
-    !isMetaMask(window.ethereum) &&
-    !window.ethereum.isCoinbaseWallet &&
-    !window.ethereum.isBraveWallet;
-
   const wallets: WalletList = [
     {
       groupName: 'Popular',
       wallets: [
+        injected({ chains, shimDisconnect: true }),
         rainbow({ chains }),
         coinbase({ appName, chains }),
         metaMask({ chains, shimDisconnect: true }),
         walletConnect({ chains }),
         brave({ chains, shimDisconnect: true }),
-        ...(needsInjectedWalletFallback
-          ? [injected({ chains, shimDisconnect: true })]
-          : []),
       ],
     },
   ];

--- a/packages/rainbowkit/src/wallets/getDefaultWallets.ts
+++ b/packages/rainbowkit/src/wallets/getDefaultWallets.ts
@@ -22,12 +22,12 @@ export const getDefaultWallets = ({
     {
       groupName: 'Popular',
       wallets: [
-        injected({ chains, shimDisconnect: true }),
+        injected({ chains }),
         rainbow({ chains }),
         coinbase({ appName, chains }),
-        metaMask({ chains, shimDisconnect: true }),
+        metaMask({ chains }),
         walletConnect({ chains }),
-        brave({ chains, shimDisconnect: true }),
+        brave({ chains }),
       ],
     },
   ];

--- a/packages/rainbowkit/src/wallets/walletConnectors/coinbase/coinbase.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coinbase/coinbase.ts
@@ -10,12 +10,19 @@ export interface CoinbaseOptions {
 }
 
 export const coinbase = ({ appName, chains }: CoinbaseOptions): Wallet => {
+  const isCoinbaseWalletInjected =
+    typeof window !== 'undefined' && window.ethereum?.isCoinbaseWallet === true;
+
   return {
     id: 'coinbase',
     name: 'Coinbase Wallet',
     shortName: 'Coinbase',
     iconUrl: async () => (await import('./coinbase.svg')).default,
     iconBackground: '#2c5ff6',
+    // Note that we never resolve `installed` to `false` because the
+    // Coinbase Wallet SDK falls back to other connection methods if
+    // the injected connector isn't available
+    installed: isCoinbaseWalletInjected || undefined,
     downloadUrls: {
       browserExtension:
         'https://chrome.google.com/webstore/detail/coinbase-wallet-extension/hnfanknocfeofbddgcijnmhnfnkdnaad',

--- a/packages/rainbowkit/src/wallets/walletConnectors/injected/injected.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/injected/injected.ts
@@ -16,6 +16,13 @@ export const injected = ({
   name: 'Injected Wallet',
   iconUrl: async () => (await import('./injected.png')).default,
   iconBackground: '#fff',
+  hidden: ({ wallets }) =>
+    wallets.some(
+      wallet =>
+        wallet.installed &&
+        (wallet.connector instanceof InjectedConnector ||
+          wallet.id === 'coinbase')
+    ),
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMask/metaMask.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMask/metaMask.ts
@@ -10,7 +10,7 @@ export interface MetaMaskOptions {
   shimDisconnect?: boolean;
 }
 
-export function isMetaMask(ethereum: NonNullable<typeof window['ethereum']>) {
+function isMetaMask(ethereum: NonNullable<typeof window['ethereum']>) {
   // Logic borrowed from wagmi's MetaMaskConnector
   // https://github.com/tmm/wagmi/blob/main/packages/core/src/connectors/metaMask.ts
   const isMetaMask = Boolean(ethereum.isMetaMask);

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMask/metaMask.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMask/metaMask.ts
@@ -25,6 +25,10 @@ function isMetaMask(ethereum: NonNullable<typeof window['ethereum']>) {
     return false;
   }
 
+  if (ethereum.isTokenPocket) {
+    return false;
+  }
+
   if (ethereum.isTokenary) {
     return false;
   }

--- a/site/data/docs/custom-wallet-list.mdx
+++ b/site/data/docs/custom-wallet-list.mdx
@@ -31,7 +31,7 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Recommended',
     wallets: [
-      wallet.injected({ chains, shimDisconnect: true }),
+      wallet.injected({ chains }),
       wallet.rainbow({ chains }),
       wallet.walletConnect({ chains }),
     ],
@@ -210,7 +210,7 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Recommended',
     wallets: [
-      wallet.injected({ chains, shimDisconnect: true }),
+      wallet.injected({ chains }),
       wallet.metaMask({ chains }),
       wallet.walletConnect({ chains }),
     ],
@@ -227,7 +227,7 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Suggested',
     wallets: [
-      wallet.injected({ chains, shimDisconnect: true }),
+      wallet.injected({ chains }),
       wallet.metaMask({ chains }),
       wallet.rainbow({ chains }),
       wallet.coinbase({ appName: 'My RainbowKit App', chains }),
@@ -256,7 +256,7 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Others',
     wallets: [
-      wallet.injected({ chains, shimDisconnect: true }),
+      wallet.injected({ chains }),
       wallet.coinbase({ chains, appName: 'My RainbowKit App' }),
       wallet.walletConnect({ chains }),
     ],

--- a/site/data/docs/custom-wallet-list.mdx
+++ b/site/data/docs/custom-wallet-list.mdx
@@ -251,12 +251,15 @@ import { connectorsForWallets, wallet } from '@rainbow-me/rainbowkit';
 const connectors = connectorsForWallets([
   {
     groupName: 'Recommended',
-    wallets: [wallet.rainbow({ chains }), wallet.metaMask({ chains })],
+    wallets: [
+      wallet.injected({ chains }),
+      wallet.rainbow({ chains }),
+      wallet.metaMask({ chains }),
+    ],
   },
   {
     groupName: 'Others',
     wallets: [
-      wallet.injected({ chains }),
       wallet.coinbase({ chains, appName: 'My RainbowKit App' }),
       wallet.walletConnect({ chains }),
     ],

--- a/site/data/docs/custom-wallet-list.mdx
+++ b/site/data/docs/custom-wallet-list.mdx
@@ -11,7 +11,7 @@ description: Customizing the wallet list
 
 You can use the `wallet` object and the `connectorsForWallets` function to build your own list of wallets and generate the necessary connectors. This way you have full control over which wallets to display, and in which order.
 
-For example, you can choose to only show Rainbow and WalletConnect.
+For example, you can choose to only show Rainbow along with generic fallback wallets.
 
 ```tsx
 import { connectorsForWallets, wallet } from '@rainbow-me/rainbowkit';
@@ -31,6 +31,7 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Recommended',
     wallets: [
+      wallet.injected({ chains, shimDisconnect: true }),
       wallet.rainbow({ chains }),
       wallet.walletConnect({ chains }),
     ],
@@ -59,6 +60,43 @@ const App = () => (
 ```
 
 ### Built-in wallets
+
+The following wallets are provided via the `wallet` object.
+
+#### Generic Wallets
+
+The following wallets are scoped to generic connection methods rather than specific apps. As a result, it’s recommended that these wallets are always included.
+
+##### WalletConnect
+
+This is a fallback wallet option designed for WalletConnect-based wallets that haven’t been provided by another wallet in the list.
+
+**It's recommended that you always include this wallet in the list to ensure all WalletConnect-based wallets are supported.**
+
+```tsx
+import { wallet } from '@rainbow-me/rainbowkit';
+
+wallet.walletConnect(options: {
+  chains: Chain[];
+});
+```
+
+##### Injected Wallet
+
+This is a fallback wallet option designed for scenarios where `window.ethereum` exists but hasn’t been provided by another wallet in the list. This wallet will automatically hide itself from the list when the fallback is not necessary or if there is no injected wallet available.
+
+**It's recommended that you always include this wallet in the list to ensure all injected wallets are supported.**
+
+```tsx
+import { wallet } from '@rainbow-me/rainbowkit';
+
+wallet.injected(options: {
+  chains: Chain[];
+  shimDisconnect?: boolean;
+});
+```
+
+### Specific Wallets
 
 The following wallets are provided via the `wallet` object (in alphabetical order).
 
@@ -92,46 +130,6 @@ wallet.coinbase(options: {
   appName: string;
   chains: Chain[];
 });
-```
-
-#### Injected Wallet
-
-This is a fallback wallet option designed for scenarios where `window.ethereum` exists but hasn’t been provided by another wallet in the list.
-
-```tsx
-import { wallet } from '@rainbow-me/rainbowkit';
-
-wallet.injected(options: {
-  chains: Chain[];
-  shimDisconnect?: boolean;
-});
-```
-
-This shouldn’t be used if another injected wallet is available. For example, when combined with MetaMask and Coinbase Wallet:
-
-```tsx line=3-7,23-25
-import { connectorsForWallets, wallet } from '@rainbow-me/rainbowkit';
-
-const needsInjectedWalletFallback =
-  typeof window !== 'undefined' &&
-  window.ethereum &&
-  !window.ethereum.isMetaMask &&
-  !window.ethereum.isCoinbaseWallet;
-
-const connectors = connectorsForWallets([
-  {
-    groupName: 'Suggested',
-    wallets: [
-      wallet.rainbow({ chains }),
-      wallet.metaMask({ chains }),
-      wallet.coinbase({ appName: 'My RainbowKit App', chains }),
-      wallet.metaMask({ chains }),
-      ...(needsInjectedWalletFallback
-        ? [wallet.injected({ chains })]
-        : []),
-    ],
-  },
-]);
 ```
 
 #### Ledger Live
@@ -197,25 +195,13 @@ wallet.imToken(options: {
 });
 ```
 
-#### WalletConnect
-
-This is a fallback wallet option designed for other WalletConnect-based wallets that haven’t been provided by another wallet in the list.
-
-```tsx
-import { wallet } from '@rainbow-me/rainbowkit';
-
-wallet.walletConnect(options: {
-  chains: Chain[];
-});
-```
-
 ### Examples
 
 #### Ordering
 
 Here are a few examples of displaying different wallets, in different order.
 
-Show MetaMask and WalletConnect.
+Show MetaMask along with generic fallback wallets.
 
 ```tsx
 import { connectorsForWallets, wallet } from '@rainbow-me/rainbowkit';
@@ -224,6 +210,7 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Recommended',
     wallets: [
+      wallet.injected({ chains, shimDisconnect: true }),
       wallet.metaMask({ chains }),
       wallet.walletConnect({ chains }),
     ],
@@ -231,7 +218,7 @@ const connectors = connectorsForWallets([
 ]);
 ```
 
-Show MetaMask, Rainbow and Coinbase.
+Show MetaMask, Rainbow and Coinbase along with generic fallback wallets.
 
 ```tsx
 import { connectorsForWallets, wallet } from '@rainbow-me/rainbowkit';
@@ -240,9 +227,11 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Suggested',
     wallets: [
+      wallet.injected({ chains, shimDisconnect: true }),
       wallet.metaMask({ chains }),
       wallet.rainbow({ chains }),
       wallet.coinbase({ appName: 'My RainbowKit App', chains }),
+      wallet.walletConnect({ chains }),
     ],
   },
 ]);
@@ -254,7 +243,7 @@ const connectors = connectorsForWallets([
 
 You can use the `groupName` key to name different wallet groups. This is useful if you want to communicate to your users which wallets you recommend, as well as other possibile wallets.
 
-Recommend Rainbow and MetaMask, but also offer WalletConnect and Coinbase.
+Recommend Rainbow and MetaMask, but also offer Coinbase along with generic fallback wallets.
 
 ```tsx
 import { connectorsForWallets, wallet } from '@rainbow-me/rainbowkit';
@@ -267,8 +256,9 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Others',
     wallets: [
-      wallet.walletConnect({ chains }),
+      wallet.injected({ chains, shimDisconnect: true }),
       wallet.coinbase({ chains, appName: 'My RainbowKit App' }),
+      wallet.walletConnect({ chains }),
     ],
   },
 ]);

--- a/site/data/docs/custom-wallets.mdx
+++ b/site/data/docs/custom-wallets.mdx
@@ -65,6 +65,14 @@ The `Wallet` function type is provided to help you define your own custom wallet
       description: 'Object containing download URLs',
     },
     {
+      name: 'hidden',
+      required: false,
+      type: '(args: { wallets: Array<{ id: string, connector: Connector, installed?: boolean }> }) => boolean',
+      typeSimple: '(args) => boolean | undefined',
+      description:
+        'Function for calculating whether this wallet should be hidden from the list. This is useful for defining generic fallback wallets, e.g. the built-in "Injected Wallet" fallback makes use of this feature',
+    },
+    {
       name: 'createConnector',
       required: true,
       type: '() => RainbowKitConnector',


### PR DESCRIPTION
To make it easier for consumers to include the Injected Wallet fallback, this PR internalises the logic for calculating whether the option should be visible or not. This means that consumers no longer need to do this:

```ts
const needsInjectedWalletFallback =
  typeof window !== 'undefined' &&
  window.ethereum &&
  !window.ethereum.isMetaMask &&
  !window.ethereum.isCoinbaseWallet;
  
const connectors = connectorsForWallets([
  {
    groupName: 'Suggested',
    wallets: [
      ...(needsInjectedWalletFallback ? [wallet.injected({ chains })] : []),
      ...etc,
    ],
  },
]);
```

Instead, they can now simply add `wallet.injected({ chains })` to the list like any other wallet. The old code will still work, it's just redundant, so this isn't a breaking change.

I've also updated the custom wallet documentation to prioritise `wallet.injected` so that it (hopefully) doesn't get forgotten when consumers set up custom wallet lists.

Note that this PR also fixes PAR-15 by moving the Injected Wallet option to the start of the list since it's only visible when necessary.

This feature required a few changes that each have their own changeset, so you should find them useful for getting an idea of the moving parts.