### PR TITLE
docs: update manual installation docs to include correct ethers version

### DIFF
--- a/site/data/docs/installation.mdx
+++ b/site/data/docs/installation.mdx
@@ -28,7 +28,7 @@ Alternatively, you can manually integrate RainbowKit into your existing project.
 Install RainbowKit and its peer dependencies, [wagmi](https://wagmi-xyz.vercel.app/) and [ethers](https://docs.ethers.io).
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi ethers
+npm install @rainbow-me/rainbowkit wagmi ethers@^5.0.0
 ```
 
 > Note: RainbowKit is a [React](https://reactjs.org/) library.

--- a/site/data/docs/installation.mdx
+++ b/site/data/docs/installation.mdx
@@ -28,7 +28,7 @@ Alternatively, you can manually integrate RainbowKit into your existing project.
 Install RainbowKit and its peer dependencies, [wagmi](https://wagmi-xyz.vercel.app/) and [ethers](https://docs.ethers.io).
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi ethers@^5.0.0
+npm install @rainbow-me/rainbowkit wagmi ethers@^5
 ```
 
 > Note: RainbowKit is a [React](https://reactjs.org/) library.


### PR DESCRIPTION
Running through the `Manual Installation` instructions on the official website leads to an issue where the dev server errors out saying it can't find module `fs`.

Comparing the result of the manual installation command and the `Quick Start` command, installing `ethers` without specifying a version leads to incompatibility. 

Installing `ethers: ^5.0.0` resolves the issue.

![Screenshot 2023-03-29 at 10 56 59 AM](https://user-images.githubusercontent.com/10948068/228626798-84eb578b-0c25-41f6-99f9-13a1d9e2ce54.png)
