### PR TITLE
fix: include wallets exports alias directory in npm bundle

### DIFF
--- a/.changeset/gorgeous-penguins-carry.md
+++ b/.changeset/gorgeous-penguins-carry.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Fix package.json exports field backwards compatibility for `@rainbow-me/rainbowkit/wallets`

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -4,7 +4,8 @@
   "description": "The best way to connect a wallet",
   "files": [
     "dist",
-    "styles.css"
+    "styles.css",
+    "wallets"
   ],
   "type": "module",
   "exports": {


### PR DESCRIPTION
fix #788