### PR TITLE
fix: indicate that dist/index.css has side effects

### DIFF
--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -16,7 +16,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": [
-    "src/css/reset.css.ts"
+    "src/css/reset.css.ts",
+    "dist/index.css"
   ],
   "engines": {
     "node": ">=12.4"


### PR DESCRIPTION
some bundlers that use the package.json's `sideEffects` to ignore imports that are marked as side-effect-free end up removing the rainbowkit styles.css import. this is because `dist/index.css` (which the `./styles.css` export points to) is not included in the `sideEffects` array. this solves that.

here's an example of the issue when using `tsup` (which uses `esbuild` under the hood):
```
$ tsup --config tsup.config.bundle.ts
CLI Building entry: {"bundle":"src/index.tsx"}
CLI Using tsconfig: tsconfig.json
CLI tsup v6.5.0
CLI Using tsup config: /home/rayzr/GitHub/mint-button/tsup.config.bundle.ts
CLI Target: esnext
IIFE Build start

 WARN  ▲ [WARNING] Ignoring this import because "node_modules/.pnpm/@rainbow-me+rainbowkit@0.8.1_lnegknozu2aw57uj7nu7qr6ys4/node_modules/@rainbow-me/rainbowkit/dist/index.css" was marked as having no side effects [ignored-bare-import]                                                                                                                    16:49:12

    src/index.tsx:8:7:
      8 │ import '@rainbow-me/rainbowkit/styles.css'
        ╵        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  It was excluded from the "sideEffects" array in the enclosing "package.json" file

    node_modules/@rainbow-me/rainbowkit/package.json:18:2:
      18 │   "sideEffects": [
         ╵   ~~~~~~~~~~~~~



IIFE dist/bundle.global.js 4.21 MB
IIFE ⚡️ Build success in 181ms
```
and then after applying the following patch (using `pnpm patch`):
```diff
diff --git a/package.json b/package.json
index 2d18e99310dd125b6699c7c5a296926b75325345..a3c127d7c448d1ae722f775b6f4b1ce3443c8ff9 100644
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": [
-    "src/css/reset.css.ts"
+    "src/css/reset.css.ts",
+    "dist/index.css"
   ],
   "engines": {
     "node": ">=12.4"
```
and building again the issue is gone:
```
$ tsup --config tsup.config.bundle.ts
CLI Building entry: {"bundle":"src/index.tsx"}
CLI Using tsconfig: tsconfig.json
CLI tsup v6.5.0
CLI Using tsup config: /home/rayzr/GitHub/mint-button/tsup.config.bundle.ts
CLI Target: esnext
IIFE Build start
IIFE dist/bundle.global.js 4.26 MB
IIFE ⚡️ Build success in 183ms
```