### PR TITLE
chore: sort custom wallet list to reduce merge conflicts

### DIFF
--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -119,10 +119,10 @@ const connectors = connectorsForWallets([
     groupName: 'Other',
     wallets: [
       argentWallet({ chains }),
-      trustWallet({ chains }),
-      omniWallet({ chains }),
       imTokenWallet({ chains }),
       ledgerWallet({ chains }),
+      omniWallet({ chains }),
+      trustWallet({ chains }),
     ],
   },
 ]);


### PR DESCRIPTION
We've got a number of open PRs adding wallets. This ensures that they'll all be able to add themselves to this list without introducing conflicts each time a PR is merged.