### PR TITLE
fix: updated chains available on wagmi chainlist

### DIFF
--- a/site/data/docs/chains.mdx
+++ b/site/data/docs/chains.mdx
@@ -12,20 +12,17 @@ The `chains` prop on `RainbowKitProvider` defines which chains are available for
 RainbowKit is designed to integrate with [wagmi’s `chain` object](https://wagmi.sh/docs/constants/chains#chain) which currently provides the following chains:
 
 - `chain.mainnet`
-- `chain.ropsten`
-- `chain.rinkeby`
 - `chain.goerli`
-- `chain.kovan`
 - `chain.sepolia`
 - `chain.optimism`
 - `chain.optimismGoerli`
-- `chain.optimismKovan`
 - `chain.polygon`
 - `chain.polygonMumbai`
 - `chain.arbitrum`
-- `chain.arbitrumRinkeby`
+- `chain.arbitrumGoerli`
 - `chain.localhost`
 - `chain.hardhat`
+- `chain.foundry`
 
 > For more detail about the `chain` object, or to see examples when creating a custom chain definition, see the [source code for wagmi’s `chain` object](https://github.com/tmm/wagmi/blob/main/packages/core/src/constants/chains.ts).
 


### PR DESCRIPTION
Updating the chains supported by WAGMI chain list and Rainbowkit.