### PR TITLE
fix: mobile walletconnect redirects

### DIFF
--- a/.changeset/eleven-kiwis-relax.md
+++ b/.changeset/eleven-kiwis-relax.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Fixed an issue that caused mobile WalletConnect redirects for signing hooks to fail in Wagmi 0.12.x

--- a/.changeset/eleven-kiwis-relax.md
+++ b/.changeset/eleven-kiwis-relax.md
@@ -2,4 +2,4 @@
 '@rainbow-me/rainbowkit': patch
 ---
 
-Fixed an issue that caused mobile WalletConnect redirects for signing hooks to fail in Wagmi 0.12.x
+Fixed an issue that caused mobile WalletConnect redirects for signing request hooks to fail in Wagmi 0.12.x

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -56,10 +56,7 @@ function WalletButton({ wallet }: { wallet: WalletConnector }) {
 
           if (getMobileUri) {
             const mobileUri = await getMobileUri();
-
-            if (connector.id === 'walletConnect') {
-              setWalletConnectDeepLink({ mobileUri, name });
-            }
+            setWalletConnectDeepLink({ mobileUri, name });
 
             if (mobileUri.startsWith('http')) {
               // Workaround for https://github.com/rainbow-me/rainbowkit/issues/524.

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -55,6 +55,12 @@ function WalletButton({ wallet }: { wallet: WalletConnector }) {
 
           if (getMobileUri) {
             const mobileUri = await getMobileUri();
+
+            // In Web3Modal, an equivalent setWalletConnectDeepLink routine gets called after
+            // successful connection and then the universal provider uses it on requests.
+            // We call it upon onConnecting; in the legacy provider, this was only required
+            // for the `walletConnect` fallback connector, but now appears to be required for all.
+            // https://github.com/WalletConnect/web3modal/blob/27f2b1fa2509130c5548061816c42d4596156e81/packages/core/src/utils/CoreUtil.ts#L72
             setWalletConnectDeepLink({ mobileUri, name });
 
             if (mobileUri.startsWith('http')) {

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -21,7 +21,6 @@ import * as styles from './MobileOptions.css';
 function WalletButton({ wallet }: { wallet: WalletConnector }) {
   const {
     connect,
-    connector,
     iconBackground,
     iconUrl,
     id,
@@ -78,7 +77,7 @@ function WalletButton({ wallet }: { wallet: WalletConnector }) {
             }
           }
         });
-      }, [connector, connect, getMobileUri, onConnecting, name])}
+      }, [connect, getMobileUri, onConnecting, name])}
       ref={coolModeRef}
       style={{ overflow: 'visible', textAlign: 'center' }}
       testId={`wallet-option-${id}`}


### PR DESCRIPTION
- Calling `setWalletConnectDeepLink` for all connectors on `onConnecting`
- This was previously only called for the `walletConnect` fallback connector, but a change in the `WalletConnectLegacyConnector` provider when upgrading from `ethereum-provider: 1.8.0 ` to `legacy-provider: 2.0.0` in Wagmi 0.12.x appears to have made it a requirement for all WalletConnect connectors.