### PR TITLE
fix: add extension URL to trustWallet.ts, add trust to getDefaultWall…

### DIFF
--- a/packages/rainbowkit/src/wallets/getDefaultWallets.ts
+++ b/packages/rainbowkit/src/wallets/getDefaultWallets.ts
@@ -1,6 +1,7 @@
 import { Chain } from '../components/RainbowKitProvider/RainbowKitChainContext';
 import { WalletList } from './Wallet';
 import { connectorsForWallets } from './connectorsForWallets';
+import { trustWallet } from './walletConnectors';
 import { braveWallet } from './walletConnectors/braveWallet/braveWallet';
 import { coinbaseWallet } from './walletConnectors/coinbaseWallet/coinbaseWallet';
 import { injectedWallet } from './walletConnectors/injectedWallet/injectedWallet';
@@ -23,6 +24,7 @@ export const getDefaultWallets = ({
       groupName: 'Popular',
       wallets: [
         injectedWallet({ chains }),
+        trustWallet({ chains }),
         rainbowWallet({ chains }),
         coinbaseWallet({ appName, chains }),
         metaMaskWallet({ chains }),

--- a/packages/rainbowkit/src/wallets/getDefaultWallets.ts
+++ b/packages/rainbowkit/src/wallets/getDefaultWallets.ts
@@ -1,7 +1,6 @@
 import { Chain } from '../components/RainbowKitProvider/RainbowKitChainContext';
 import { WalletList } from './Wallet';
 import { connectorsForWallets } from './connectorsForWallets';
-import { trustWallet } from './walletConnectors';
 import { braveWallet } from './walletConnectors/braveWallet/braveWallet';
 import { coinbaseWallet } from './walletConnectors/coinbaseWallet/coinbaseWallet';
 import { injectedWallet } from './walletConnectors/injectedWallet/injectedWallet';
@@ -24,7 +23,6 @@ export const getDefaultWallets = ({
       groupName: 'Popular',
       wallets: [
         injectedWallet({ chains }),
-        trustWallet({ chains }),
         rainbowWallet({ chains }),
         coinbaseWallet({ appName, chains }),
         metaMaskWallet({ chains }),

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -19,6 +19,8 @@ export const trustWallet = ({
   iconUrl: async () => (await import('./trustWallet.svg')).default,
   iconBackground: '#fff',
   downloadUrls: {
+    browserExtension:
+      'https://chrome.google.com/webstore/detail/trust-wallet/egjidjbpglichdcondbcbdnbeeppgdph',
     android:
       'https://play.google.com/store/apps/details?id=com.wallet.crypto.trustapp',
     ios: 'https://apps.apple.com/us/app/trust-crypto-bitcoin-wallet/id1288339409',

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -84,7 +84,9 @@ export const trustWallet = ({
         },
         qrCode: shouldUseWalletConnect
           ? {
-              getUri,
+              getUri: isAndroid()
+                ? getUri
+                : async () => (await connector.getProvider()).connector.uri,
               instructions: {
                 learnMoreUrl:
                   'https://trustwallet.com/blog/an-introduction-to-trustwallet',

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -84,7 +84,7 @@ export const trustWallet = ({
         },
         qrCode: shouldUseWalletConnect
           ? {
-              getUri,
+              getUri: async () => (await connector.getProvider()).connector.uri,
               instructions: {
                 learnMoreUrl:
                   'https://trustwallet.com/blog/an-introduction-to-trustwallet',

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -84,7 +84,7 @@ export const trustWallet = ({
         },
         qrCode: shouldUseWalletConnect
           ? {
-              getUri: async () => (await connector.getProvider()).connector.uri,
+              getUri,
               instructions: {
                 learnMoreUrl:
                   'https://trustwallet.com/blog/an-introduction-to-trustwallet',

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -74,7 +74,7 @@ export const trustWallet = ({
 
         return isAndroid()
           ? uri
-          : `https://link.trustwallet.com/wc?uri=${encodeURIComponent}`;
+          : `https://link.trustwallet.com/wc?uri=${encodeURIComponent(uri)}`;
       };
 
       return {

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -10,74 +10,134 @@ export interface TrustWalletOptions {
   shimDisconnect?: boolean;
 }
 
+function isTrust(ethereum: NonNullable<typeof window['ethereum']>) {
+  // Logic borrowed from wagmi's MetaMaskConnector
+  // https://github.com/tmm/wagmi/blob/main/packages/core/src/connectors/metaMask.ts
+  const isTrust = Boolean(ethereum.isTrust);
+
+  if (!isTrust) {
+    return false;
+  }
+
+  // Brave tries to make itself look like MetaMask
+  // Could also try RPC `web3_clientVersion` if following is unreliable
+  if (ethereum.isBraveWallet && !ethereum._events && !ethereum._state) {
+    return false;
+  }
+
+  if (ethereum.isTokenPocket) {
+    return false;
+  }
+
+  if (ethereum.isTokenary) {
+    return false;
+  }
+
+  return true;
+}
+
 export const trustWallet = ({
   chains,
   shimDisconnect,
-}: TrustWalletOptions): Wallet => ({
-  id: 'trust',
-  name: 'Trust Wallet',
-  iconUrl: async () => (await import('./trustWallet.svg')).default,
-  iconBackground: '#fff',
-  downloadUrls: {
-    browserExtension:
-      'https://chrome.google.com/webstore/detail/trust-wallet/egjidjbpglichdcondbcbdnbeeppgdph',
-    android:
-      'https://play.google.com/store/apps/details?id=com.wallet.crypto.trustapp',
-    ios: 'https://apps.apple.com/us/app/trust-crypto-bitcoin-wallet/id1288339409',
-    qrCode: 'https://link.trustwallet.com',
-  },
-  createConnector: () => {
-    const inAppBrowser = Boolean(
-      typeof window !== 'undefined' && window.ethereum?.isTrust
-    );
+}: TrustWalletOptions): Wallet => {
+  const isTrustInjected =
+    typeof window !== 'undefined' &&
+    typeof window.ethereum !== 'undefined' &&
+    isTrust(window.ethereum);
 
-    if (inAppBrowser) {
-      return {
-        connector: new InjectedConnector({
-          chains,
-          options: { shimDisconnect },
-        }),
+  const shouldUseWalletConnect = !isTrustInjected;
+
+  return {
+    id: 'trust',
+    name: 'Trust Wallet',
+    iconUrl: async () => (await import('./trustWallet.svg')).default,
+    iconBackground: '#fff',
+    installed: !shouldUseWalletConnect ? isTrustInjected : undefined,
+    downloadUrls: {
+      browserExtension:
+        'https://chrome.google.com/webstore/detail/trust-wallet/egjidjbpglichdcondbcbdnbeeppgdph',
+      android:
+        'https://play.google.com/store/apps/details?id=com.wallet.crypto.trustapp',
+      ios: 'https://apps.apple.com/us/app/trust-crypto-bitcoin-wallet/id1288339409',
+      qrCode: 'https://link.trustwallet.com',
+    },
+    createConnector: () => {
+      const connector = shouldUseWalletConnect
+        ? getWalletConnectConnector({ chains })
+        : new InjectedConnector({
+            chains,
+            options: { shimDisconnect },
+          });
+
+      const getUri = async () => {
+        const { uri } = (await connector.getProvider()).connector;
+
+        return isAndroid()
+          ? uri
+          : `https://link.trustwallet.com/wc?uri=${encodeURIComponent}`;
       };
-    }
 
-    const connector = getWalletConnectConnector({ chains });
-
-    return {
-      connector,
-      mobile: {
-        getUri: async () => {
-          const { uri } = (await connector.getProvider()).connector;
-          return isAndroid()
-            ? uri
-            : `https://link.trustwallet.com/wc?uri=${encodeURIComponent(uri)}`;
+      return {
+        connector,
+        mobile: {
+          getUri: shouldUseWalletConnect ? getUri : undefined,
         },
-      },
-      qrCode: {
-        getUri: async () => (await connector.getProvider()).connector.uri,
-        instructions: {
+        qrCode: shouldUseWalletConnect
+          ? {
+              getUri,
+              instructions: {
+                learnMoreUrl:
+                  'https://trustwallet.com/blog/an-introduction-to-trustwallet',
+                steps: [
+                  {
+                    description:
+                      'Put Trust Wallet on your home screen for faster access to your wallet.',
+                    step: 'install',
+                    title: 'Open the Trust Wallet app',
+                  },
+                  {
+                    description:
+                      'Create a new wallet or import an existing one.',
+                    step: 'create',
+                    title: 'Create or Import a Wallet',
+                  },
+                  {
+                    description:
+                      'Choose New Connection, then scan the QR code and confirm the prompt to connect.',
+                    step: 'scan',
+                    title: 'Tap WalletConnect in Settings',
+                  },
+                ],
+              },
+            }
+          : undefined,
+        extension: {
           learnMoreUrl:
             'https://trustwallet.com/blog/an-introduction-to-trustwallet',
-          steps: [
-            {
-              description:
-                'Put Trust Wallet on your home screen for faster access to your wallet.',
-              step: 'install',
-              title: 'Open the Trust Wallet app',
-            },
-            {
-              description: 'Create a new wallet or import an existing one.',
-              step: 'create',
-              title: 'Create or Import a Wallet',
-            },
-            {
-              description:
-                'Choose New Connection, then scan the QR code and confirm the prompt to connect.',
-              step: 'scan',
-              title: 'Tap WalletConnect in Settings',
-            },
-          ],
+          instructions: {
+            steps: [
+              {
+                description:
+                  'We recommend pinning Trust Wallet to your taskbar for quicker access to your wallet.',
+                step: 'install',
+                title: 'Install the Trust Wallet extension',
+              },
+              {
+                description:
+                  'Be sure to back up your wallet using a secure method. Never share your secret phrase with anyone.',
+                step: 'create',
+                title: 'Create or Import a Wallet',
+              },
+              {
+                description:
+                  'Once you set up your wallet, click below to refresh the browser and load up the extension.',
+                step: 'refresh',
+                title: 'Refresh your browser',
+              },
+            ],
+          },
         },
-      },
-    };
-  },
-});
+      };
+    },
+  };
+};


### PR DESCRIPTION
Added extension URL to `trustWallet.ts` given that we have launched a new browser extension (https://chrome.google.com/webstore/detail/trust-wallet/egjidjbpglichdcondbcbdnbeeppgdph). Have also added trust to the wallets in `getDefaultWallets.ts` given that we are 1st or 2nd most popular web3 wallet by users and thus should be in the 'popular' grouping.