### PR TITLE
fix: migrated site/example alchemy id 

### DIFF
--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -40,6 +40,7 @@ import {
   optimism,
   polygon,
 } from 'wagmi/chains';
+import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 import { AppContextProps } from '../lib/AppContextProps';
 
@@ -54,7 +55,10 @@ const { chains, provider, webSocketProvider } = configureChains(
     avalanche,
     ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],
-  [publicProvider()]
+  [
+    alchemyProvider({ apiKey: process.env.NEXT_PUBLIC_ALCHEMY_ID || '' }),
+    publicProvider(),
+  ]
 );
 
 const { wallets } = getDefaultWallets({

--- a/site/components/Provider/Provider.tsx
+++ b/site/components/Provider/Provider.tsx
@@ -18,7 +18,7 @@ import { publicProvider } from 'wagmi/providers/public';
 export const { chains, provider } = configureChains(
   [mainnet, polygon, optimism, arbitrum],
   [
-    alchemyProvider({ apiKey: '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC' }),
+    alchemyProvider({ apiKey: process.env.NEXT_PUBLIC_ALCHEMY_ID || '' }),
     publicProvider(),
   ]
 );


### PR DESCRIPTION
## Context:
Alchemy appears to have rate-limited the API Key leveraged by the Site and Example. Deployed a new internal Alchemy API Key to the web deployments.

## Changes:
- Using `NEXT_PUBLIC_ALCHEMY_ID` in `example/` and `site/`

