### PR TITLE
feat: walletconnect web3modal options

### DIFF
--- a/.changeset/hip-brooms-do.md
+++ b/.changeset/hip-brooms-do.md
@@ -1,0 +1,24 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Support for `options` customization for `walletConnectWallet`
+
+**Example usage**
+
+```tsx
+walletConnectWallet(options: {
+  projectId: string;
+  chains: Chain[];
+  options?: {
+    bridge?: string;
+    qrcode?: boolean;
+    qrcodeModalOptions?: {
+      desktopLinks?: string[];
+      mobileLinks: string[];
+    };
+  }
+});
+```
+
+Reference the [docs](https://www.rainbowkit.com/docs/custom-wallet-list#walletconnect) for additional supported options for Web3Modal v2.

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -27,10 +27,11 @@ type WalletConnectLegacyConnectorOptions =
 
 function createConnector(
   version: WalletConnectVersion,
-  options: WalletConnectLegacyConnectorConfig | WalletConnectConnectorConfig
+  config: WalletConnectLegacyConnectorConfig | WalletConnectConnectorConfig
 ) {
-  const connector = new WalletConnectLegacyConnector(options);
-  sharedConnectors.set(JSON.stringify(options), connector);
+  // ignoring `version` until v2 delayed uri fetch changes are merged
+  const connector = new WalletConnectLegacyConnector(config);
+  sharedConnectors.set(JSON.stringify(config), connector);
   return connector;
 }
 

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -7,7 +7,7 @@ import { Chain } from '../components/RainbowKitProvider/RainbowKitChainContext';
 type SerializedOptions = string;
 const sharedConnectors = new Map<
   SerializedOptions,
-  WalletConnectLegacyConnector
+  WalletConnectLegacyConnector | WalletConnectConnector
 >();
 
 type WalletConnectVersion = '1' | '2';

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -1,41 +1,82 @@
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable no-redeclare */
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
 import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy';
 import { Chain } from '../components/RainbowKitProvider/RainbowKitChainContext';
+
 type SerializedOptions = string;
 const sharedConnectors = new Map<
   SerializedOptions,
-  WalletConnectConnector | WalletConnectLegacyConnector
+  WalletConnectLegacyConnector
 >();
 
-type WalletConnectConnectorOptions = ConstructorParameters<
-  typeof WalletConnectConnector | typeof WalletConnectLegacyConnector
->[0];
+type WalletConnectVersion = '1' | '2';
 
-function createConnector(options: WalletConnectConnectorOptions) {
+type WalletConnectConnectorConfig = ConstructorParameters<
+  typeof WalletConnectConnector
+>[0];
+// @ts-ignore
+type WalletConnectConnectorOptions = WalletConnectConnectorConfig['options'];
+
+type WalletConnectLegacyConnectorConfig = ConstructorParameters<
+  typeof WalletConnectLegacyConnector
+>[0];
+type WalletConnectLegacyConnectorOptions =
+  // @ts-ignore
+  WalletConnectLegacyConnectorConfig['options'];
+
+function createConnector(
+  version: WalletConnectVersion,
+  options: WalletConnectLegacyConnectorConfig | WalletConnectConnectorConfig
+) {
   const connector = new WalletConnectLegacyConnector(options);
   sharedConnectors.set(JSON.stringify(options), connector);
   return connector;
 }
 
+export function getWalletConnectConnector(config: {
+  chains: Chain[];
+  projectId?: string; // to prepare for migration to v2
+  options?: WalletConnectLegacyConnectorOptions;
+}): WalletConnectLegacyConnector;
+
+export function getWalletConnectConnector(config: {
+  version: '1';
+  chains: Chain[];
+  options?: WalletConnectLegacyConnectorOptions;
+}): WalletConnectLegacyConnector;
+
+export function getWalletConnectConnector(config: {
+  version: '2';
+  chains: Chain[];
+  projectId: string;
+  options?: WalletConnectConnectorOptions;
+}): WalletConnectConnector;
+
 export function getWalletConnectConnector({
   chains,
+  options = {},
   projectId,
   qrcode = false,
+  version = '1',
 }: {
   chains: Chain[];
   projectId?: string;
   qrcode?: boolean;
-}) {
-  const options: WalletConnectConnectorOptions = {
+  version?: WalletConnectVersion;
+  options?: WalletConnectLegacyConnectorOptions | WalletConnectConnectorOptions;
+}): any {
+  const config = {
     chains,
     options: {
       projectId,
       qrcode,
+      ...options,
     },
   };
 
-  const serializedOptions = JSON.stringify(options);
-  const sharedConnector = sharedConnectors.get(serializedOptions);
+  const serializedConfig = JSON.stringify(config);
+  const sharedConnector = sharedConnectors.get(serializedConfig);
 
-  return sharedConnector ?? createConnector(options);
+  return sharedConnector ?? createConnector(version, config);
 }

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -57,12 +57,10 @@ export function getWalletConnectConnector({
   chains,
   options = {},
   projectId,
-  qrcode = false,
   version = '1',
 }: {
   chains: Chain[];
   projectId?: string;
-  qrcode?: boolean;
   version?: WalletConnectVersion;
   options?: WalletConnectLegacyConnectorOptions | WalletConnectConnectorOptions;
 }): any {
@@ -70,7 +68,6 @@ export function getWalletConnectConnector({
     chains,
     options: {
       projectId,
-      qrcode,
       ...options,
     },
   };

--- a/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.ts
@@ -21,9 +21,12 @@ export const walletConnectWallet = ({
     const ios = isIOS();
 
     const connector = getWalletConnectConnector({
-      projectId,
+      version: '1',
       chains,
-      qrcode: ios,
+      options: {
+        qrcode: ios,
+        projectId,
+      },
     });
 
     const getUri = async () => (await connector.getProvider()).connector.uri;

--- a/site/data/docs/custom-wallet-list.mdx
+++ b/site/data/docs/custom-wallet-list.mdx
@@ -84,8 +84,20 @@ import { walletConnectWallet } from '@rainbow-me/rainbowkit/wallets';
 walletConnectWallet(options: {
   projectId: string;
   chains: Chain[];
+  options?: {
+    bridge?: string;
+    qrcode?: boolean;
+    qrcodeModalOptions?: {
+      desktopLinks?: string[];
+      mobileLinks: string[];
+    };
+  }
 });
 ```
+
+Additional documentation for supported `options` can be found [here](https://docs.walletconnect.com/1.0/quick-start/dapps/web3-provider#optional).
+
+In preparation for the migration to WalletConnect v2, the `options` for Web3Modal v2 are also supported. Reference the [Ethereum Provider docs](https://docs.walletconnect.com/2.0/javascript/providers/ethereum#initialization). The required `projectId` is automatically pre-populated by RainbowKit.
 
 ##### Injected Wallet
 


### PR DESCRIPTION
- `options` param on `walletConnectWallet`
- removed explicit `qrcode` param in `getWalletConnectConnector` in favor of `options`
- overload functions for v1 and v2 typed option support in `getWalletConnectConnector`
- doc site changes for new options and additional information about v2 transition