### PR TITLE
fix: corrected migration guide for 0.8.1

### DIFF
--- a/packages/rainbowkit/CHANGELOG.md
+++ b/packages/rainbowkit/CHANGELOG.md
@@ -11,7 +11,7 @@
   #### 1. Upgrade RainbowKit and `wagmi` to their latest version:
 
   ```bash
-  npm i @rainbow-me/rainbowkit@^0.9.0 wagmi@^0.9.0
+  npm i @rainbow-me/rainbowkit@^0.8.1 wagmi@^0.9.0
   ```
 
   #### 2. Check for breaking changes in `wagmi`

--- a/site/data/docs/migration-guide.mdx
+++ b/site/data/docs/migration-guide.mdx
@@ -15,7 +15,7 @@ Follow the steps below to migrate.
 #### 1. Upgrade RainbowKit and `wagmi` to their latest version:
 
 ```bash
-npm i @rainbow-me/rainbowkit@^0.9.0 wagmi@^0.9.0
+npm i @rainbow-me/rainbowkit@^0.8.1 wagmi@^0.9.0
 ```
 
 #### 2. Check for breaking changes in `wagmi`


### PR DESCRIPTION
## Changes
- Fixed incorrect `0.9.0` version references in changelog and docs migration guide