### PR TITLE
fix(siwe-next-auth): include RainbowKit v0.6.x in peer range

### DIFF
--- a/.changeset/tender-coats-laugh.md
+++ b/.changeset/tender-coats-laugh.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit-siwe-next-auth': patch
+---
+
+Include RainbowKit v0.6.x in peer dependency range

--- a/packages/rainbowkit-siwe-next-auth/package.json
+++ b/packages/rainbowkit-siwe-next-auth/package.json
@@ -29,7 +29,7 @@
   "author": "Rainbow",
   "license": "MIT",
   "peerDependencies": {
-    "@rainbow-me/rainbowkit": "^0.5.0",
+    "@rainbow-me/rainbowkit": "0.5.x || 0.6.x",
     "next-auth": "^4.10.2",
     "react": ">=17",
     "siwe": "^1.1.6"


### PR DESCRIPTION
The latest set of changesets will inadvertently trigger a major release of `rainbowkit-siwe-next-auth` since RainbowKit no longer satisfies its peer dependency range. Hopefully this patch changeset fixes it.