### PR TITLE
fix: ensure loading spinner is not visible on install prompt

### DIFF
--- a/.changeset/eleven-pots-hear.md
+++ b/.changeset/eleven-pots-hear.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Ensure loading indicator is not visible for custom wallets when wallet isn't installed

--- a/.changeset/eleven-pots-hear.md
+++ b/.changeset/eleven-pots-hear.md
@@ -2,4 +2,4 @@
 '@rainbow-me/rainbowkit': patch
 ---
 
-Ensure loading indicator is not visible for custom wallets when wallet isn't installed
+Ensure loading spinner is not visible on install prompt

--- a/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
@@ -279,50 +279,52 @@ export function ConnectDetail({
                 </Box>
               ) : null}
               {ready && !hasQrCode && (
-                <Box
-                  alignItems="center"
-                  display="flex"
-                  flexDirection="column"
-                  justifyContent="center"
-                >
-                  <Text
-                    color="modalTextSecondary"
-                    size="14"
-                    textAlign="center"
-                    weight="medium"
+                <>
+                  <Box
+                    alignItems="center"
+                    display="flex"
+                    flexDirection="column"
+                    justifyContent="center"
                   >
-                    Confirm connection in the extension
-                  </Text>
-                </Box>
-              )}
-              <Box
-                alignItems="center"
-                color="modalText"
-                display="flex"
-                flexDirection="row"
-                height="32"
-                marginTop="8"
-              >
-                {connectionError ? (
-                  <ActionButton
-                    label="RETRY"
-                    onClick={
-                      getDesktopDeepLink
-                        ? async () => {
-                            const uri = await getDesktopDeepLink();
-                            window.open(uri, safari ? '_blank' : '_self');
-                          }
-                        : () => {
-                            reconnect(wallet);
-                          }
-                    }
-                  />
-                ) : (
-                  <Box color="modalTextSecondary">
-                    <SpinnerIcon />
+                    <Text
+                      color="modalTextSecondary"
+                      size="14"
+                      textAlign="center"
+                      weight="medium"
+                    >
+                      Confirm connection in the extension
+                    </Text>
                   </Box>
-                )}
-              </Box>
+                  <Box
+                    alignItems="center"
+                    color="modalText"
+                    display="flex"
+                    flexDirection="row"
+                    height="32"
+                    marginTop="8"
+                  >
+                    {connectionError ? (
+                      <ActionButton
+                        label="RETRY"
+                        onClick={
+                          getDesktopDeepLink
+                            ? async () => {
+                                const uri = await getDesktopDeepLink();
+                                window.open(uri, safari ? '_blank' : '_self');
+                              }
+                            : () => {
+                                reconnect(wallet);
+                              }
+                        }
+                      />
+                    ) : (
+                      <Box color="modalTextSecondary">
+                        <SpinnerIcon />
+                      </Box>
+                    )}
+                  </Box>
+                </>
+              )}
             </Box>
           </Box>
         </Box>


### PR DESCRIPTION
While migrating one of the wallet PRs to our new tree-shakeable API, I noticed this UI bug that isn't present with any of our current built-in wallets. To reproduce the issue, I edited `metaMaskWallet` so it doesn't use WalletConnect on desktop.

Note: The diff is much easier to follow if you hide whitespace changes: https://github.com/rainbow-me/rainbowkit/pull/786/files?diff=unified&w=1

Before:

<img width="775" alt="Screen Shot 2022-09-30 at 10 30 53 am" src="https://user-images.githubusercontent.com/696693/193165873-820cfb51-a212-4fb0-bf36-594134d116c3.png">

After:

<img width="759" alt="Screen Shot 2022-09-30 at 10 31 08 am" src="https://user-images.githubusercontent.com/696693/193165882-78eb0a94-5d44-4139-8233-31a4c5a36ed0.png">
