### PR TITLE
fix: create new QR code when WalletConnect request is rejected

### DIFF
--- a/.changeset/swift-cars-listen.md
+++ b/.changeset/swift-cars-listen.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Generate a new QR code when WalletConnect request is rejected

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -84,7 +84,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
     }
   };
 
-  const onSelectWallet = (wallet: WalletConnector) => {
+  const selectWallet = (wallet: WalletConnector) => {
     connectToWallet(wallet);
     setSelectedOptionId(wallet.id);
 
@@ -112,6 +112,23 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
           },
           uri ? 0 : 50
         );
+
+        // If the WalletConnect request is rejected, restart the wallet
+        // selection flow to create a new connection with a new QR code
+        const provider = await sWallet?.connector.getProvider();
+        const connection = provider?.signer?.connection;
+        if (connection && connection.on && connection.off) {
+          function handleConnectionClose() {
+            removeHandlers();
+            selectWallet(wallet);
+          }
+          function removeHandlers() {
+            connection.off('close', handleConnectionClose);
+            connection.off('open', removeHandlers);
+          }
+          connection.on('close', handleConnectionClose);
+          connection.on('open', removeHandlers);
+        }
       });
     } else {
       setSelectedWallet(wallet);
@@ -246,7 +263,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
     case WalletStep.InstructionsMobile:
       walletContent = selectedWallet && (
         <InstructionMobileDetail
-          connectWallet={onSelectWallet}
+          connectWallet={selectWallet}
           wallet={selectedWallet}
         />
       );
@@ -346,7 +363,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
                             iconUrl={wallet.iconUrl}
                             key={wallet.id}
                             name={wallet.name}
-                            onClick={() => onSelectWallet(wallet)}
+                            onClick={() => selectWallet(wallet)}
                             ready={wallet.ready}
                             recent={wallet.recent}
                           />

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -117,15 +117,15 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
         // selection flow to create a new connection with a new QR code
         const provider = await sWallet?.connector.getProvider();
         const connection = provider?.signer?.connection;
-        if (connection && connection.on && connection.off) {
-          function handleConnectionClose() {
+        if (connection?.on && connection?.off) {
+          const handleConnectionClose = () => {
             removeHandlers();
             selectWallet(wallet);
-          }
-          function removeHandlers() {
+          };
+          const removeHandlers = () => {
             connection.off('close', handleConnectionClose);
             connection.off('open', removeHandlers);
-          }
+          };
           connection.on('close', handleConnectionClose);
           connection.on('open', removeHandlers);
         }


### PR DESCRIPTION
This fixes an issue where rejecting the WalletConnect request would leave you with an unusable QR code.