### PR TITLE
chore: updated docs to reflect yarn create changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ You can scaffold a new RainbowKit + [wagmi](https://wagmi.sh) + [Next.js](https:
 ```bash
 npm init @rainbow-me/rainbowkit@latest
 # or
-yarn create @rainbow-me/rainbowkit@latest
-# or
 pnpm create @rainbow-me/rainbowkit@latest
+# or
+yarn create @rainbow-me/rainbowkit
 ```
 
 ## Documentation

--- a/packages/create-rainbowkit/README.md
+++ b/packages/create-rainbowkit/README.md
@@ -5,9 +5,9 @@ Scaffold a new RainbowKit project.
 ```bash
 npm init @rainbow-me/rainbowkit@latest
 # or
-yarn create @rainbow-me/rainbowkit@latest
-# or
 pnpm create @rainbow-me/rainbowkit@latest
+# or
+yarn create @rainbow-me/rainbowkit
 ```
 
 ## License

--- a/site/data/docs/installation.mdx
+++ b/site/data/docs/installation.mdx
@@ -14,9 +14,9 @@ You can scaffold a new RainbowKit + [wagmi](https://wagmi.sh) + [Next.js](https:
 ```bash
 npm init @rainbow-me/rainbowkit@latest
 # or
-yarn create @rainbow-me/rainbowkit@latest
-# or
 pnpm create @rainbow-me/rainbowkit@latest
+# or
+yarn create @rainbow-me/rainbowkit
 ```
 
 This will prompt you for a project name, generate a new directory containing a boilerplate project, and install all required dependencies.


### PR DESCRIPTION
## Changes
Recommending `yarn create @rainbow-me/rainbowkit` over `yarn create @rainbow-me/rainbowkit@latest` to mitigate `No such file or directory` error

```bash
% yarn create @rainbow-me/rainbowkit@latest
yarn create v1.22.19
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...

success Installed "@rainbow-me/create-rainbowkit@0.1.7" with binaries:
      - create-rainbowkit
[##############################################################################################################] 236/236/bin/sh: /.yarn/bin/create-rainbowkit@latest: No such file or directory
error Command failed.
Exit code: 127
Command: /.yarn/bin/create-rainbowkit@latest
Arguments: 
Directory: /Desktop
Output:

info Visit https://yarnpkg.com/en/docs/cli/create for documentation about this command.
```