### PR TITLE
feat: add data-testid attributes to support e2e testing

### DIFF
--- a/.changeset/cold-knives-heal.md
+++ b/.changeset/cold-knives-heal.md
@@ -1,0 +1,23 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Add `data-testid` attributes to support end-to-end testing.
+
+The following set of `data-testid` attribute values are now provided.
+
+- `rk-connect-button`
+- `rk-disconnect-button`
+- `rk-account-button`
+- `rk-chain-button`
+- `rk-wrong-network-button`
+- `rk-wallet-option-${wallet.id}`
+- `rk-chain-option-${chain.id}`
+- `rk-chain-option-disconnect`
+- `rk-auth-message-button`
+
+These attributes can be targeted with a selector like this:
+
+```css
+[data-testid="rk-connect-button"]
+```

--- a/packages/rainbowkit/src/components/Box/Box.ts
+++ b/packages/rainbowkit/src/components/Box/Box.ts
@@ -12,10 +12,11 @@ type Props = Atoms &
   HTMLProperties & {
     as?: React.ElementType;
     className?: ClassValue;
+    testId?: string;
   };
 
 export const Box = React.forwardRef<HTMLElement, Props>(
-  ({ as = 'div', className, ...props }: Props, ref) => {
+  ({ as = 'div', className, testId, ...props }: Props, ref) => {
     const atomProps: Record<string, unknown> = {};
     const nativeProps: Record<string, unknown> = {};
 
@@ -33,8 +34,9 @@ export const Box = React.forwardRef<HTMLElement, Props>(
     });
 
     return React.createElement(as, {
-      className: clsx(atomicClasses, className),
+      'className': clsx(atomicClasses, className),
       ...nativeProps,
+      'data-testid': testId ? `rk-${testId.replace(/^rk-/, '')}` : undefined,
       ref,
     });
   }

--- a/packages/rainbowkit/src/components/Button/ActionButton.tsx
+++ b/packages/rainbowkit/src/components/Button/ActionButton.tsx
@@ -41,6 +41,7 @@ export function ActionButton({
   rel = 'noreferrer noopener',
   size = 'medium',
   target = '_blank',
+  testId,
   type = 'primary',
 }: {
   href?: string;
@@ -51,6 +52,7 @@ export function ActionButton({
   target?: string;
   type?: 'primary' | 'secondary';
   disabled?: boolean;
+  testId?: string;
 }) {
   const isPrimary = type === 'primary';
   const isNotLarge = size !== 'large';
@@ -90,6 +92,7 @@ export function ActionButton({
       paddingX={paddingX}
       paddingY={paddingY}
       style={{ willChange: 'transform' }}
+      testId={testId}
       textAlign="center"
       transition="transform"
       {...(background ? { background } : {})}

--- a/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
+++ b/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
@@ -124,6 +124,7 @@ export function ChainModal({ onClose, open }: ChainModalProps) {
                               switchNetwork(chain.id);
                             }
                       }
+                      testId={`chain-option-${chain.id}`}
                     >
                       <Box fontFamily="body" fontSize="16" fontWeight="bold">
                         <Box
@@ -228,7 +229,10 @@ export function ChainModal({ onClose, open }: ChainModalProps) {
             {unsupportedChain && (
               <>
                 <Box background="generalBorderDim" height="1" marginX="8" />
-                <MenuButton onClick={() => disconnect()}>
+                <MenuButton
+                  onClick={() => disconnect()}
+                  testId="chain-option-disconnect"
+                >
                   <Box
                     color="error"
                     fontFamily="body"

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -102,6 +102,9 @@ export function ConnectButton({
                     onClick={openChainModal}
                     paddingX="10"
                     paddingY="8"
+                    testId={
+                      unsupportedChain ? 'wrong-network-button' : 'chain-button'
+                    }
                     transition="default"
                     type="button"
                   >
@@ -171,6 +174,7 @@ export function ConnectButton({
                     fontFamily="body"
                     fontWeight="bold"
                     onClick={openAccountModal}
+                    testId="account-button"
                     transition="default"
                     type="button"
                   >
@@ -256,6 +260,7 @@ export function ConnectButton({
                 key="connect"
                 onClick={openConnectModal}
                 paddingX="14"
+                testId="connect-button"
                 transition="default"
                 type="button"
               >

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -366,6 +366,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
                             onClick={() => selectWallet(wallet)}
                             ready={wallet.ready}
                             recent={wallet.recent}
+                            testId={`wallet-option-${wallet.id}`}
                           />
                         );
                       })}

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -84,6 +84,7 @@ function WalletButton({ wallet }: { wallet: WalletConnector }) {
       }, [connector, connect, getMobileUri, onConnecting, name])}
       ref={coolModeRef}
       style={{ overflow: 'visible', textAlign: 'center' }}
+      testId={`wallet-option-${id}`}
       type="button"
       width="full"
     >

--- a/packages/rainbowkit/src/components/MenuButton/MenuButton.tsx
+++ b/packages/rainbowkit/src/components/MenuButton/MenuButton.tsx
@@ -8,11 +8,18 @@ type Props = {
   children?: React.ReactNode;
   onClick?: React.MouseEventHandler<HTMLElement> | undefined;
   currentlySelected?: boolean;
+  testId?: string;
 };
 
 export const MenuButton = React.forwardRef(
   (
-    { children, currentlySelected = false, onClick, ...urlProps }: Props,
+    {
+      children,
+      currentlySelected = false,
+      onClick,
+      testId,
+      ...urlProps
+    }: Props,
     ref: React.Ref<HTMLElement>
   ) => {
     const mobile = isMobile();
@@ -24,6 +31,7 @@ export const MenuButton = React.forwardRef(
         display="flex"
         onClick={onClick}
         ref={ref}
+        testId={testId}
         type="button"
       >
         <Box

--- a/packages/rainbowkit/src/components/ModalSelection/ModalSelection.tsx
+++ b/packages/rainbowkit/src/components/ModalSelection/ModalSelection.tsx
@@ -15,6 +15,7 @@ type Props = {
   name: string;
   iconUrl: string | (() => Promise<string>);
   iconBackground?: string;
+  testId?: string;
 };
 
 export const ModalSelection = ({
@@ -26,6 +27,7 @@ export const ModalSelection = ({
   onClick,
   ready,
   recent,
+  testId,
   ...urlProps
 }: Props) => {
   const coolModeRef = useCoolMode(iconUrl);
@@ -58,6 +60,7 @@ export const ModalSelection = ({
         onClick={onClick}
         padding="5"
         style={{ willChange: 'transform' }}
+        testId={testId}
         transition="default"
         width="full"
         {...(currentlySelected

--- a/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
+++ b/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
@@ -141,6 +141,7 @@ export function ProfileDetails({
               action={onDisconnect}
               icon={<DisconnectIcon />}
               label="Disconnect"
+              testId="disconnect-button"
             />
           </Box>
         </Box>

--- a/packages/rainbowkit/src/components/ProfileDetails/ProfileDetailsAction.tsx
+++ b/packages/rainbowkit/src/components/ProfileDetails/ProfileDetailsAction.tsx
@@ -9,12 +9,14 @@ interface ProfileDetailsActionProps {
   action?: () => void;
   icon: JSX.Element;
   url?: string;
+  testId?: string;
 }
 
 export function ProfileDetailsAction({
   action,
   icon,
   label,
+  testId,
   url,
 }: ProfileDetailsActionProps) {
   const mobile = isMobile();
@@ -37,6 +39,7 @@ export function ProfileDetailsAction({
       onClick={action}
       padding={mobile ? '6' : '8'}
       style={{ willChange: 'transform' }}
+      testId={testId}
       transition="default"
       width="full"
     >

--- a/packages/rainbowkit/src/components/SignIn/SignIn.tsx
+++ b/packages/rainbowkit/src/components/SignIn/SignIn.tsx
@@ -212,6 +212,7 @@ export function SignIn({ onClose }: { onClose: () => void }) {
             }
             onClick={signIn}
             size={mobile ? 'large' : 'medium'}
+            testId="auth-message-button"
           />
           {mobile ? (
             <ActionButton


### PR DESCRIPTION
The following set of `data-testid` attribute values are now provided.

- `rk-connect-button`
- `rk-disconnect-button`
- `rk-account-button`
- `rk-chain-button`
- `rk-wrong-network-button`
- `rk-wallet-option-${wallet.id}`
- `rk-chain-option-${chain.id}`
- `rk-chain-option-disconnect`
- `rk-auth-message-button`

To make this easy to implement, our `Box` component now supports a `testId` prop which applies a `data-testid` attribute with the value automatically prefixed with `rk-`.