### PR TITLE
feat: walletconnect cloud projectId

### DIFF
--- a/.changeset/chilled-mirrors-divide.md
+++ b/.changeset/chilled-mirrors-divide.md
@@ -1,6 +1,5 @@
 ---
 '@rainbow-me/rainbowkit': patch
-'@rainbow-me/create-rainbowkit': patch
 ---
 
 **Support for WalletConnect Cloud `projectId`**

--- a/.changeset/chilled-mirrors-divide.md
+++ b/.changeset/chilled-mirrors-divide.md
@@ -1,0 +1,36 @@
+---
+'@rainbow-me/rainbowkit': patch
+'@rainbow-me/create-rainbowkit': patch
+---
+
+**Support for WalletConnect Cloud `projectId`**
+
+Every dApp that relies on WalletConnect now needs to obtain a `projectId` from [WalletConnect Cloud](https://cloud.walletconnect.com/). This is absolutely free and only takes a few minutes.
+
+RainbowKit will enable WalletConnect v2 for supported wallets when `projectId` is specified. If `projectId` is unspecified, RainbowKit will quietly prefer WalletConnect v1.
+
+This must be completed before WalletConnect v1 bridge servers are shutdown on June 28, 2023.
+
+Provide the `projectId` to `getDefaultWallets` and individual RainbowKit wallet connectors like the following:
+
+```ts
+const projectId = 'YOUR_PROJECT_ID';
+
+const { wallets } = getDefaultWallets({
+  appName: 'My RainbowKit App',
+  projectId,
+  chains,
+});
+
+const connectors = connectorsForWallets([
+  ...wallets,
+  {
+    groupName: 'Other',
+    wallets: [
+      argentWallet({ projectId, chains }),
+      trustWallet({ projectId, chains }),
+      ledgerWallet({ projectId, chains }),
+    ],
+  },
+]);
+```

--- a/.changeset/rotten-monkeys-battle.md
+++ b/.changeset/rotten-monkeys-battle.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/create-rainbowkit': patch
+---
+
+Support for WalletConnect Cloud `projectId`

--- a/examples/with-create-react-app/src/index.tsx
+++ b/examples/with-create-react-app/src/index.tsx
@@ -24,6 +24,7 @@ const { chains, provider, webSocketProvider } = configureChains(
 
 const { connectors } = getDefaultWallets({
   appName: 'RainbowKit demo',
+  projectId: '',
   chains,
 });
 

--- a/examples/with-create-react-app/src/index.tsx
+++ b/examples/with-create-react-app/src/index.tsx
@@ -24,7 +24,7 @@ const { chains, provider, webSocketProvider } = configureChains(
 
 const { connectors } = getDefaultWallets({
   appName: 'RainbowKit demo',
-  projectId: '',
+  projectId: 'YOUR_PROJECT_ID',
   chains,
 });
 

--- a/examples/with-next-custom-button/pages/_app.tsx
+++ b/examples/with-next-custom-button/pages/_app.tsx
@@ -26,7 +26,7 @@ const { chains, provider, webSocketProvider } = configureChains(
   [publicProvider()]
 );
 
-const projectId = '';
+const projectId = 'YOUR_PROJECT_ID';
 
 const { wallets } = getDefaultWallets({
   appName: 'RainbowKit demo',

--- a/examples/with-next-custom-button/pages/_app.tsx
+++ b/examples/with-next-custom-button/pages/_app.tsx
@@ -26,8 +26,11 @@ const { chains, provider, webSocketProvider } = configureChains(
   [publicProvider()]
 );
 
+const projectId = '';
+
 const { wallets } = getDefaultWallets({
   appName: 'RainbowKit demo',
+  projectId,
   chains,
 });
 
@@ -40,9 +43,9 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Other',
     wallets: [
-      argentWallet({ chains }),
-      trustWallet({ chains }),
-      ledgerWallet({ chains }),
+      argentWallet({ projectId, chains }),
+      trustWallet({ projectId, chains }),
+      ledgerWallet({ projectId, chains }),
     ],
   },
 ]);

--- a/examples/with-next-mint-nft/pages/_app.tsx
+++ b/examples/with-next-mint-nft/pages/_app.tsx
@@ -43,8 +43,11 @@ const { chains, provider, webSocketProvider } = configureChains(
   [publicProvider()]
 );
 
+const projectId = '';
+
 const { wallets } = getDefaultWallets({
   appName: 'RainbowKit Mint NFT Demo',
+  projectId,
   chains,
 });
 
@@ -56,7 +59,10 @@ const connectors = connectorsForWallets([
   ...wallets,
   {
     groupName: 'Other',
-    wallets: [argentWallet({ chains }), trustWallet({ chains })],
+    wallets: [
+      argentWallet({ projectId, chains }),
+      trustWallet({ projectId, chains }),
+    ],
   },
 ]);
 

--- a/examples/with-next-mint-nft/pages/_app.tsx
+++ b/examples/with-next-mint-nft/pages/_app.tsx
@@ -43,7 +43,7 @@ const { chains, provider, webSocketProvider } = configureChains(
   [publicProvider()]
 );
 
-const projectId = '';
+const projectId = 'YOUR_PROJECT_ID';
 
 const { wallets } = getDefaultWallets({
   appName: 'RainbowKit Mint NFT Demo',

--- a/examples/with-next-siwe-iron-session/pages/_app.tsx
+++ b/examples/with-next-siwe-iron-session/pages/_app.tsx
@@ -33,7 +33,7 @@ const { chains, provider, webSocketProvider } = configureChains(
   [publicProvider()]
 );
 
-const projectId = '';
+const projectId = 'YOUR_PROJECT_ID';
 
 const { wallets } = getDefaultWallets({
   appName: 'RainbowKit demo',

--- a/examples/with-next-siwe-iron-session/pages/_app.tsx
+++ b/examples/with-next-siwe-iron-session/pages/_app.tsx
@@ -33,8 +33,11 @@ const { chains, provider, webSocketProvider } = configureChains(
   [publicProvider()]
 );
 
+const projectId = '';
+
 const { wallets } = getDefaultWallets({
   appName: 'RainbowKit demo',
+  projectId,
   chains,
 });
 
@@ -47,9 +50,9 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Other',
     wallets: [
-      argentWallet({ chains }),
-      trustWallet({ chains }),
-      ledgerWallet({ chains }),
+      argentWallet({ projectId, chains }),
+      trustWallet({ projectId, chains }),
+      ledgerWallet({ projectId, chains }),
     ],
   },
 ]);

--- a/examples/with-next-siwe-next-auth/pages/_app.tsx
+++ b/examples/with-next-siwe-next-auth/pages/_app.tsx
@@ -31,7 +31,7 @@ const { chains, provider, webSocketProvider } = configureChains(
   [publicProvider()]
 );
 
-const projectId = '';
+const projectId = 'YOUR_PROJECT_ID';
 
 const { wallets } = getDefaultWallets({
   appName: 'RainbowKit demo',

--- a/examples/with-next-siwe-next-auth/pages/_app.tsx
+++ b/examples/with-next-siwe-next-auth/pages/_app.tsx
@@ -31,8 +31,11 @@ const { chains, provider, webSocketProvider } = configureChains(
   [publicProvider()]
 );
 
+const projectId = '';
+
 const { wallets } = getDefaultWallets({
   appName: 'RainbowKit demo',
+  projectId,
   chains,
 });
 
@@ -45,9 +48,9 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Other',
     wallets: [
-      argentWallet({ chains }),
-      trustWallet({ chains }),
-      ledgerWallet({ chains }),
+      argentWallet({ projectId, chains }),
+      trustWallet({ projectId, chains }),
+      ledgerWallet({ projectId, chains }),
     ],
   },
 ]);

--- a/examples/with-next/pages/_app.tsx
+++ b/examples/with-next/pages/_app.tsx
@@ -26,7 +26,7 @@ const { chains, provider, webSocketProvider } = configureChains(
   [publicProvider()]
 );
 
-const projectId = '';
+const projectId = 'YOUR_PROJECT_ID';
 
 const { wallets } = getDefaultWallets({
   appName: 'RainbowKit demo',

--- a/examples/with-next/pages/_app.tsx
+++ b/examples/with-next/pages/_app.tsx
@@ -26,8 +26,11 @@ const { chains, provider, webSocketProvider } = configureChains(
   [publicProvider()]
 );
 
+const projectId = '';
+
 const { wallets } = getDefaultWallets({
   appName: 'RainbowKit demo',
+  projectId,
   chains,
 });
 
@@ -40,9 +43,9 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Other',
     wallets: [
-      argentWallet({ chains }),
-      trustWallet({ chains }),
-      ledgerWallet({ chains }),
+      argentWallet({ projectId, chains }),
+      trustWallet({ projectId, chains }),
+      ledgerWallet({ projectId, chains }),
     ],
   },
 ]);

--- a/examples/with-remix/app/root.tsx
+++ b/examples/with-remix/app/root.tsx
@@ -71,7 +71,7 @@ export default function App() {
 
     const { connectors } = getDefaultWallets({
       appName: 'RainbowKit Remix Example',
-      projectId: '',
+      projectId: 'YOUR_PROJECT_ID',
       chains,
     });
 

--- a/examples/with-remix/app/root.tsx
+++ b/examples/with-remix/app/root.tsx
@@ -71,6 +71,7 @@ export default function App() {
 
     const { connectors } = getDefaultWallets({
       appName: 'RainbowKit Remix Example',
+      projectId: '',
       chains,
     });
 

--- a/examples/with-vite/src/main.tsx
+++ b/examples/with-vite/src/main.tsx
@@ -16,7 +16,7 @@ const { chains, provider } = configureChains(
 
 const { connectors } = getDefaultWallets({
   appName: 'RainbowKit demo',
-  projectId: '',
+  projectId: 'YOUR_PROJECT_ID',
   chains,
 });
 

--- a/examples/with-vite/src/main.tsx
+++ b/examples/with-vite/src/main.tsx
@@ -16,6 +16,7 @@ const { chains, provider } = configureChains(
 
 const { connectors } = getDefaultWallets({
   appName: 'RainbowKit demo',
+  projectId: '',
   chains,
 });
 

--- a/packages/create-rainbowkit/generated-test-app/pages/_app.tsx
+++ b/packages/create-rainbowkit/generated-test-app/pages/_app.tsx
@@ -19,7 +19,7 @@ const { chains, provider, webSocketProvider } = configureChains(
 
 const { connectors } = getDefaultWallets({
   appName: 'RainbowKit App',
-  projectId: '',
+  projectId: 'YOUR_PROJECT_ID',
   chains,
 });
 

--- a/packages/create-rainbowkit/generated-test-app/pages/_app.tsx
+++ b/packages/create-rainbowkit/generated-test-app/pages/_app.tsx
@@ -19,6 +19,7 @@ const { chains, provider, webSocketProvider } = configureChains(
 
 const { connectors } = getDefaultWallets({
   appName: 'RainbowKit App',
+  projectId: '',
   chains,
 });
 

--- a/packages/create-rainbowkit/templates/next-app/pages/_app.tsx
+++ b/packages/create-rainbowkit/templates/next-app/pages/_app.tsx
@@ -19,7 +19,7 @@ const { chains, provider, webSocketProvider } = configureChains(
 
 const { connectors } = getDefaultWallets({
   appName: 'RainbowKit App',
-  projectId: '',
+  projectId: 'YOUR_PROJECT_ID',
   chains,
 });
 

--- a/packages/create-rainbowkit/templates/next-app/pages/_app.tsx
+++ b/packages/create-rainbowkit/templates/next-app/pages/_app.tsx
@@ -19,6 +19,7 @@ const { chains, provider, webSocketProvider } = configureChains(
 
 const { connectors } = getDefaultWallets({
   appName: 'RainbowKit App',
+  projectId: '',
   chains,
 });
 

--- a/packages/example/.env.local.example
+++ b/packages/example/.env.local.example
@@ -1,3 +1,6 @@
+NEXT_PUBLIC_ALCHEMY_ID= # Required for Alchemy provider
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID= # Required for WalletConnect v2
+
 NEXTAUTH_SECRET= # Mac/Linux: `openssl rand -hex 32` or go to https://generate-secret.now.sh/32
 NEXTAUTH_URL=http://localhost:3000
 

--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -72,9 +72,39 @@ const { chains, provider, webSocketProvider } = configureChains(
   ]
 );
 
+const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || '';
+
 const { wallets } = getDefaultWallets({
   appName: 'RainbowKit demo',
   chains,
+  projectId,
+});
+
+const connectors = connectorsForWallets([
+  ...wallets,
+  {
+    groupName: 'Other',
+    wallets: [
+      argentWallet({ chains, projectId }),
+      bitskiWallet({ chains }),
+      dawnWallet({ chains }),
+      imTokenWallet({ chains, projectId }),
+      ledgerWallet({ chains, projectId }),
+      mewWallet({ chains }),
+      okxWallet({ chains, projectId }),
+      omniWallet({ chains, projectId }),
+      tahoWallet({ chains }),
+      trustWallet({ chains, projectId }),
+      zerionWallet({ chains, projectId }),
+    ],
+  },
+]);
+
+const wagmiClient = createClient({
+  autoConnect: true,
+  connectors,
+  provider,
+  webSocketProvider,
 });
 
 const demoAppInfo = {
@@ -108,33 +138,6 @@ const CustomAvatar: AvatarComponent = ({ size }) => {
     </div>
   );
 };
-
-const connectors = connectorsForWallets([
-  ...wallets,
-  {
-    groupName: 'Other',
-    wallets: [
-      argentWallet({ chains }),
-      bitskiWallet({ chains }),
-      dawnWallet({ chains }),
-      imTokenWallet({ chains }),
-      ledgerWallet({ chains }),
-      mewWallet({ chains }),
-      okxWallet({ chains }),
-      omniWallet({ chains }),
-      tahoWallet({ chains }),
-      trustWallet({ chains }),
-      zerionWallet({ chains }),
-    ],
-  },
-]);
-
-const wagmiClient = createClient({
-  autoConnect: true,
-  connectors,
-  provider,
-  webSocketProvider,
-});
 
 const getSiweMessageOptions: GetSiweMessageOptions = () => ({
   statement: 'Sign in to the RainbowKit Demo',

--- a/packages/rainbowkit/src/wallets/getDefaultWallets.ts
+++ b/packages/rainbowkit/src/wallets/getDefaultWallets.ts
@@ -12,8 +12,10 @@ import { walletConnectWallet } from './walletConnectors/walletConnectWallet/wall
 export const getDefaultWallets = ({
   appName,
   chains,
+  projectId,
 }: {
   appName: string;
+  projectId?: string;
   chains: Chain[];
 }): {
   connectors: ReturnType<typeof connectorsForWallets>;
@@ -25,10 +27,10 @@ export const getDefaultWallets = ({
       wallets: [
         injectedWallet({ chains }),
         safeWallet({ chains }),
-        rainbowWallet({ chains }),
+        rainbowWallet({ chains, projectId }),
         coinbaseWallet({ appName, chains }),
-        metaMaskWallet({ chains }),
-        walletConnectWallet({ chains }),
+        metaMaskWallet({ chains, projectId }),
+        walletConnectWallet({ chains, projectId }),
         braveWallet({ chains }),
       ],
     },

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -29,10 +29,7 @@ export function getWalletConnectConnector({
   const options: WalletConnectConnectorOptions = {
     chains,
     options: {
-      projectId:
-        projectId ||
-        (process.env.WALLETCONNECT_PROJECT_ID as string) ||
-        (process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID as string),
+      projectId,
       qrcode,
     },
   };

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -1,13 +1,14 @@
+import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
 import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy';
 import { Chain } from '../components/RainbowKitProvider/RainbowKitChainContext';
 type SerializedOptions = string;
 const sharedConnectors = new Map<
   SerializedOptions,
-  WalletConnectLegacyConnector
+  WalletConnectConnector | WalletConnectLegacyConnector
 >();
 
 type WalletConnectConnectorOptions = ConstructorParameters<
-  typeof WalletConnectLegacyConnector
+  typeof WalletConnectConnector | typeof WalletConnectLegacyConnector
 >[0];
 
 function createConnector(options: WalletConnectConnectorOptions) {
@@ -18,14 +19,20 @@ function createConnector(options: WalletConnectConnectorOptions) {
 
 export function getWalletConnectConnector({
   chains,
+  projectId,
   qrcode = false,
 }: {
   chains: Chain[];
+  projectId?: string;
   qrcode?: boolean;
 }) {
   const options: WalletConnectConnectorOptions = {
     chains,
     options: {
+      projectId:
+        projectId ||
+        (process.env.WALLETCONNECT_PROJECT_ID as string) ||
+        (process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID as string),
       qrcode,
     },
   };

--- a/packages/rainbowkit/src/wallets/walletConnectors/argentWallet/argentWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/argentWallet/argentWallet.ts
@@ -5,10 +5,14 @@ import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface ArgentWalletOptions {
+  projectId?: string;
   chains: Chain[];
 }
 
-export const argentWallet = ({ chains }: ArgentWalletOptions): Wallet => ({
+export const argentWallet = ({
+  chains,
+  projectId,
+}: ArgentWalletOptions): Wallet => ({
   id: 'argent',
   name: 'Argent',
   iconUrl: async () => (await import('./argentWallet.svg')).default,
@@ -20,7 +24,7 @@ export const argentWallet = ({ chains }: ArgentWalletOptions): Wallet => ({
     qrCode: 'https://argent.link/app',
   },
   createConnector: () => {
-    const connector = getWalletConnectConnector({ chains });
+    const connector = getWalletConnectConnector({ projectId, chains });
 
     return {
       connector,

--- a/packages/rainbowkit/src/wallets/walletConnectors/imTokenWallet/imTokenWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/imTokenWallet/imTokenWallet.ts
@@ -4,10 +4,14 @@ import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface ImTokenWalletOptions {
+  projectId?: string;
   chains: Chain[];
 }
 
-export const imTokenWallet = ({ chains }: ImTokenWalletOptions): Wallet => ({
+export const imTokenWallet = ({
+  chains,
+  projectId,
+}: ImTokenWalletOptions): Wallet => ({
   id: 'imToken',
   name: 'imToken',
   iconUrl: async () => (await import('./imTokenWallet.svg')).default,
@@ -18,7 +22,7 @@ export const imTokenWallet = ({ chains }: ImTokenWalletOptions): Wallet => ({
     qrCode: 'https://token.im/download',
   },
   createConnector: () => {
-    const connector = getWalletConnectConnector({ chains });
+    const connector = getWalletConnectConnector({ projectId, chains });
 
     return {
       connector,

--- a/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
@@ -5,10 +5,14 @@ import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface LedgerWalletOptions {
+  projectId?: string;
   chains: Chain[];
 }
 
-export const ledgerWallet = ({ chains }: LedgerWalletOptions): Wallet => ({
+export const ledgerWallet = ({
+  chains,
+  projectId,
+}: LedgerWalletOptions): Wallet => ({
   id: 'ledger',
   iconBackground: '#000',
   name: 'Ledger Live',
@@ -19,7 +23,7 @@ export const ledgerWallet = ({ chains }: LedgerWalletOptions): Wallet => ({
     qrCode: 'https://www.ledger.com/ledger-live/download#download-device-2',
   },
   createConnector: () => {
-    const connector = getWalletConnectConnector({ chains });
+    const connector = getWalletConnectConnector({ projectId, chains });
 
     return {
       connector,

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -7,6 +7,7 @@ import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface MetaMaskWalletOptions {
+  projectId?: string;
   chains: Chain[];
 }
 
@@ -30,6 +31,7 @@ function isMetaMask(ethereum?: typeof window['ethereum']): boolean {
 
 export const metaMaskWallet = ({
   chains,
+  projectId,
   ...options
 }: MetaMaskWalletOptions & MetaMaskConnectorOptions): Wallet => {
   const isMetaMaskInjected =
@@ -55,7 +57,7 @@ export const metaMaskWallet = ({
     },
     createConnector: () => {
       const connector = shouldUseWalletConnect
-        ? getWalletConnectConnector({ chains })
+        ? getWalletConnectConnector({ projectId, chains })
         : new MetaMaskConnector({
             chains,
             options,

--- a/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
@@ -7,11 +7,13 @@ import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface OKXWalletOptions {
+  projectId?: string;
   chains: Chain[];
 }
 
 export const okxWallet = ({
   chains,
+  projectId,
   ...options
 }: OKXWalletOptions & InjectedConnectorOptions): Wallet => {
   // `isOkxWallet` or `isOKExWallet` needs to be added to the wagmi `Ethereum` object
@@ -38,7 +40,7 @@ export const okxWallet = ({
     },
     createConnector: () => {
       const connector = shouldUseWalletConnect
-        ? getWalletConnectConnector({ chains })
+        ? getWalletConnectConnector({ projectId, chains })
         : new InjectedConnector({
             chains,
             options: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/omniWallet/omniWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/omniWallet/omniWallet.ts
@@ -5,10 +5,14 @@ import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface OmniWalletOptions {
+  projectId?: string;
   chains: Chain[];
 }
 
-export const omniWallet = ({ chains }: OmniWalletOptions): Wallet => ({
+export const omniWallet = ({
+  chains,
+  projectId,
+}: OmniWalletOptions): Wallet => ({
   id: 'omni',
   name: 'Omni',
   iconUrl: async () => (await import('./omniWallet.svg')).default,
@@ -19,7 +23,7 @@ export const omniWallet = ({ chains }: OmniWalletOptions): Wallet => ({
     qrCode: 'https://omniwallet.app.link',
   },
   createConnector: () => {
-    const connector = getWalletConnectConnector({ chains });
+    const connector = getWalletConnectConnector({ projectId, chains });
 
     return {
       connector,

--- a/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
@@ -7,6 +7,7 @@ import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface RainbowWalletOptions {
+  projectId?: string;
   chains: Chain[];
 }
 
@@ -23,6 +24,7 @@ function isRainbow(ethereum: NonNullable<typeof window['ethereum']>) {
 
 export const rainbowWallet = ({
   chains,
+  projectId,
   ...options
 }: RainbowWalletOptions & InjectedConnectorOptions): Wallet => {
   const isRainbowInjected =
@@ -47,7 +49,7 @@ export const rainbowWallet = ({
     },
     createConnector: () => {
       const connector = shouldUseWalletConnect
-        ? getWalletConnectConnector({ chains })
+        ? getWalletConnectConnector({ projectId, chains })
         : new InjectedConnector({
             chains,
             options,

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -7,11 +7,13 @@ import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface TrustWalletOptions {
+  projectId?: string;
   chains: Chain[];
 }
 
 export const trustWallet = ({
   chains,
+  projectId,
   ...options
 }: TrustWalletOptions & InjectedConnectorOptions): Wallet => ({
   id: 'trust',
@@ -38,7 +40,7 @@ export const trustWallet = ({
       };
     }
 
-    const connector = getWalletConnectConnector({ chains });
+    const connector = getWalletConnectConnector({ projectId, chains });
 
     return {
       connector,

--- a/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.ts
@@ -5,11 +5,13 @@ import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface WalletConnectWalletOptions {
+  projectId?: string;
   chains: Chain[];
 }
 
 export const walletConnectWallet = ({
   chains,
+  projectId,
 }: WalletConnectWalletOptions): Wallet => ({
   id: 'walletConnect',
   name: 'WalletConnect',
@@ -19,6 +21,7 @@ export const walletConnectWallet = ({
     const ios = isIOS();
 
     const connector = getWalletConnectConnector({
+      projectId,
       chains,
       qrcode: ios,
     });

--- a/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
@@ -7,11 +7,13 @@ import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface ZerionWalletOptions {
+  projectId?: string;
   chains: Chain[];
 }
 
 export const zerionWallet = ({
   chains,
+  projectId,
   ...options
 }: ZerionWalletOptions & InjectedConnectorOptions): Wallet => {
   const isZerionInjected =
@@ -39,7 +41,7 @@ export const zerionWallet = ({
     },
     createConnector: () => {
       const connector = shouldUseWalletConnect
-        ? getWalletConnectConnector({ chains })
+        ? getWalletConnectConnector({ projectId, chains })
         : new InjectedConnector({
             chains,
             options: {

--- a/site/components/Provider/Provider.tsx
+++ b/site/components/Provider/Provider.tsx
@@ -23,9 +23,12 @@ export const { chains, provider } = configureChains(
   ]
 );
 
+const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || '';
+
 const { wallets } = getDefaultWallets({
   appName: 'rainbowkit.com',
   chains,
+  projectId,
 });
 
 const connectors = connectorsForWallets([
@@ -33,11 +36,11 @@ const connectors = connectorsForWallets([
   {
     groupName: 'More',
     wallets: [
-      argentWallet({ chains }),
-      trustWallet({ chains }),
-      omniWallet({ chains }),
-      imTokenWallet({ chains }),
-      ledgerWallet({ chains }),
+      argentWallet({ chains, projectId }),
+      trustWallet({ chains, projectId }),
+      omniWallet({ chains, projectId }),
+      imTokenWallet({ chains, projectId }),
+      ledgerWallet({ chains, projectId }),
     ],
   },
 ]);

--- a/site/data/docs/custom-chains.mdx
+++ b/site/data/docs/custom-chains.mdx
@@ -51,6 +51,7 @@ const { provider, chains } = configureChains(
 
 const { connectors } = getDefaultWallets({
   appName: 'My RainbowKit App',
+  projectId: 'YOUR_PROJECT_ID',
   chains,
 });
 

--- a/site/data/docs/custom-wallet-list.mdx
+++ b/site/data/docs/custom-wallet-list.mdx
@@ -37,8 +37,8 @@ const connectors = connectorsForWallets([
     groupName: 'Recommended',
     wallets: [
       injectedWallet({ chains }),
-      rainbowWallet({ chains }),
-      walletConnectWallet({ chains }),
+      rainbowWallet({ projectId, chains }),
+      walletConnectWallet({ projectId, chains }),
     ],
   },
 ]);
@@ -82,6 +82,7 @@ This is a fallback wallet option designed for WalletConnect-based wallets that h
 import { walletConnectWallet } from '@rainbow-me/rainbowkit/wallets';
 
 walletConnectWallet(options: {
+  projectId: string;
   chains: Chain[];
 });
 ```
@@ -110,6 +111,7 @@ The following wallets are provided via the `wallet` object (in alphabetical orde
 import { argentWallet } from '@rainbow-me/rainbowkit/wallets';
 
 argentWallet(options: {
+  projectId: string;
   chains: Chain[];
 });
 ```
@@ -150,7 +152,7 @@ coinbaseWallet(options: {
 ```tsx
 import { dawnWallet } from '@rainbow-me/rainbowkit/wallets';
 
-dawnWallet((options: {
+dawnWallet(options: {
   chains: Chain[];
 });
 ```
@@ -161,6 +163,7 @@ dawnWallet((options: {
 import { ledgerWallet } from '@rainbow-me/rainbowkit/wallets';
 
 ledgerWallet(options: {
+  projectId: string;
   chains: Chain[];
   infuraId?: string;
 });
@@ -172,6 +175,7 @@ ledgerWallet(options: {
 import { imTokenWallet } from '@rainbow-me/rainbowkit/wallets';
 
 imTokenWallet(options: {
+  projectId: string;
   chains: Chain[];
 });
 ```
@@ -182,6 +186,7 @@ imTokenWallet(options: {
 import { metaMaskWallet } from '@rainbow-me/rainbowkit/wallets';
 
 metaMaskWallet(options: {
+  projectId: string;
   chains: Chain[];
 });
 ```
@@ -201,6 +206,7 @@ mewWallet(options: {
 import { okxWallet } from '@rainbow-me/rainbowkit/wallets';
 
 okxWallet(options: {
+  projectId: string;
   chains: Chain[];
 });
 ```
@@ -211,6 +217,7 @@ okxWallet(options: {
 import { omniWallet } from '@rainbow-me/rainbowkit/wallets';
 
 omniWallet(options: {
+  projectId: string;
   chains: Chain[];
 });
 ```
@@ -221,6 +228,7 @@ omniWallet(options: {
 import { rainbowWallet } from '@rainbow-me/rainbowkit/wallets';
 
 rainbowWallet(options: {
+  projectId: string;
   chains: Chain[];
 });
 ```
@@ -251,6 +259,7 @@ tahoWallet(options: {
 import { trustWallet } from '@rainbow-me/rainbowkit/wallets';
 
 trustWallet(options: {
+  projectId: string;
   chains: Chain[];
 });
 ```
@@ -261,6 +270,7 @@ trustWallet(options: {
 import { zerionWallet } from '@rainbow-me/rainbowkit/wallets';
 
 zerionWallet(options: {
+  projectId: string;
   chains: Chain[];
 });
 ```
@@ -286,8 +296,8 @@ const connectors = connectorsForWallets([
     groupName: 'Recommended',
     wallets: [
       injectedWallet({ chains }),
-      metaMaskWallet({ chains }),
-      walletConnectWallet({ chains }),
+      metaMaskWallet({ projectId, chains }),
+      walletConnectWallet({ projectId, chains }),
     ],
   },
 ]);
@@ -310,10 +320,10 @@ const connectors = connectorsForWallets([
     groupName: 'Suggested',
     wallets: [
       injectedWallet({ chains }),
-      rainbowWallet({ chains }),
-      metaMaskWallet({ chains }),
+      rainbowWallet({ projectId, chains }),
+      metaMaskWallet({ projectId, chains }),
       coinbaseWallet({ chains, appName: 'My RainbowKit App' }),
-      walletConnectWallet({ chains }),
+      walletConnectWallet({ projectId, chains }),
     ],
   },
 ]);
@@ -342,15 +352,15 @@ const connectors = connectorsForWallets([
     groupName: 'Recommended',
     wallets: [
       injectedWallet({ chains }),
-      rainbowWallet({ chains }),
-      metaMaskWallet({ chains }),
+      rainbowWallet({ projectId, chains }),
+      metaMaskWallet({ projectId, chains }),
     ],
   },
   {
     groupName: 'Others',
     wallets: [
       coinbaseWallet({ chains, appName: 'My RainbowKit App' }),
-      walletConnectWallet({ chains }),
+      walletConnectWallet({ projectId, chains }),
     ],
   },
 ]);

--- a/site/data/docs/custom-wallets.mdx
+++ b/site/data/docs/custom-wallets.mdx
@@ -127,10 +127,14 @@ import {
 } from '@rainbow-me/rainbowkit';
 
 export interface MyWalletOptions {
+  projectId: string;
   chains: Chain[];
 }
 
-export const rainbow = ({ chains }: MyWalletOptions): Wallet => ({
+export const rainbow = ({
+  chains,
+  projectId,
+}: MyWalletOptions): Wallet => ({
   id: 'my-wallet',
   name: 'My Wallet',
   iconUrl: 'https://my-image.xyz',
@@ -141,7 +145,7 @@ export const rainbow = ({ chains }: MyWalletOptions): Wallet => ({
     qrCode: 'https://my-wallet/qr',
   },
   createConnector: () => {
-    const connector = getWalletConnectConnector({ chains });
+    const connector = getWalletConnectConnector({ projectId, chains });
 
     return {
       connector,

--- a/site/data/docs/installation.mdx
+++ b/site/data/docs/installation.mdx
@@ -54,6 +54,8 @@ import { publicProvider } from 'wagmi/providers/public';
 
 Configure your desired chains and generate the required connectors. You will also need to setup a `wagmi` client.
 
+> Note: Every dApp that relies on WalletConnect now needs to obtain a `projectId` from [WalletConnect Cloud](https://cloud.walletconnect.com/). This is absolutely free and only takes a few minutes.
+
 ```tsx line=4-99
 ...
 import { alchemyProvider } from 'wagmi/providers/alchemy';
@@ -69,6 +71,7 @@ const { chains, provider } = configureChains(
 
 const { connectors } = getDefaultWallets({
   appName: 'My RainbowKit App',
+  projectId: 'YOUR_PROJECT_ID',
   chains
 });
 

--- a/site/data/docs/migration-guide.mdx
+++ b/site/data/docs/migration-guide.mdx
@@ -14,12 +14,42 @@ RainbowKit has adopted the `WalletConnectLegacyConnector` connector in `wagmi` f
 
 Wallets will be transitioned automatically in future releases.
 
+Every dApp must now provide a [WalletConnect Cloud](https://cloud.walletconnect.com/) `projectId` to enable WalletConnect v2. This must be completed before WalletConnect v1 bridge servers are shutdown on June 28, 2023. RainbowKit will quietly prefer v1 for all wallets if `projectId` is unspecified.
+
 Follow the steps below to migrate.
 
 #### 1. Upgrade RainbowKit and `wagmi` to their latest version
 
 ```bash
 npm i @rainbow-me/rainbowkit@^0.12.0 wagmi@^0.12.0
+```
+
+#### 2. Supply a WalletConnect Cloud projectId
+
+Every dApp that relies on WalletConnect now needs to obtain a `projectId` from [WalletConnect Cloud](https://cloud.walletconnect.com/). This is absolutely free and only takes a few minutes.
+
+Provide the `projectId` to `getDefaultWallets` and individual RainbowKit wallet connectors like the following:
+
+```ts
+const projectId = 'YOUR_PROJECT_ID';
+
+const { wallets } = getDefaultWallets({
+  appName: 'My RainbowKit App',
+  projectId,
+  chains,
+});
+
+const connectors = connectorsForWallets([
+  ...wallets,
+  {
+    groupName: 'Other',
+    wallets: [
+      argentWallet({ projectId, chains }),
+      trustWallet({ projectId, chains }),
+      ledgerWallet({ projectId, chains }),
+    ],
+  },
+]);
 ```
 
 ### 0.11.x Breaking changes


### PR DESCRIPTION
**Support for WalletConnect Cloud `projectId`**

Every dApp that relies on WalletConnect now needs to obtain a `projectId` from [WalletConnect Cloud](https://cloud.walletconnect.com/). This is absolutely free and only takes a few minutes.

RainbowKit will enable WalletConnect v2 for supported wallets when `projectId` is specified. If `projectId` is unspecified, RainbowKit will quietly prefer WalletConnect v1.

This must be completed before WalletConnect v1 bridge servers are shutdown on June 28, 2023.

Provide the `projectId` to `getDefaultWallets` and individual RainbowKit wallet connectors like the following:

```ts
const projectId = 'YOUR_PROJECT_ID';

const { wallets } = getDefaultWallets({
  appName: 'My RainbowKit App',
  projectId,
  chains,
});

const connectors = connectorsForWallets([
  ...wallets,
  {
    groupName: 'Other',
    wallets: [
      argentWallet({ projectId, chains }),
      trustWallet({ projectId, chains }),
      ledgerWallet({ projectId, chains }),
    ],
  },
]);
```
