### PR TITLE
chore: changeset bump for wagmi 0.9.x release

### DIFF
--- a/.changeset/new-dolls-dream.md
+++ b/.changeset/new-dolls-dream.md
@@ -1,0 +1,15 @@
+---
+'@rainbow-me/rainbowkit': minor
+---
+
+The wagmi peer dependency has been updated to `0.9.x`.
+
+Follow the steps below to migrate.
+
+```bash
+npm i @rainbow-me/rainbowkit@^0.9.0 wagmi@^0.9.0
+```
+
+If you use `wagmi` hooks in your application, you will need to check if your application has been affected by the breaking changes in `wagmi`.
+
+[You can see their migration guide here](https://wagmi.sh/react/migration-guide#09x-breaking-changes).


### PR DESCRIPTION
Bumped RainbowKit version to align with Wagmi `0.9.x` release. Docs and `create-rainbowkit` already in alignment.