### PR TITLE
Update SIWE peer and dev dependencies

### DIFF
--- a/packages/rainbowkit-siwe-next-auth/package.json
+++ b/packages/rainbowkit-siwe-next-auth/package.json
@@ -32,11 +32,11 @@
     "@rainbow-me/rainbowkit": "0.5.x || 0.6.x || 0.7.x || 0.8.x",
     "next-auth": "^4.10.2",
     "react": ">=17",
-    "siwe": "^1.1.6"
+    "siwe": "^2.1.3"
   },
   "devDependencies": {
     "@rainbow-me/rainbowkit": "workspace:*",
-    "siwe": "^1.1.6"
+    "siwe": "^2.1.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Was getting `siwe.verify is not a function` before.

Updated to 2.0.3 to be in accordance with the latest version of SIWE