### PR TITLE
Set connect modal state to closed after sign-in to prevent open on disconnect

### DIFF
--- a/packages/rainbowkit/src/components/SignIn/SignIn.tsx
+++ b/packages/rainbowkit/src/components/SignIn/SignIn.tsx
@@ -101,6 +101,7 @@ export function SignIn({ onClose }: { onClose: () => void }) {
         const verified = await authAdapter.verify({ message, signature });
 
         if (verified) {
+          onClose();
           return;
         } else {
           throw new Error();


### PR DESCRIPTION
When using an authentication adapter with rainbow kit, the connect modal state is never set to closed after sign-in, it just doesn't have an effect because the model component itself returns `null`.  The issue is that once the user disconnects, the modal instantly re-appears.

This PR just calls the function to close the connect modal once the authentication `verify` function returns successfully.