### PR TITLE
fix: set shimDisconnect to true for all injected providers

### DIFF
--- a/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
@@ -5,13 +5,9 @@ import { Wallet } from '../../Wallet';
 
 export interface BitskiWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
-export const bitskiWallet = ({
-  chains,
-  shimDisconnect,
-}: BitskiWalletOptions): Wallet => ({
+export const bitskiWallet = ({ chains }: BitskiWalletOptions): Wallet => ({
   id: 'bitski',
   name: 'Bitski',
   installed:
@@ -28,7 +24,6 @@ export const bitskiWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options: { shimDisconnect },
     }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
@@ -5,13 +5,9 @@ import { Wallet } from '../../Wallet';
 
 export interface BraveWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
-export const braveWallet = ({
-  chains,
-  shimDisconnect,
-}: BraveWalletOptions): Wallet => ({
+export const braveWallet = ({ chains }: BraveWalletOptions): Wallet => ({
   id: 'brave',
   name: 'Brave Wallet',
   iconUrl: async () => (await import('./braveWallet.svg')).default,
@@ -27,7 +23,6 @@ export const braveWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options: { shimDisconnect },
     }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
@@ -5,13 +5,9 @@ import { Wallet } from '../../Wallet';
 
 export interface InjectedWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
-export const injectedWallet = ({
-  chains,
-  shimDisconnect,
-}: InjectedWalletOptions): Wallet => ({
+export const injectedWallet = ({ chains }: InjectedWalletOptions): Wallet => ({
   id: 'injected',
   name: 'Injected Wallet',
   iconUrl: async () => (await import('./injectedWallet.png')).default,
@@ -26,7 +22,6 @@ export const injectedWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options: { shimDisconnect },
     }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -7,7 +7,6 @@ import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface MetaMaskWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
 function isMetaMask(ethereum: NonNullable<typeof window['ethereum']>) {
@@ -36,10 +35,7 @@ function isMetaMask(ethereum: NonNullable<typeof window['ethereum']>) {
   return true;
 }
 
-export const metaMaskWallet = ({
-  chains,
-  shimDisconnect,
-}: MetaMaskWalletOptions): Wallet => {
+export const metaMaskWallet = ({ chains }: MetaMaskWalletOptions): Wallet => {
   const isMetaMaskInjected =
     typeof window !== 'undefined' &&
     typeof window.ethereum !== 'undefined' &&
@@ -66,7 +62,6 @@ export const metaMaskWallet = ({
         ? getWalletConnectConnector({ chains })
         : new MetaMaskConnector({
             chains,
-            options: { shimDisconnect },
           });
 
       const getUri = async () => {

--- a/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
@@ -4,13 +4,9 @@ import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainCon
 import { Wallet } from '../../Wallet';
 export interface MewWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
-export const mewWallet = ({
-  chains,
-  shimDisconnect,
-}: MewWalletOptions): Wallet => {
+export const mewWallet = ({ chains }: MewWalletOptions): Wallet => {
   const isMewWalletInjected =
     typeof window !== 'undefined' &&
     Boolean(
@@ -35,7 +31,6 @@ export const mewWallet = ({
       return {
         connector: new InjectedConnector({
           chains,
-          options: { shimDisconnect },
         }),
       };
     },

--- a/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
@@ -7,7 +7,6 @@ import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface RainbowWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
 function isRainbow(ethereum: NonNullable<typeof window['ethereum']>) {
@@ -21,10 +20,7 @@ function isRainbow(ethereum: NonNullable<typeof window['ethereum']>) {
   return true;
 }
 
-export const rainbowWallet = ({
-  chains,
-  shimDisconnect,
-}: RainbowWalletOptions): Wallet => {
+export const rainbowWallet = ({ chains }: RainbowWalletOptions): Wallet => {
   const isRainbowInjected =
     typeof window !== 'undefined' &&
     typeof window.ethereum !== 'undefined' &&
@@ -46,7 +42,6 @@ export const rainbowWallet = ({
         ? getWalletConnectConnector({ chains })
         : new InjectedConnector({
             chains,
-            options: { shimDisconnect },
           });
 
       const getUri = async () => {

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -7,13 +7,9 @@ import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface TrustWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
-export const trustWallet = ({
-  chains,
-  shimDisconnect,
-}: TrustWalletOptions): Wallet => ({
+export const trustWallet = ({ chains }: TrustWalletOptions): Wallet => ({
   id: 'trust',
   name: 'Trust Wallet',
   iconUrl: async () => (await import('./trustWallet.svg')).default,
@@ -33,7 +29,6 @@ export const trustWallet = ({
       return {
         connector: new InjectedConnector({
           chains,
-          options: { shimDisconnect },
         }),
       };
     }


### PR DESCRIPTION
## problem

currently `shimDisconnect` is an option when creating any wallet with an associated `InjectedConnector`. having this as an option has the unintended consequence of auto-connecting *any* injected wallet, since there is no differentiation between the initialisation of them.

e.g. using the following wallet list

```ts
const wallets = [
      bitskiWallet({ chains }),
      metaMaskWallet({ chains, shimDisconnect: true }),
];
```

if you connect and disconnect from `MetaMask`, then refresh the page, the wallet will auto-connect. 

## solution

this pr removes `shimDisconnect` as an option wherever it was available to ensure a fallback auto-connect is never made.

## alternatives

an alternative solution could be to only allow `shimDisconnect` to be false if the `installed` property is true, but since the option creates an awkward experience anyway, i don't think that's necessary.

## fixed issues

fixes #1054, which is enabled by `getDefaultWallets` not passing `shimDisconnect: true` to each injected connector wallet.
