### PR TITLE
fix: remix example bundling issues

### DIFF
--- a/examples/with-remix/app/entry.client.tsx
+++ b/examples/with-remix/app/entry.client.tsx
@@ -1,5 +1,5 @@
 import './polyfills';
 import { RemixBrowser } from '@remix-run/react';
-import { hydrate } from 'react-dom';
+import { hydrateRoot } from 'react-dom/client';
 
-hydrate(<RemixBrowser />, document);
+hydrateRoot(document, <RemixBrowser />);

--- a/examples/with-remix/remix.config.js
+++ b/examples/with-remix/remix.config.js
@@ -10,7 +10,11 @@ module.exports = {
   serverDependenciesToBundle: [
     '@rainbow-me/rainbowkit',
     '@rainbow-me/rainbowkit/wallets',
-    'wagmi',
-    '@wagmi/core',
+    /^@?wagmi.*/,
+    /.*/,
   ],
 };
+
+// https://github.com/remix-run/remix/discussions/2594#discussioncomment-4733564
+// Remix currently does not bundle all dependency packages
+// /.*/ is the recommended catch-all for missing RainbowKit dependencies


### PR DESCRIPTION
Changes:
- Pulling in Wagmi dependency bundling changes from #922
- Wildcard dependency bundling to resolve #943
- `hydrateRoot` migration for [React 18](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis:~:text=for%20more%20information.-,Finally,-%2C%20if%20your%20app)