### PR TITLE
Remove unmaintained Alchemy provider from examples

### DIFF
--- a/examples/with-create-react-app/src/index.tsx
+++ b/examples/with-create-react-app/src/index.tsx
@@ -7,7 +7,6 @@ import '@rainbow-me/rainbowkit/styles.css';
 import { getDefaultWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit';
 import { configureChains, createClient, WagmiConfig } from 'wagmi';
 import { mainnet, polygon, optimism, arbitrum, goerli } from 'wagmi/chains';
-import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 import App from './App';
 
@@ -19,10 +18,7 @@ const { chains, provider, webSocketProvider } = configureChains(
     arbitrum,
     ...(process.env.REACT_APP_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],
-  [
-    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
-    publicProvider(),
-  ]
+  [publicProvider()]
 );
 
 const { connectors } = getDefaultWallets({

--- a/examples/with-next-custom-button/pages/_app.tsx
+++ b/examples/with-next-custom-button/pages/_app.tsx
@@ -13,7 +13,6 @@ import {
 } from '@rainbow-me/rainbowkit/wallets';
 import { configureChains, createClient, WagmiConfig } from 'wagmi';
 import { mainnet, polygon, optimism, arbitrum, goerli } from 'wagmi/chains';
-import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 
 const { chains, provider, webSocketProvider } = configureChains(
@@ -24,10 +23,7 @@ const { chains, provider, webSocketProvider } = configureChains(
     arbitrum,
     ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],
-  [
-    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
-    publicProvider(),
-  ]
+  [publicProvider()]
 );
 
 const { wallets } = getDefaultWallets({

--- a/examples/with-next-siwe-iron-session/pages/_app.tsx
+++ b/examples/with-next-siwe-iron-session/pages/_app.tsx
@@ -18,7 +18,6 @@ import {
 } from '@rainbow-me/rainbowkit/wallets';
 import { configureChains, createClient, WagmiConfig } from 'wagmi';
 import { mainnet, polygon, optimism, arbitrum, goerli } from 'wagmi/chains';
-import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 import { SiweMessage } from 'siwe';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -31,10 +30,7 @@ const { chains, provider, webSocketProvider } = configureChains(
     arbitrum,
     ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],
-  [
-    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
-    publicProvider(),
-  ]
+  [publicProvider()]
 );
 
 const { wallets } = getDefaultWallets({

--- a/examples/with-next-siwe-next-auth/pages/_app.tsx
+++ b/examples/with-next-siwe-next-auth/pages/_app.tsx
@@ -13,7 +13,6 @@ import {
 } from '@rainbow-me/rainbowkit/wallets';
 import { configureChains, createClient, WagmiConfig } from 'wagmi';
 import { mainnet, polygon, optimism, arbitrum, goerli } from 'wagmi/chains';
-import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 import { SessionProvider } from 'next-auth/react';
 import {
@@ -29,10 +28,7 @@ const { chains, provider, webSocketProvider } = configureChains(
     arbitrum,
     ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],
-  [
-    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
-    publicProvider(),
-  ]
+  [publicProvider()]
 );
 
 const { wallets } = getDefaultWallets({

--- a/examples/with-next/pages/_app.tsx
+++ b/examples/with-next/pages/_app.tsx
@@ -13,7 +13,6 @@ import {
 } from '@rainbow-me/rainbowkit/wallets';
 import { configureChains, createClient, WagmiConfig } from 'wagmi';
 import { mainnet, polygon, optimism, arbitrum, goerli } from 'wagmi/chains';
-import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 
 const { chains, provider, webSocketProvider } = configureChains(
@@ -24,10 +23,7 @@ const { chains, provider, webSocketProvider } = configureChains(
     arbitrum,
     ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],
-  [
-    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
-    publicProvider(),
-  ]
+  [publicProvider()]
 );
 
 const { wallets } = getDefaultWallets({

--- a/examples/with-remix/app/root.tsx
+++ b/examples/with-remix/app/root.tsx
@@ -16,7 +16,6 @@ import type {
 } from '@remix-run/node';
 import { configureChains, createClient, WagmiConfig } from 'wagmi';
 import { mainnet, polygon, optimism, arbitrum, goerli } from 'wagmi/chains';
-import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 import type { Chain } from 'wagmi';
 import {
@@ -28,7 +27,7 @@ import {
 import globalStylesUrl from './styles/global.css';
 import rainbowStylesUrl from '@rainbow-me/rainbowkit/styles.css';
 
-type Env = { ALCHEMY_API_KEY?: string; PUBLIC_ENABLE_TESTNETS?: string };
+type Env = { PUBLIC_ENABLE_TESTNETS?: string };
 
 type LoaderData = { ENV: Env };
 
@@ -48,8 +47,6 @@ export const links: LinksFunction = () => [
 export const loader: LoaderFunction = () => {
   const data: LoaderData = {
     ENV: {
-      ALCHEMY_API_KEY:
-        process.env.ALCHEMY_API_KEY || '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC',
       PUBLIC_ENABLE_TESTNETS: process.env.PUBLIC_ENABLE_TESTNETS || 'false',
     },
   };
@@ -69,7 +66,7 @@ export default function App() {
 
     const { chains, provider } = configureChains(
       [mainnet, polygon, optimism, arbitrum, ...testChains],
-      [alchemyProvider({ apiKey: ENV.ALCHEMY_API_KEY! }), publicProvider()]
+      [publicProvider()]
     );
 
     const { connectors } = getDefaultWallets({

--- a/examples/with-vite/src/main.tsx
+++ b/examples/with-vite/src/main.tsx
@@ -4,7 +4,6 @@ import '@rainbow-me/rainbowkit/styles.css';
 import { getDefaultWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit';
 import { configureChains, createClient, WagmiConfig } from 'wagmi';
 import { mainnet, polygon, optimism, arbitrum } from 'wagmi/chains';
-import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
@@ -12,10 +11,7 @@ import App from './App';
 
 const { chains, provider } = configureChains(
   [mainnet, polygon, optimism, arbitrum],
-  [
-    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
-    publicProvider(),
-  ]
+  [publicProvider()]
 );
 
 const { connectors } = getDefaultWallets({


### PR DESCRIPTION
This PR removes all the instances of Alchemy providers from examples. Until now, each Alchemy provider was initialized using a hardcoded API key which eventually became obsolete, breaking the app functionality due to the inability to connect to the Alchemy network. 

Another more versatile solution, if we still want to support Alchemy in example apps, would be to allow users to define an Alchemy provider themselves through an environmental variable, e.g., `ALCHEMY=API_KEY`. If `ALCHEMY` is present, then the corresponding example will be initialized through Alchemy, else it will be initialized through public providers. This is just an idea and is currently out of the scope of the submitted work; `reainbowkit` team will decide the best action. 

Please also note that the example `with-next-mint-nft` is obsolete. The contracts are deployed on Rinkeby, which was [deprecated](https://twitter.com/etherscan/status/1569311894279958531) due to incompatibility with ETH 2.