### PR TITLE
fix: include `styles.css` in npm bundle

### DIFF
--- a/.changeset/large-rabbits-provide.md
+++ b/.changeset/large-rabbits-provide.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Ensure `styles.css` directory is included in npm bundle

--- a/.changeset/large-rabbits-provide.md
+++ b/.changeset/large-rabbits-provide.md
@@ -4,4 +4,4 @@
 
 Ensure `styles.css` directory is included in npm bundle
 
-This is a follow-up to a fix released v0.5.2 which added a backwards compatibility layer for Jest's module resolver.
+This is a follow-up to a fix released in v0.5.2 which added a compatibility layer for Jest's module resolver.

--- a/.changeset/large-rabbits-provide.md
+++ b/.changeset/large-rabbits-provide.md
@@ -3,3 +3,5 @@
 ---
 
 Ensure `styles.css` directory is included in npm bundle
+
+This is a follow-up to a fix released v0.5.2 which added a backwards compatibility layer for Jest's module resolver.

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -3,7 +3,8 @@
   "version": "0.6.0",
   "description": "The best way to connect a wallet",
   "files": [
-    "dist"
+    "dist",
+    "styles.css"
   ],
   "type": "module",
   "exports": {


### PR DESCRIPTION
Follow up to https://github.com/rainbow-me/rainbowkit/pull/727

@markdalgleish The change was great but the folder is not included in the NPM bundle - it works in the monorepo but does not work for outside projects.

<img width="827" alt="Screenshot 2022-09-20 at 11 21 34" src="https://user-images.githubusercontent.com/12039224/191220906-f2c2a3d0-0acf-4a9d-b685-bc72d8e15f1e.png">

Thanks for your commitment to support different build tools.