### PR TITLE
docs: fix server error on NFT mint demo

### DIFF
--- a/examples/with-next-mint-nft/pages/_app.tsx
+++ b/examples/with-next-mint-nft/pages/_app.tsx
@@ -8,20 +8,11 @@ import {
 } from '@rainbow-me/rainbowkit';
 import { argentWallet, trustWallet } from '@rainbow-me/rainbowkit/wallets';
 import { chain, createClient, configureChains, WagmiConfig } from 'wagmi';
-import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 
 const { chains, provider, webSocketProvider } = configureChains(
-  [
-    chain.rinkeby,
-    ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true'
-      ? [chain.rinkeby]
-      : []),
-  ],
-  [
-    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
-    publicProvider(),
-  ]
+  [chain.rinkeby],
+  [publicProvider()]
 );
 
 const { wallets } = getDefaultWallets({


### PR DESCRIPTION
The build in main is currently broken because the NFT mint example app is showing a 404 error in the terminal when running the Next build step. Turns out it's because it's trying to interact with a contract on Rinkeby and Alchemy is returning a 404. As a quick fix to get the build passing, I removed Alchemy from the list of providers and only used `publicProvider`. We'll obviously need to revisit this example more holistically at some point.