### PR TITLE
fix(crk): avoid Linux/WSL crash when renaming branch

### DIFF
--- a/.changeset/silly-melons-worry.md
+++ b/.changeset/silly-melons-worry.md
@@ -1,0 +1,7 @@
+---
+'@rainbow-me/create-rainbowkit': patch
+---
+
+Fix crash in Linux/WSL when attempting to rename branch after running `git init`
+
+When scaffolding a new project, we now honor the system default setting rather than forcibly renaming the branch.

--- a/packages/create-rainbowkit/src/cli.ts
+++ b/packages/create-rainbowkit/src/cli.ts
@@ -208,7 +208,6 @@ async function run() {
     if (!options.skipGit) {
       log(chalk.cyan(`📚 Initializing git repository`));
       await execa('git', ['init'], { cwd: targetPath });
-      await execa('git', ['branch', '-m', 'main'], { cwd: targetPath });
       await execa('git', ['add', '.'], { cwd: targetPath });
       await execa(
         'git',


### PR DESCRIPTION
The issue raised in #650 is that Linux/WSL/Git bash crash when attempting to rename a branch that doesn't have any commits. Rather than re-ordering the steps, I opted to remove the branch rename step entirely since it makes more sense to honor the consumer's system-wide Git settings.