### PR TITLE
fix: treating ipad as small ios to enable mobile deep linking

### DIFF
--- a/.changeset/stupid-swans-type.md
+++ b/.changeset/stupid-swans-type.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Improvements to RainbowKit UX on iPad

--- a/packages/rainbowkit/src/utils/isMobile.ts
+++ b/packages/rainbowkit/src/utils/isMobile.ts
@@ -19,5 +19,5 @@ export function isIOS(): boolean {
 }
 
 export function isMobile(): boolean {
-  return isAndroid() || isSmallIOS();
+  return isAndroid() || isIOS();
 }

--- a/packages/rainbowkit/src/utils/isMobile.ts
+++ b/packages/rainbowkit/src/utils/isMobile.ts
@@ -11,7 +11,11 @@ export function isSmallIOS(): boolean {
 }
 
 export function isLargeIOS(): boolean {
-  return typeof navigator !== 'undefined' && /iPad/.test(navigator.userAgent);
+  return (
+    typeof navigator !== 'undefined' &&
+    (/iPad/.test(navigator.userAgent) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1))
+  );
 }
 
 export function isIOS(): boolean {


### PR DESCRIPTION
- Fix for #845