### PR TITLE
fix: injected wallet check for rainbow

### DIFF
--- a/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
@@ -21,7 +21,8 @@ export const injectedWallet = ({
       wallet =>
         wallet.installed &&
         (wallet.connector instanceof InjectedConnector ||
-          wallet.id === 'coinbase')
+          wallet.id === 'coinbase' ||
+          wallet.id === 'rainbow')
     ),
   createConnector: () => ({
     connector: new InjectedConnector({

--- a/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
@@ -42,6 +42,7 @@ export const rainbowWallet = ({
       ios: 'https://apps.apple.com/us/app/rainbow-ethereum-wallet/id1457119021',
       qrCode: 'https://rainbow.download',
     },
+    installed: isRainbowInjected || undefined,
     createConnector: () => {
       const connector = shouldUseWalletConnect
         ? getWalletConnectConnector({ chains })


### PR DESCRIPTION
Adding this check to not show the "injected wallet" option while using the ~~extension~~