### PR TITLE
Polyfills in Create React App Example

### DIFF
--- a/examples/with-create-react-app/package.json
+++ b/examples/with-create-react-app/package.json
@@ -17,7 +17,8 @@
     "typescript": "^4.7.2",
     "util": "0.12.4",
     "wagmi": "^0.9.0",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "buffer": "npm:buffer@6.0.3"
   },
   "scripts": {
     "dev": "npm run start",

--- a/examples/with-create-react-app/src/index.tsx
+++ b/examples/with-create-react-app/src/index.tsx
@@ -1,3 +1,4 @@
+import './polyfills';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import reportWebVitals from './reportWebVitals';

--- a/examples/with-create-react-app/src/polyfills.ts
+++ b/examples/with-create-react-app/src/polyfills.ts
@@ -1,0 +1,7 @@
+import { Buffer } from 'buffer';
+
+window.global = window.global ?? window;
+window.Buffer = window.Buffer ?? Buffer;
+window.process = window.process ?? { env: {} }; // Minimal process polyfill
+
+export {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,7 @@ importers:
       '@testing-library/react': ^13.2.0
       '@testing-library/user-event': ^13.5.0
       '@types/jest': ^27.5.1
+      buffer: npm:buffer@6.0.3
       ethers: ^5.0.0
       react-scripts: 5.0.1
       util: 0.12.4
@@ -102,6 +103,7 @@ importers:
       '@testing-library/react': 13.3.0
       '@testing-library/user-event': 13.5.0
       '@types/jest': 27.5.2
+      buffer: 6.0.3
       ethers: 5.6.8
       react-scripts: 5.0.1
       util: 0.12.4


### PR DESCRIPTION
 - Polyfills were deprecated as of react-scripts@v5 https://github.com/facebook/create-react-app/issues/11756
 - Introduced a `polyfills.ts` file in `with-create-react-app` in alignment with the Vite and Remix examples to resolve the dangling Buffer polyfill