### PR TITLE
Add ledger extension

### DIFF
--- a/.changeset/gold-apples-shave.md
+++ b/.changeset/gold-apples-shave.md
@@ -1,0 +1,9 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+**Added support for the Ledger Extension to the Ledger connector**
+
+Users just need to be on a platform supported by the Extension, which
+currently is Safari on macOS and iOS, and connecting to Ethereum Mainnet or
+Polygon and the Extension will be used instead of Ledger Live.

--- a/.changeset/wise-doors-give.md
+++ b/.changeset/wise-doors-give.md
@@ -1,0 +1,42 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+**Improved desktop app download support**
+
+RainbowKit wallet connectors now support a desktop download link and desktop
+app instructions.
+
+dApps that utilize the Custom Wallets API can reference the updated docs
+[here](https://www.rainbowkit.com/docs/custom-wallets).
+
+```ts
+{
+  downloadUrls: {
+    desktop: 'https://my-wallet/desktop-app',
+  }
+}
+```
+
+There is a new 'connect' step on the instructions that shows a connect button
+you can use after installing the app.
+
+```ts
+return {
+  connector,
+  desktop: {
+    getUri,
+    instructions: {
+      learnMoreUrl: 'https://my-wallet/learn-more',
+      steps: [
+        // ...
+        {
+          description: 'Connect to wallet'
+          step: 'connect',
+          title: 'Connect',
+        }
+      ]
+    },
+  },
+}
+```

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -26,6 +26,7 @@ import {
   DownloadDetail,
   DownloadOptionsDetail,
   GetDetail,
+  InstructionDesktopDetail,
   InstructionExtensionDetail,
   InstructionMobileDetail,
 } from './ConnectDetails';
@@ -43,6 +44,7 @@ export enum WalletStep {
   DownloadOptions = 'DOWNLOAD_OPTIONS',
   Download = 'DOWNLOAD',
   InstructionsMobile = 'INSTRUCTIONS_MOBILE',
+  InstructionsDesktop = 'INSTRUCTIONS_DESKTOP',
   InstructionsExtension = 'INSTRUCTIONS_EXTENSION',
 }
 
@@ -144,12 +146,15 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
     setSelectedOptionId(id);
     const sWallet = wallets.find(w => id === w.id);
     const isMobile = sWallet?.downloadUrls?.qrCode;
+    const isDesktop = !!sWallet?.desktopDownloadUrl;
     const isExtension = !!sWallet?.extensionDownloadUrl;
     setSelectedWallet(sWallet);
-    if (isMobile && isExtension) {
+    if (isMobile && (isExtension || isDesktop)) {
       changeWalletStep(WalletStep.DownloadOptions);
     } else if (isMobile) {
       changeWalletStep(WalletStep.Download);
+    } else if (isDesktop) {
+      changeWalletStep(WalletStep.InstructionsDesktop);
     } else {
       changeWalletStep(WalletStep.InstructionsExtension);
     }
@@ -285,6 +290,22 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
     case WalletStep.InstructionsExtension:
       walletContent = selectedWallet && (
         <InstructionExtensionDetail wallet={selectedWallet} />
+      );
+      headerLabel =
+        selectedWallet &&
+        `Get started with ${
+          compactModeEnabled
+            ? selectedWallet.shortName || selectedWallet.name
+            : selectedWallet.name
+        }`;
+      headerBackButtonLink = WalletStep.DownloadOptions;
+      break;
+    case WalletStep.InstructionsDesktop:
+      walletContent = selectedWallet && (
+        <InstructionDesktopDetail
+          connectWallet={selectWallet}
+          wallet={selectedWallet}
+        />
       );
       headerLabel =
         selectedWallet &&

--- a/packages/rainbowkit/src/utils/browsers.ts
+++ b/packages/rainbowkit/src/utils/browsers.ts
@@ -1,6 +1,9 @@
 export function isSafari(): boolean {
   return (
     typeof navigator !== 'undefined' &&
+    !/fxios\//i.test(navigator.userAgent) && // exclude Firefox on iOS
+    !/opt\//i.test(navigator.userAgent) && // exclude Opera on iOS
+    !/edgios\//i.test(navigator.userAgent) && // exclude Edge on iOS
     /Version\/([0-9._]+).*Safari/.test(navigator.userAgent) // Source: https://github.com/DamonOehlman/detect-browser/blob/master/src/index.ts
   );
 }

--- a/packages/rainbowkit/src/wallets/Wallet.ts
+++ b/packages/rainbowkit/src/wallets/Wallet.ts
@@ -1,6 +1,11 @@
 import { Connector } from 'wagmi';
 
-export type InstructionStepName = 'install' | 'create' | 'scan' | 'refresh';
+export type InstructionStepName =
+  | 'install'
+  | 'create'
+  | 'scan'
+  | 'connect'
+  | 'refresh';
 
 type RainbowKitConnector<C extends Connector = Connector> = {
   connector: C;
@@ -9,6 +14,14 @@ type RainbowKitConnector<C extends Connector = Connector> = {
   };
   desktop?: {
     getUri?: () => Promise<string>;
+    instructions?: {
+      learnMoreUrl: string;
+      steps: {
+        step: InstructionStepName;
+        title: string;
+        description: string;
+      }[];
+    };
   };
   qrCode?: {
     getUri: () => Promise<string>;
@@ -45,6 +58,7 @@ export type Wallet<C extends Connector = Connector> = {
     android?: string;
     ios?: string;
     mobile?: string;
+    desktop?: string;
     qrCode?: string;
     chrome?: string;
     edge?: string;

--- a/packages/rainbowkit/src/wallets/downloadUrls.ts
+++ b/packages/rainbowkit/src/wallets/downloadUrls.ts
@@ -27,3 +27,7 @@ export const getMobileDownloadUrl = (wallet?: WalletInstance) => {
     wallet?.downloadUrls?.mobile
   );
 };
+
+export const getDesktopDownloadUrl = (wallet?: WalletInstance) => {
+  return wallet?.downloadUrls?.desktop;
+};

--- a/packages/rainbowkit/src/wallets/useWalletConnectors.ts
+++ b/packages/rainbowkit/src/wallets/useWalletConnectors.ts
@@ -7,7 +7,11 @@ import {
   useRainbowKitChains,
 } from './../components/RainbowKitProvider/RainbowKitChainContext';
 import { WalletInstance } from './Wallet';
-import { getExtensionDownloadUrl, getMobileDownloadUrl } from './downloadUrls';
+import {
+  getDesktopDownloadUrl,
+  getExtensionDownloadUrl,
+  getMobileDownloadUrl,
+} from './downloadUrls';
 import { addRecentWalletId, getRecentWalletIds } from './recentWalletIds';
 
 export interface WalletConnector extends WalletInstance {
@@ -18,6 +22,7 @@ export interface WalletConnector extends WalletInstance {
   recent: boolean;
   mobileDownloadUrl?: string;
   extensionDownloadUrl?: string;
+  desktopDownloadUrl?: string;
 }
 
 export function useWalletConnectors(): WalletConnector[] {
@@ -106,6 +111,7 @@ export function useWalletConnectors(): WalletConnector[] {
         wallet.connector.showQrModal
           ? connectToWalletConnectModal(wallet.id, wallet.connector)
           : connectWallet(wallet.id, wallet.connector),
+      desktopDownloadUrl: getDesktopDownloadUrl(wallet),
       extensionDownloadUrl: getExtensionDownloadUrl(wallet),
       groupName: wallet.groupName,
       mobileDownloadUrl: getMobileDownloadUrl(wallet),

--- a/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
@@ -1,15 +1,39 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
+import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
+import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
+import { isSafari } from '../../../utils/browsers';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
-import { isAndroid } from '../../../utils/isMobile';
+import { isAndroid, isIOS } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
-import { getWalletConnectConnector } from '../../getWalletConnectConnector';
-import type {
+import {
+  getWalletConnectConnector,
   WalletConnectConnectorOptions,
   WalletConnectLegacyConnectorOptions,
 } from '../../getWalletConnectConnector';
 
-const LEDGERLIVE_WEB_URL = 'https://www.ledger.com/ledger-live';
+interface ExtensionProvider {
+  isLedgerConnect: boolean;
+  chainId: string;
+}
+
+interface WindowWithEthereum {
+  ethereum: ExtensionProvider;
+}
+
+enum ExtensionSupportedChains {
+  EthereumMainnet = 1,
+  Polygon = 137,
+}
+
+const EXTENSION_WEB_URL = 'https://ledger.com/ledger-extension';
+const EXTENSION_APPLE_URL =
+  'https://apps.apple.com/app/ledger-extension-browse-web3/id1627727841';
+const LEDGERLIVE_WEB_URL = 'https://ledger.com/ledger-live';
+const LEDGERLIVE_ANDROID_URL =
+  'https://play.google.com/store/apps/details?id=com.ledger.live';
+const LEDGERLIVE_APPLE_URL =
+  'https://apps.apple.com/us/app/ledger-live-web3-wallet/id1361671700';
 
 export interface LedgerWalletLegacyOptions {
   projectId?: string;
@@ -30,100 +54,184 @@ export const ledgerWallet = ({
   projectId,
   walletConnectOptions,
   walletConnectVersion = '2',
-}: LedgerWalletLegacyOptions | LedgerWalletOptions): Wallet => ({
-  id: 'ledger',
-  iconBackground: '#000',
-  iconAccent: '#000',
-  name: 'Ledger Live',
-  iconUrl: async () => (await import('./ledgerWallet.svg')).default,
-  downloadUrls: {
-    android: 'https://play.google.com/store/apps/details?id=com.ledger.live',
-    ios: 'https://apps.apple.com/us/app/ledger-live-web3-wallet/id1361671700',
-    mobile: LEDGERLIVE_WEB_URL,
-    desktop: LEDGERLIVE_WEB_URL,
-    qrCode: LEDGERLIVE_WEB_URL,
-  },
-  createConnector: () => {
-    const connector = getWalletConnectConnector({
-      projectId,
-      chains,
-      version: walletConnectVersion,
-      options: walletConnectOptions,
-    });
+  ...options
+}:
+  | (LedgerWalletLegacyOptions | LedgerWalletOptions) &
+      InjectedConnectorOptions): Wallet => {
+  const initialChainId = chains[0].id;
+  const isExtensionSupported = isSafari();
+  const isInitialChainSupported = !!ExtensionSupportedChains[initialChainId];
+  const isExtensionEnabled = !!(
+    typeof window !== 'undefined' &&
+    (window as unknown as WindowWithEthereum).ethereum?.isLedgerConnect
+  );
 
-    return {
-      connector,
-      mobile: {
-        getUri: async () => {
-          const uri = await getWalletConnectUri(
-            connector,
-            walletConnectVersion
-          );
-          return isAndroid()
-            ? uri
-            : `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+  // only use extension if the first chain is supported
+  const shouldUseExtension = isExtensionSupported && isInitialChainSupported;
+
+  return {
+    id: 'ledger',
+    iconBackground: '#000',
+    iconAccent: '#000',
+    name: 'Ledger',
+    iconUrl: async () => (await import('./ledgerWallet.svg')).default,
+    downloadUrls: shouldUseExtension
+      ? {
+          // shown on Safari macOS
+          safari: EXTENSION_APPLE_URL,
+          // shown on Safari iOS/iPadOS
+          ios: EXTENSION_APPLE_URL,
+        }
+      : {
+          // shown on desktop when the Extension is not supported
+          desktop: LEDGERLIVE_WEB_URL,
+          // shown on Android and iOS when the Extension is not supported
+          android: LEDGERLIVE_ANDROID_URL,
+          ios: LEDGERLIVE_APPLE_URL,
+          // shown on desktop as a QR code when the Extension is not supported
+          qrCode: LEDGERLIVE_WEB_URL,
         },
-      },
-      desktop: {
-        getUri: async () => {
-          const uri = await getWalletConnectUri(
-            connector,
-            walletConnectVersion
-          );
-          return `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+    createConnector: () => {
+      // return the WC connector if the Extension is not enabled on iOS so
+      // that the Ledger button is always shown, even though we will return
+      // the Extension install link and not the WC URI in that case
+      const connector = shouldUseExtension
+        ? !isExtensionEnabled && isIOS()
+          ? getWalletConnectConnector({
+              projectId,
+              chains,
+              version: walletConnectVersion,
+              options: walletConnectOptions,
+            })
+          : new InjectedConnector({ chains, options })
+        : getWalletConnectConnector({
+            projectId,
+            chains,
+            version: walletConnectVersion,
+            options: walletConnectOptions,
+          });
+
+      return {
+        connector,
+        mobile: {
+          getUri: async () => {
+            if (shouldUseExtension) {
+              if (!isExtensionEnabled && isIOS()) {
+                // return the Extension install URL so that clicking the Ledger
+                // button on iOS when the Extension is not enabled takes users
+                // to the App Store
+                return EXTENSION_APPLE_URL;
+              }
+
+              // return undefined on Safari macOS or when the extension is enabled
+              // return undefined;
+            }
+
+            const uri = await getWalletConnectUri(
+              connector,
+              walletConnectVersion
+            );
+            return isAndroid()
+              ? uri
+              : `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+          },
         },
-        instructions: {
-          learnMoreUrl: LEDGERLIVE_WEB_URL,
-          steps: [
-            {
-              description:
-                'We recommend putting Ledger Live on your home screen for quicker',
-              step: 'install',
-              title: 'Open the Ledger Live app',
-            },
-            {
-              description: 'Set up a new Ledger or connect to an existing one.',
-              step: 'create',
-              title: 'Set up your Ledger',
-            },
-            {
-              description:
-                'A connection prompt will appear for you to connect your wallet.',
-              step: 'connect',
-              title: 'Connect',
-            },
-          ],
+        desktop: {
+          getUri: shouldUseExtension
+            ? undefined
+            : async () => {
+                const uri = await getWalletConnectUri(
+                  connector,
+                  walletConnectVersion
+                );
+                return `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+              },
+          instructions: {
+            learnMoreUrl: LEDGERLIVE_WEB_URL,
+            steps: [
+              {
+                description:
+                  'We recommend putting Ledger Live on your home screen for quicker access.',
+                step: 'install',
+                title: 'Open the Ledger Live app',
+              },
+              {
+                description:
+                  'Set up a new Ledger or connect to an existing one.',
+                step: 'create',
+                title: 'Set up your Ledger',
+              },
+              {
+                description:
+                  'A connection prompt will appear for you to connect your wallet.',
+                step: 'connect',
+                title: 'Connect',
+              },
+            ],
+          },
         },
-      },
-      qrCode: {
-        getUri: async () => {
-          const { uri } = (await connector.getProvider()).connector;
-          return `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+        qrCode: {
+          getUri: async () => {
+            if (isExtensionSupported) {
+              return '';
+            } else {
+              const uri = await getWalletConnectUri(
+                connector,
+                walletConnectVersion
+              );
+              return `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+            }
+          },
+          instructions: {
+            learnMoreUrl: LEDGERLIVE_WEB_URL,
+            steps: [
+              {
+                description:
+                  'We recommend putting Ledger Live on your home screen for quicker access.',
+                step: 'install',
+                title: 'Open the Ledger Live app',
+              },
+              {
+                description:
+                  'You can either sync with the desktop app or connect your Ledger.',
+                step: 'create',
+                title: 'Set up your Ledger',
+              },
+              {
+                description:
+                  'Tap WalletConnect then Switch to Scanner. After you scan, a connection prompt will appear for you to connect your wallet.',
+                step: 'scan',
+                title: 'Scan the code',
+              },
+            ],
+          },
         },
-        instructions: {
-          learnMoreUrl: LEDGERLIVE_WEB_URL,
-          steps: [
-            {
-              description:
-                'We recommend putting Ledger Live on your home screen for quicker access.',
-              step: 'install',
-              title: 'Open the Ledger Live app',
-            },
-            {
-              description:
-                'You can either sync with the desktop app or connect your Ledger.',
-              step: 'create',
-              title: 'Set up your Ledger',
-            },
-            {
-              description:
-                'Tap WalletConnect then Switch to Scanner. After you scan, a connection prompt will appear for you to connect your wallet.',
-              step: 'scan',
-              title: 'Scan the code',
-            },
-          ],
+        extension: {
+          instructions: {
+            learnMoreUrl: EXTENSION_WEB_URL,
+            steps: [
+              {
+                description:
+                  'Select Safari from the menu bar and then Preferences, or Settings. Select Extensions. Check the box next to Ledger Extension.',
+                step: 'install',
+                title: 'Activate the Ledger Extension',
+              },
+              {
+                description:
+                  'Click on the Ledger logo located on the left of the URL bar. Select "Always Allow on Every Website". The Ledger logo should turn blue.',
+                step: 'create',
+                title: 'Allow Safari Permissions',
+              },
+              {
+                description:
+                  'Make sure vour device is unlocked with the Ethereum app installed and opened. Click below to refresh the browser and load up the extension.',
+                step: 'refresh',
+                title: 'Connect your Ledger & Refresh',
+              },
+            ],
+          },
         },
-      },
-    };
-  },
-});
+      };
+    },
+  };
+};

--- a/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
@@ -9,6 +9,8 @@ import type {
   WalletConnectLegacyConnectorOptions,
 } from '../../getWalletConnectConnector';
 
+const LEDGERLIVE_WEB_URL = 'https://www.ledger.com/ledger-live';
+
 export interface LedgerWalletLegacyOptions {
   projectId?: string;
   chains: Chain[];
@@ -31,13 +33,15 @@ export const ledgerWallet = ({
 }: LedgerWalletLegacyOptions | LedgerWalletOptions): Wallet => ({
   id: 'ledger',
   iconBackground: '#000',
+  iconAccent: '#000',
   name: 'Ledger Live',
   iconUrl: async () => (await import('./ledgerWallet.svg')).default,
   downloadUrls: {
     android: 'https://play.google.com/store/apps/details?id=com.ledger.live',
     ios: 'https://apps.apple.com/us/app/ledger-live-web3-wallet/id1361671700',
-    mobile: 'https://www.ledger.com/ledger-live',
-    qrCode: 'https://ledger.com/ledger-live',
+    mobile: LEDGERLIVE_WEB_URL,
+    desktop: LEDGERLIVE_WEB_URL,
+    qrCode: LEDGERLIVE_WEB_URL,
   },
   createConnector: () => {
     const connector = getWalletConnectConnector({
@@ -67,6 +71,57 @@ export const ledgerWallet = ({
             walletConnectVersion
           );
           return `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+        },
+        instructions: {
+          learnMoreUrl: LEDGERLIVE_WEB_URL,
+          steps: [
+            {
+              description:
+                'We recommend putting Ledger Live on your home screen for quicker',
+              step: 'install',
+              title: 'Open the Ledger Live app',
+            },
+            {
+              description: 'Set up a new Ledger or connect to an existing one.',
+              step: 'create',
+              title: 'Set up your Ledger',
+            },
+            {
+              description:
+                'A connection prompt will appear for you to connect your wallet.',
+              step: 'connect',
+              title: 'Connect',
+            },
+          ],
+        },
+      },
+      qrCode: {
+        getUri: async () => {
+          const { uri } = (await connector.getProvider()).connector;
+          return `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+        },
+        instructions: {
+          learnMoreUrl: LEDGERLIVE_WEB_URL,
+          steps: [
+            {
+              description:
+                'We recommend putting Ledger Live on your home screen for quicker access.',
+              step: 'install',
+              title: 'Open the Ledger Live app',
+            },
+            {
+              description:
+                'You can either sync with the desktop app or connect your Ledger.',
+              step: 'create',
+              title: 'Set up your Ledger',
+            },
+            {
+              description:
+                'Tap WalletConnect then Switch to Scanner. After you scan, a connection prompt will appear for you to connect your wallet.',
+              step: 'scan',
+              title: 'Scan the code',
+            },
+          ],
         },
       },
     };

--- a/site/data/docs/custom-wallets.mdx
+++ b/site/data/docs/custom-wallets.mdx
@@ -121,6 +121,12 @@ The `Wallet` function type is provided to help you define your own custom wallet
         'Landing page for users that scan the mobile download QR Code',
     },
     {
+      name: 'desktop',
+      required: false,
+      type: 'string',
+      description: 'Landing page for desktop users',
+    },
+    {
       name: 'chrome',
       required: false,
       type: 'string',


### PR DESCRIPTION
This PR is based on #1233, which should be merged first.

Adds support for the Ledger Extension to the Ledger connector when on Safari.

- shows Ledger Extension install link
- shows instructions after install
- pops up the Extension when enabled
- falls back to WalletConnect and Ledger Live on platforms that don't support the Extension, or when the first chain is not supported by the Extension

demo here: https://64a4448e617de90084cc00a4--ledger-rainbowkit-demo.netlify.app/

![image](https://github.com/rainbow-me/rainbowkit/assets/106091551/5315e2f1-8518-471d-9a26-6afca936c531)
![image](https://github.com/rainbow-me/rainbowkit/assets/106091551/7c16fcc7-68cb-427a-870d-ec07386845b0)
![image](https://github.com/rainbow-me/rainbowkit/assets/106091551/b9851ec1-4a70-46be-b0c1-10c2dd5f75e7)
