### PR TITLE
docs: Update custom authentication code snippets

### DIFF
--- a/site/data/docs/custom-authentication.mdx
+++ b/site/data/docs/custom-authentication.mdx
@@ -62,23 +62,77 @@ const authenticationAdapter = createAuthenticationAdapter({
 Assuming your application is already managing the authentication lifecycle in some way, you can pass the current authentication status along with your custom adapter to `RainbowKitAuthenticationProvider`, wrapping your existing `RainbowKitProvider`.
 
 ```tsx
+import { useEffect, useState } from "react";
 import {
-  createAuthenticationAdapter,
-  RainbowKitAuthenticationProvider,
+  getDefaultWallets,
   RainbowKitProvider,
-} from '@rainbow-me/rainbowkit';
+  RainbowKitAuthenticationProvider,
+  createAuthenticationAdapter,
+} from "@rainbow-me/rainbowkit";
+import { SiweMessage } from "siwe";
 import { AppProps } from 'next/app';
 import { WagmiConfig } from 'wagmi';
 
-const authenticationAdapter = createAuthenticationAdapter({
-  /* See above... */
-});
-
 export default function App({ Component, pageProps }: AppProps) {
-  // You'll need to resolve AUTHENTICATION_STATUS here
-  // using your application's authentication system.
-  // It needs to be either 'loading' (during initial load),
-  // 'unathenticated' or 'authenticated'.
+  const [authenticationStatus, setAuthenticationStatus] = useState<
+    "loading" | "unauthenticated" | "authenticated"
+  >("loading");
+  const [hasMounted, setHasMounted] = useState(false);
+
+  const authenticationAdapter = createAuthenticationAdapter({
+    getNonce: async () => {
+      const response = await fetch("/api/auth/nonce");
+      const res = await response.text();
+      return res;
+    },
+    createMessage: ({ nonce, address, chainId }) => {
+      return new SiweMessage({
+        domain: window.location.host,
+        address,
+        statement: "Sign in with Ethereum to the app.",
+        uri: window.location.origin,
+        version: "1",
+        chainId,
+        nonce,
+      });
+    },
+    getMessageBody: ({ message }) => {
+      return message.prepareMessage();
+    },
+    verify: async ({ message, signature }) => {
+      const verifyRes = await fetch("/api/auth/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message,
+          signature,
+        }),
+      });
+      setAuthenticationStatus(
+        verifyRes.ok ? "authenticated" : "unauthenticated"
+      );
+      return Boolean(verifyRes.ok);
+    },
+    signOut: async () => {
+      await fetch("/api/auth/logout");
+      setAuthenticationStatus("unauthenticated");
+    },
+  });
+
+  useEffect(() => {
+    const fetchAuthStatus = async () => {
+      const res = await fetch("/api/auth/me", {
+        credentials: "include",
+      });
+
+      if (!res.ok) {
+        setAuthenticationStatus("unauthenticated");
+      } else {
+        setAuthenticationStatus("authenticated");
+      }
+    };
+    fetchAuthStatus();
+  }, []);
 
   return (
     <WagmiConfig {...etc}>
@@ -95,4 +149,6 @@ export default function App({ Component, pageProps }: AppProps) {
 }
 ```
 
-If you've got this far and created an adapter for an existing open source authentication library, please consider creating a package for others to use!
+Full working example:
+- Frontend: https://github.com/smakosh/SIWE-Next.js
+- Backend: https://github.com/smakosh/SIWE-Express.js

--- a/site/data/docs/custom-authentication.mdx
+++ b/site/data/docs/custom-authentication.mdx
@@ -150,5 +150,5 @@ export default function App({ Component, pageProps }: AppProps) {
 ```
 
 Full working example:
-- Frontend: https://github.com/smakosh/SIWE-Next.js
-- Backend: https://github.com/smakosh/SIWE-Express.js
+- [Frontend](https://github.com/smakosh/SIWE-Next.js)
+- [Backend](https://github.com/smakosh/SIWE-Express.js)


### PR DESCRIPTION
## What's new?
- Open GH discussion: https://github.com/rainbow-me/rainbowkit/discussions/884

There seems to be a typo and missing pieces in the docs regarding custom authentication, see: https://github.com/rainbow-me/rainbowkit/issues/680

So I decided to make two working boilerplates following the examples in that GitHub issue, you can find them here:

- Frontend: https://github.com/smakosh/SIWE-Next.js
- Backend: https://github.com/smakosh/SIWE-Express.js
- Demo: https://twitter.com/smakosh/status/1594872447173623810