### PR TITLE
fix: close modal state on dialog unmount

### DIFF
--- a/packages/rainbowkit/src/components/Dialog/Dialog.tsx
+++ b/packages/rainbowkit/src/components/Dialog/Dialog.tsx
@@ -39,6 +39,7 @@ export function Dialog({ children, onClose, open, titleId }: DialogProps) {
     setBodyScrollable(
       getComputedStyle(window.document.body).overflow !== 'hidden'
     );
+    return () => onClose();
   }, []);
 
   const handleBackdropClick = useCallback(() => onClose(), [onClose]);


### PR DESCRIPTION
## Changes
- Added a call to `onClose` in the `useEffect` clean up return function in `Dialog.tsx`

## Fixes Issues
#836
#837

Based on what I've read, the issue exists only in development mode with React Strict Mode enabled. Rather than remove strict mode,  I think it makes sense to do some clean up on the dialog state. For example, in the `AccountModal`, if no `address` is present, the component returns `null`, but it is possible that the modal's state is still set to `true`. Below are two screen recordings taken from the vite example, before and after the fix.

## Screen recording: Before Fix
> Notice how the `AccountModal` pops up immediately after disconnecting and can't be closed.
https://user-images.githubusercontent.com/82186307/216893941-0cdcc1ba-b5fb-4051-b83e-1091b46d26b1.mov

## Screen recording: After Fix
> Modal closes properly even after disconnecting
https://user-images.githubusercontent.com/82186307/216894023-0eae670e-0057-46e5-ab59-706f14ea1f9e.mov

