### PR TITLE
fix: injectedWallet fallback detection improvement

### DIFF
--- a/.changeset/weak-berries-rest.md
+++ b/.changeset/weak-berries-rest.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+RainbowKit dApps that use `getDefaultWallets` or `injectedWallet` will now more eagerly display the fallback `injectedWallet` connector to better support dApp Browsers when a branded connector is unavailable.

--- a/packages/rainbowkit/src/wallets/Wallet.ts
+++ b/packages/rainbowkit/src/wallets/Wallet.ts
@@ -51,6 +51,7 @@ export type Wallet<C extends Connector = Connector> = {
       id: string;
       connector: Connector;
       installed?: boolean;
+      name: string;
     }[];
   }) => boolean;
   createConnector: () => RainbowKitConnector<C>;

--- a/packages/rainbowkit/src/wallets/connectorsForWallets.test.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.test.ts
@@ -181,7 +181,9 @@ describe('connectorsForWallets', () => {
           wallets: [
             {
               createConnector: () => ({
-                connector: new InjectedConnector(),
+                connector: new InjectedConnector({
+                  options: { chains, name: 'Test Wallet Installed' },
+                }),
               }),
               iconBackground: '#fff',
               iconUrl: '/test.png',

--- a/packages/rainbowkit/src/wallets/connectorsForWallets.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.ts
@@ -76,10 +76,11 @@ export const connectorsForWallets = (walletList: WalletList) => {
             wallets: [
               // Note: We only expose a subset of fields
               // publicly to reduce API surface area
-              ...walletInstances.map(({ connector, id, installed }) => ({
+              ...walletInstances.map(({ connector, id, installed, name }) => ({
                 connector,
                 id,
                 installed,
+                name,
               })),
             ],
           });

--- a/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
@@ -20,6 +20,7 @@ export const injectedWallet = ({
     wallets.some(
       wallet =>
         wallet.installed &&
+        wallet.name === wallet.connector.name &&
         (wallet.connector instanceof InjectedConnector ||
           wallet.id === 'coinbase')
     ),

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -10,29 +10,21 @@ export interface MetaMaskWalletOptions {
   chains: Chain[];
 }
 
-function isMetaMask(ethereum: NonNullable<typeof window['ethereum']>) {
+function isMetaMask(ethereum?: typeof window['ethereum']): boolean {
   // Logic borrowed from wagmi's MetaMaskConnector
-  // https://github.com/tmm/wagmi/blob/main/packages/core/src/connectors/metaMask.ts
-  const isMetaMask = Boolean(ethereum.isMetaMask);
-
-  if (!isMetaMask) {
-    return false;
-  }
-
+  // https://github.com/wagmi-dev/references/blob/main/packages/connectors/src/metaMask.ts
+  const isMetaMask = !!ethereum?.isMetaMask;
+  if (!isMetaMask) return false;
   // Brave tries to make itself look like MetaMask
   // Could also try RPC `web3_clientVersion` if following is unreliable
-  if (ethereum.isBraveWallet && !ethereum._events && !ethereum._state) {
+  if (ethereum.isBraveWallet && !ethereum._events && !ethereum._state)
     return false;
-  }
-
-  if (ethereum.isTokenPocket) {
-    return false;
-  }
-
-  if (ethereum.isTokenary) {
-    return false;
-  }
-
+  if (ethereum.isApexWallet) return false;
+  if (ethereum.isAvalanche) return false;
+  if (ethereum.isKuCoinWallet) return false;
+  if (ethereum.isPortal) return false;
+  if (ethereum.isTokenPocket) return false;
+  if (ethereum.isTokenary) return false;
   return true;
 }
 


### PR DESCRIPTION
### Changes
- Added `name` param to `Wallet: hidden` to check against connector names
- `injectedWallet` now checks `wallet.name === wallet.connector.name` to determine visibility. Wagmi assigns `name` to `InjectedConnector` based on checks against `window.ethereum.provider` or `window.ethereum.provider` for wallets that use both `isMetaMask` and their own flag like `isRainbow`. This will display `Injected Wallet` fallback more aggressively when a wallet connector is unavailable.
- Improved test to pass through `name` and `chains` to InjectedConnector like RainbowKit's implementation
- Updated `isMetaMask` with latest Wagmi logic

### Tests
- MetaMask in Chrome
- Coinbase Wallet in Chrome
- Brave Browser Wallet
- MetaMask Mobile Browser
- KuCoin Wallet Browser