### PR TITLE
fix: qrcode defaults for walletconnect connectors

### DIFF
--- a/.changeset/lemon-eggs-bake.md
+++ b/.changeset/lemon-eggs-bake.md
@@ -1,0 +1,22 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Support for `options` customization for `walletConnectWallet`
+
+**Example usage**
+
+```tsx
+walletConnectWallet(options: {
+  projectId: string;
+  chains: Chain[];
+  options?: {
+    qrcodeModalOptions?: {
+      desktopLinks?: string[];
+      mobileLinks?: string[];
+    };
+  }
+});
+```
+
+Reference the [docs](https://www.rainbowkit.com/docs/custom-wallet-list#walletconnect) for additional supported options.

--- a/packages/rainbowkit/CHANGELOG.md
+++ b/packages/rainbowkit/CHANGELOG.md
@@ -2,27 +2,6 @@
 
 ## 0.12.11
 
-### Patch Changes
-
-- 0469e00: Support for `options` customization for `walletConnectWallet`
-
-  **Example usage**
-
-  ```tsx
-  walletConnectWallet(options: {
-    projectId: string;
-    chains: Chain[];
-    options?: {
-      qrcodeModalOptions?: {
-        desktopLinks?: string[];
-        mobileLinks?: string[];
-      };
-    }
-  });
-  ```
-
-  Reference the [docs](https://www.rainbowkit.com/docs/custom-wallet-list#walletconnect) for additional supported options.
-
 ## 0.12.10
 
 ## 0.12.9

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.test.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.test.ts
@@ -18,6 +18,10 @@ describe('getWalletConnectConnector', () => {
       expect(connector.id).toBe('walletConnectLegacy');
       expectTypeOf(connector).toMatchTypeOf<WalletConnectLegacyConnector>();
     });
+    it('qrcode defaults', () => {
+      const connector = getWalletConnectConnector({ chains });
+      expect(connector.options.qrcode).toBe(false);
+    });
   });
 
   describe("version '1'", () => {
@@ -28,6 +32,7 @@ describe('getWalletConnectConnector', () => {
       });
       expect(connector.id).toBe('walletConnectLegacy');
       expectTypeOf(connector).toMatchTypeOf<WalletConnectLegacyConnector>();
+      expect(connector.options.qrcode).toBe(false);
     });
     it('with options', () => {
       const connector = getWalletConnectConnector({
@@ -43,6 +48,7 @@ describe('getWalletConnectConnector', () => {
       });
       expect(connector.id).toBe('walletConnectLegacy');
       expectTypeOf(connector).toMatchTypeOf<WalletConnectLegacyConnector>();
+      expect(connector.options.qrcode).toBe(true);
     });
   });
 

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -70,6 +70,7 @@ export function getWalletConnectConnector({
     chains,
     options: {
       projectId,
+      qrcode: false,
       ...options,
     },
   };


### PR DESCRIPTION
Default `qrcode` to `false` to fix regression that triggered Web3Modal to display for wallet connectors that didn't implement `getWalletConnectConnector` `options`