### PR TITLE
fix: shimDisconnect option passthrough

### DIFF
--- a/.changeset/blue-gifts-hunt.md
+++ b/.changeset/blue-gifts-hunt.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Fixed `shimDisconnect` wallet connector option to maintain default Wagmi disconnect behavior when `shimDisconnect` is unspecified. RainbowKit wallet connectors now also accept all `InjectedConnectorOptions` options.

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
@@ -1,17 +1,17 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
+import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
 
 export interface BitskiWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
 export const bitskiWallet = ({
   chains,
-  shimDisconnect,
-}: BitskiWalletOptions): Wallet => ({
+  ...options
+}: BitskiWalletOptions & InjectedConnectorOptions): Wallet => ({
   id: 'bitski',
   name: 'Bitski',
   installed:
@@ -28,7 +28,7 @@ export const bitskiWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options: { shimDisconnect },
+      options,
     }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
@@ -1,17 +1,17 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
+import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
 
 export interface BraveWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
 export const braveWallet = ({
   chains,
-  shimDisconnect,
-}: BraveWalletOptions): Wallet => ({
+  ...options
+}: BraveWalletOptions & InjectedConnectorOptions): Wallet => ({
   id: 'brave',
   name: 'Brave Wallet',
   iconUrl: async () => (await import('./braveWallet.svg')).default,
@@ -27,7 +27,7 @@ export const braveWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options: { shimDisconnect },
+      options,
     }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
@@ -12,6 +12,7 @@ export interface CoinbaseWalletOptions {
 export const coinbaseWallet = ({
   appName,
   chains,
+  ...options
 }: CoinbaseWalletOptions): Wallet => {
   const isCoinbaseWalletInjected =
     typeof window !== 'undefined' && window.ethereum?.isCoinbaseWallet === true;
@@ -42,6 +43,7 @@ export const coinbaseWallet = ({
         options: {
           appName,
           headlessMode: true,
+          ...options,
         },
       });
 

--- a/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
@@ -1,17 +1,17 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
+import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
 
 export interface InjectedWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
 export const injectedWallet = ({
   chains,
-  shimDisconnect,
-}: InjectedWalletOptions): Wallet => ({
+  ...options
+}: InjectedWalletOptions & InjectedConnectorOptions): Wallet => ({
   id: 'injected',
   name: 'Injected Wallet',
   iconUrl: async () => (await import('./injectedWallet.png')).default,
@@ -26,7 +26,7 @@ export const injectedWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options: { shimDisconnect },
+      options,
     }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -1,4 +1,5 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
+import type { MetaMaskConnectorOptions } from '@wagmi/core/dist/connectors/metaMask';
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { isAndroid } from '../../../utils/isMobile';
@@ -7,7 +8,6 @@ import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface MetaMaskWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
 function isMetaMask(ethereum: NonNullable<typeof window['ethereum']>) {
@@ -38,8 +38,8 @@ function isMetaMask(ethereum: NonNullable<typeof window['ethereum']>) {
 
 export const metaMaskWallet = ({
   chains,
-  shimDisconnect,
-}: MetaMaskWalletOptions): Wallet => {
+  ...options
+}: MetaMaskWalletOptions & MetaMaskConnectorOptions): Wallet => {
   const isMetaMaskInjected =
     typeof window !== 'undefined' &&
     typeof window.ethereum !== 'undefined' &&
@@ -66,7 +66,7 @@ export const metaMaskWallet = ({
         ? getWalletConnectConnector({ chains })
         : new MetaMaskConnector({
             chains,
-            options: { shimDisconnect },
+            options,
           });
 
       const getUri = async () => {

--- a/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
@@ -1,16 +1,16 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
+import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
 export interface MewWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
 export const mewWallet = ({
   chains,
-  shimDisconnect,
-}: MewWalletOptions): Wallet => {
+  ...options
+}: MewWalletOptions & InjectedConnectorOptions): Wallet => {
   const isMewWalletInjected =
     typeof window !== 'undefined' &&
     Boolean(
@@ -35,7 +35,7 @@ export const mewWallet = ({
       return {
         connector: new InjectedConnector({
           chains,
-          options: { shimDisconnect },
+          options,
         }),
       };
     },

--- a/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
@@ -1,4 +1,5 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
+import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { isAndroid } from '../../../utils/isMobile';
@@ -7,7 +8,6 @@ import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface RainbowWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
 function isRainbow(ethereum: NonNullable<typeof window['ethereum']>) {
@@ -23,8 +23,8 @@ function isRainbow(ethereum: NonNullable<typeof window['ethereum']>) {
 
 export const rainbowWallet = ({
   chains,
-  shimDisconnect,
-}: RainbowWalletOptions): Wallet => {
+  ...options
+}: RainbowWalletOptions & InjectedConnectorOptions): Wallet => {
   const isRainbowInjected =
     typeof window !== 'undefined' &&
     typeof window.ethereum !== 'undefined' &&
@@ -46,7 +46,7 @@ export const rainbowWallet = ({
         ? getWalletConnectConnector({ chains })
         : new InjectedConnector({
             chains,
-            options: { shimDisconnect },
+            options,
           });
 
       const getUri = async () => {

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -1,4 +1,5 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
+import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { isAndroid } from '../../../utils/isMobile';
@@ -7,13 +8,12 @@ import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface TrustWalletOptions {
   chains: Chain[];
-  shimDisconnect?: boolean;
 }
 
 export const trustWallet = ({
   chains,
-  shimDisconnect,
-}: TrustWalletOptions): Wallet => ({
+  ...options
+}: TrustWalletOptions & InjectedConnectorOptions): Wallet => ({
   id: 'trust',
   name: 'Trust Wallet',
   iconUrl: async () => (await import('./trustWallet.svg')).default,
@@ -33,7 +33,7 @@ export const trustWallet = ({
       return {
         connector: new InjectedConnector({
           chains,
-          options: { shimDisconnect },
+          options,
         }),
       };
     }

--- a/site/data/docs/custom-wallet-list.mdx
+++ b/site/data/docs/custom-wallet-list.mdx
@@ -97,7 +97,6 @@ import { injectedWallet } from '@rainbow-me/rainbowkit/wallets';
 
 injectedWallet(options: {
   chains: Chain[];
-  shimDisconnect?: boolean;
 });
 ```
 
@@ -122,7 +121,6 @@ import { bitskiWallet } from '@rainbow-me/rainbowkit/wallets';
 
 bitskiWallet(options: {
   chains: Chain[];
-  shimDisconnect?: boolean;
 });
 ```
 
@@ -133,7 +131,6 @@ import { braveWallet } from '@rainbow-me/rainbowkit/wallets';
 
 braveWallet(options: {
   chains: Chain[];
-  shimDisconnect?: boolean;
 });
 ```
 
@@ -166,7 +163,6 @@ import { metaMaskWallet } from '@rainbow-me/rainbowkit/wallets';
 
 metaMaskWallet(options: {
   chains: Chain[];
-  shimDisconnect?: boolean;
 });
 ```
 
@@ -176,7 +172,6 @@ metaMaskWallet(options: {
 import { mewWallet } from '@rainbow-me/rainbowkit/wallets';
 mewWallet(options: {
   chains: Chain[];
-  shimDisconnect?: boolean;
 });
 ```
 
@@ -207,7 +202,6 @@ import { trustWallet } from '@rainbow-me/rainbowkit/wallets';
 
 trustWallet(options: {
   chains: Chain[];
-  shimDisconnect?: boolean;
 });
 ```
 


### PR DESCRIPTION
Fixed `shimDisconnect` wallet connector option to maintain default Wagmi disconnect behavior when `shimDisconnect` is unspecified. RainbowKit wallet connectors now also accept all `InjectedConnectorOptions` options.

- Avoiding assigning `shimDisconnect` directly to prevent overriding Wagmi defaults for `shimDisconnect` with `undefined` when unset
- Altered connectors to passthrough `InjectedConnectorOptions` options to underlying `InjectedConnector` connector
- Removed `shimDisconnect` option from docs