### PR TITLE
Add optional onSignIn and onSignOut callbacks to next-auth adapter

### DIFF
--- a/packages/rainbowkit-siwe-next-auth/src/RainbowKitSiweNextAuthProvider.tsx
+++ b/packages/rainbowkit-siwe-next-auth/src/RainbowKitSiweNextAuthProvider.tsx
@@ -23,6 +23,8 @@ export type GetSiweMessageOptions = () => ConfigurableMessageOptions;
 interface RainbowKitSiweNextAuthProviderProps {
   enabled?: boolean;
   getSiweMessageOptions?: GetSiweMessageOptions;
+  onSignIn?: () => void;
+  onSignOut?: () => void;
   children: ReactNode;
 }
 
@@ -30,6 +32,8 @@ export function RainbowKitSiweNextAuthProvider({
   children,
   enabled,
   getSiweMessageOptions,
+  onSignIn,
+  onSignOut,
 }: RainbowKitSiweNextAuthProviderProps) {
   const { status } = useSession();
   const adapter = useMemo(
@@ -70,6 +74,7 @@ export function RainbowKitSiweNextAuthProvider({
 
         signOut: async () => {
           await signOut({ redirect: false });
+          if (onSignOut) onSignOut();
         },
 
         verify: async ({ message, signature }) => {
@@ -79,10 +84,13 @@ export function RainbowKitSiweNextAuthProvider({
             signature,
           });
 
-          return response?.ok ?? false;
+          if (!response?.ok) return false;
+
+          if (onSignIn) signIn();
+          return true;
         },
       }),
-    [getSiweMessageOptions]
+    [getSiweMessageOptions, onSignIn, onSignOut]
   );
 
   return (


### PR DESCRIPTION
Implemented the same callbacks in the auth adapter I wrote for [UseSIWE](https://github.com/random-bits-studio/use-siwe)
https://github.com/random-bits-studio/rainbowkit-use-siwe-auth

Related Discussion: https://github.com/rainbow-me/rainbowkit/discussions/904