### PR TITLE
revert: siwe-next-auth changeset versions

### DIFF
--- a/examples/with-next-siwe-next-auth/CHANGELOG.md
+++ b/examples/with-next-siwe-next-auth/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Updated dependencies [49f0ec9]
   - @rainbow-me/rainbowkit@0.9.0
-  - @rainbow-me/rainbowkit-siwe-next-auth@1.0.0
+  - @rainbow-me/rainbowkit-siwe-next-auth@0.1.6
 
 ## 0.0.14
 
@@ -135,5 +135,5 @@
 - Updated dependencies [737a1d6]
 - Updated dependencies [737a1d6]
 - Updated dependencies [488c5a1]
-  - @rainbow-me/rainbowkit-siwe-next-auth@1.0.0
+  - @rainbow-me/rainbowkit-siwe-next-auth@0.1.6
   - @rainbow-me/rainbowkit@0.5.0

--- a/packages/example/CHANGELOG.md
+++ b/packages/example/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Updated dependencies [49f0ec9]
   - @rainbow-me/rainbowkit@0.9.0
-  - @rainbow-me/rainbowkit-siwe-next-auth@1.0.0
+  - @rainbow-me/rainbowkit-siwe-next-auth@0.1.6
 
 ## 0.0.42
 
@@ -135,7 +135,7 @@
 - Updated dependencies [737a1d6]
 - Updated dependencies [737a1d6]
 - Updated dependencies [488c5a1]
-  - @rainbow-me/rainbowkit-siwe-next-auth@1.0.0
+  - @rainbow-me/rainbowkit-siwe-next-auth@0.1.6
   - @rainbow-me/rainbowkit@0.5.0
 
 ## 0.0.28

--- a/packages/rainbowkit-siwe-next-auth/CHANGELOG.md
+++ b/packages/rainbowkit-siwe-next-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @rainbow-me/rainbowkit-siwe-next-auth
 
-## 1.0.0
+## 0.1.6
 
 ### Patch Changes
 

--- a/packages/rainbowkit-siwe-next-auth/package.json
+++ b/packages/rainbowkit-siwe-next-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainbow-me/rainbowkit-siwe-next-auth",
-  "version": "1.0.0",
+  "version": "0.1.6",
   "description": "RainbowKit authentication adapter for Sign-In with Ethereum and NextAuth.js",
   "files": [
     "dist"
@@ -29,7 +29,7 @@
   "author": "Rainbow",
   "license": "MIT",
   "peerDependencies": {
-    "@rainbow-me/rainbowkit": "0.9.0",
+    "@rainbow-me/rainbowkit": "0.5.x || 0.6.x || 0.7.x || 0.8.x || 0.9.x",
     "next-auth": "^4.10.2",
     "react": ">=17",
     "siwe": "^1.1.6"


### PR DESCRIPTION
- Bumped `rainbowkit-siwe-next-auth` back to `0.1.6` to revert invalid changeset