### PR TITLE
Export AuthenticationContext

### DIFF
--- a/packages/rainbowkit/src/components/RainbowKitProvider/AuthenticationContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/AuthenticationContext.tsx
@@ -37,7 +37,7 @@ export function createAuthenticationAdapter<Message>(
   return adapter;
 }
 
-const AuthenticationContext = createContext<AuthenticationConfig<any> | null>(
+export const AuthenticationContext = createContext<AuthenticationConfig<any> | null>(
   null
 );
 


### PR DESCRIPTION
When using a custom button to signout, it's required a call to the `useAuthenticationAdapter` hook.

This currently results in the error:

```
Module not found: Error: Package path ./dist/components/RainbowKitProvider/AuthenticationContext is not exported from package /Users/.../node_modules/@rainbow-me/rainbowkit (see exports field in /Users/.../node_modules/@rainbow-me/rainbowkit/package.json)
```

This PR simply exports `AuthenticationContext`.