### PR TITLE
chore: upgrade wagmi and viem

### DIFF
--- a/.changeset/shiny-elephants-decide.md
+++ b/.changeset/shiny-elephants-decide.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Modified acceptable peer dependency versions to ensure proper peer warnings for future versions of wagmi and viem. `wagmi` now requires `~1.0.1` and `viem` now requires `~0.3.19`. 

--- a/.changeset/shiny-elephants-decide.md
+++ b/.changeset/shiny-elephants-decide.md
@@ -2,4 +2,4 @@
 '@rainbow-me/rainbowkit': patch
 ---
 
-Modified acceptable peer dependency versions to ensure proper peer warnings for future versions of wagmi and viem. `wagmi` now requires `~1.0.1` and `viem` now requires `~0.3.19`. 
+Modified acceptable peer dependency versions to ensure proper peer warnings for future versions of wagmi and viem. `wagmi` now requires `~1.0.1` and `viem` now requires `~0.3.19`.

--- a/examples/with-create-react-app/package.json
+++ b/examples/with-create-react-app/package.json
@@ -16,7 +16,7 @@
     "typescript": "^5.0.4",
     "util": "0.12.4",
     "viem": "~0.3.33",
-    "wagmi": "^1.0.5",
+    "wagmi": "~1.0.5",
     "web-vitals": "^2.1.4",
     "buffer": "npm:buffer@6.0.3"
   },

--- a/examples/with-create-react-app/package.json
+++ b/examples/with-create-react-app/package.json
@@ -15,7 +15,7 @@
     "react": "^18.2.0",
     "typescript": "^5.0.4",
     "util": "0.12.4",
-    "viem": "~0.3.26",
+    "viem": "~0.3.29",
     "wagmi": "^1.0.5",
     "web-vitals": "^2.1.4",
     "buffer": "npm:buffer@6.0.3"

--- a/examples/with-create-react-app/package.json
+++ b/examples/with-create-react-app/package.json
@@ -15,7 +15,7 @@
     "react": "^18.2.0",
     "typescript": "^5.0.4",
     "util": "0.12.4",
-    "viem": "~0.3.29",
+    "viem": "~0.3.33",
     "wagmi": "^1.0.5",
     "web-vitals": "^2.1.4",
     "buffer": "npm:buffer@6.0.3"

--- a/examples/with-create-react-app/package.json
+++ b/examples/with-create-react-app/package.json
@@ -15,7 +15,7 @@
     "react": "^18.2.0",
     "typescript": "^5.0.4",
     "util": "0.12.4",
-    "viem": "~0.3.33",
+    "viem": "~0.3.35",
     "wagmi": "~1.0.5",
     "web-vitals": "^2.1.4",
     "buffer": "npm:buffer@6.0.3"

--- a/examples/with-create-react-app/package.json
+++ b/examples/with-create-react-app/package.json
@@ -15,8 +15,8 @@
     "react": "^18.2.0",
     "typescript": "^5.0.4",
     "util": "0.12.4",
-    "viem": "~0.3.19",
-    "wagmi": "^1.0.1",
+    "viem": "~0.3.26",
+    "wagmi": "^1.0.5",
     "web-vitals": "^2.1.4",
     "buffer": "npm:buffer@6.0.3"
   },

--- a/examples/with-next-custom-button/package.json
+++ b/examples/with-next-custom-button/package.json
@@ -13,8 +13,8 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.19",
-    "wagmi": "^1.0.1"
+    "viem": "~0.3.26",
+    "wagmi": "^1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next-custom-button/package.json
+++ b/examples/with-next-custom-button/package.json
@@ -13,7 +13,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.29",
+    "viem": "~0.3.33",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next-custom-button/package.json
+++ b/examples/with-next-custom-button/package.json
@@ -14,7 +14,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "viem": "~0.3.33",
-    "wagmi": "^1.0.5"
+    "wagmi": "~1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next-custom-button/package.json
+++ b/examples/with-next-custom-button/package.json
@@ -13,7 +13,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.33",
+    "viem": "~0.3.35",
     "wagmi": "~1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next-custom-button/package.json
+++ b/examples/with-next-custom-button/package.json
@@ -13,7 +13,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.26",
+    "viem": "~0.3.29",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next-mint-nft/package.json
+++ b/examples/with-next-mint-nft/package.json
@@ -14,7 +14,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.33",
+    "viem": "~0.3.35",
     "wagmi": "~1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next-mint-nft/package.json
+++ b/examples/with-next-mint-nft/package.json
@@ -14,7 +14,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.26",
+    "viem": "~0.3.29",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next-mint-nft/package.json
+++ b/examples/with-next-mint-nft/package.json
@@ -14,7 +14,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.29",
+    "viem": "~0.3.33",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next-mint-nft/package.json
+++ b/examples/with-next-mint-nft/package.json
@@ -14,8 +14,8 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.19",
-    "wagmi": "^1.0.1"
+    "viem": "~0.3.26",
+    "wagmi": "^1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next-mint-nft/package.json
+++ b/examples/with-next-mint-nft/package.json
@@ -15,7 +15,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "viem": "~0.3.33",
-    "wagmi": "^1.0.5"
+    "wagmi": "~1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next-siwe-iron-session/package.json
+++ b/examples/with-next-siwe-iron-session/package.json
@@ -16,7 +16,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
-    "viem": "~0.3.33",
+    "viem": "~0.3.35",
     "wagmi": "~1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next-siwe-iron-session/package.json
+++ b/examples/with-next-siwe-iron-session/package.json
@@ -16,8 +16,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
-    "viem": "~0.3.19",
-    "wagmi": "^1.0.1"
+    "viem": "~0.3.26",
+    "wagmi": "^1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next-siwe-iron-session/package.json
+++ b/examples/with-next-siwe-iron-session/package.json
@@ -16,7 +16,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
-    "viem": "~0.3.26",
+    "viem": "~0.3.29",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next-siwe-iron-session/package.json
+++ b/examples/with-next-siwe-iron-session/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
     "viem": "~0.3.33",
-    "wagmi": "^1.0.5"
+    "wagmi": "~1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next-siwe-iron-session/package.json
+++ b/examples/with-next-siwe-iron-session/package.json
@@ -16,7 +16,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
-    "viem": "~0.3.29",
+    "viem": "~0.3.33",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next-siwe-next-auth/package.json
+++ b/examples/with-next-siwe-next-auth/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
-    "viem": "~0.3.26",
+    "viem": "~0.3.29",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next-siwe-next-auth/package.json
+++ b/examples/with-next-siwe-next-auth/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
     "viem": "~0.3.33",
-    "wagmi": "^1.0.5"
+    "wagmi": "~1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next-siwe-next-auth/package.json
+++ b/examples/with-next-siwe-next-auth/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
-    "viem": "~0.3.29",
+    "viem": "~0.3.33",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next-siwe-next-auth/package.json
+++ b/examples/with-next-siwe-next-auth/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
-    "viem": "~0.3.33",
+    "viem": "~0.3.35",
     "wagmi": "~1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next-siwe-next-auth/package.json
+++ b/examples/with-next-siwe-next-auth/package.json
@@ -17,8 +17,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
-    "viem": "~0.3.19",
-    "wagmi": "^1.0.1"
+    "viem": "~0.3.26",
+    "wagmi": "^1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next/package.json
+++ b/examples/with-next/package.json
@@ -13,8 +13,8 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.19",
-    "wagmi": "^1.0.1"
+    "viem": "~0.3.26",
+    "wagmi": "^1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next/package.json
+++ b/examples/with-next/package.json
@@ -13,7 +13,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.29",
+    "viem": "~0.3.33",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next/package.json
+++ b/examples/with-next/package.json
@@ -14,7 +14,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "viem": "~0.3.33",
-    "wagmi": "^1.0.5"
+    "wagmi": "~1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/examples/with-next/package.json
+++ b/examples/with-next/package.json
@@ -13,7 +13,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.33",
+    "viem": "~0.3.35",
     "wagmi": "~1.0.5"
   },
   "devDependencies": {

--- a/examples/with-next/package.json
+++ b/examples/with-next/package.json
@@ -13,7 +13,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.26",
+    "viem": "~0.3.29",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-remix/package.json
+++ b/examples/with-remix/package.json
@@ -18,7 +18,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "viem": "~0.3.33",
-    "wagmi": "^1.0.5"
+    "wagmi": "~1.0.5"
   },
   "devDependencies": {
     "@remix-run/dev": "^1.5.1",

--- a/examples/with-remix/package.json
+++ b/examples/with-remix/package.json
@@ -17,7 +17,7 @@
     "buffer-polyfill": "npm:buffer@^6.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.33",
+    "viem": "~0.3.35",
     "wagmi": "~1.0.5"
   },
   "devDependencies": {

--- a/examples/with-remix/package.json
+++ b/examples/with-remix/package.json
@@ -17,7 +17,7 @@
     "buffer-polyfill": "npm:buffer@^6.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.29",
+    "viem": "~0.3.33",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-remix/package.json
+++ b/examples/with-remix/package.json
@@ -17,8 +17,8 @@
     "buffer-polyfill": "npm:buffer@^6.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.19",
-    "wagmi": "^1.0.1"
+    "viem": "~0.3.26",
+    "wagmi": "^1.0.5"
   },
   "devDependencies": {
     "@remix-run/dev": "^1.5.1",

--- a/examples/with-remix/package.json
+++ b/examples/with-remix/package.json
@@ -17,7 +17,7 @@
     "buffer-polyfill": "npm:buffer@^6.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.26",
+    "viem": "~0.3.29",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-vite/package.json
+++ b/examples/with-vite/package.json
@@ -12,7 +12,7 @@
     "buffer": "^6.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.26",
+    "viem": "~0.3.29",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-vite/package.json
+++ b/examples/with-vite/package.json
@@ -12,7 +12,7 @@
     "buffer": "^6.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.33",
+    "viem": "~0.3.35",
     "wagmi": "~1.0.5"
   },
   "devDependencies": {

--- a/examples/with-vite/package.json
+++ b/examples/with-vite/package.json
@@ -12,7 +12,7 @@
     "buffer": "^6.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.29",
+    "viem": "~0.3.33",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/examples/with-vite/package.json
+++ b/examples/with-vite/package.json
@@ -12,8 +12,8 @@
     "buffer": "^6.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.19",
-    "wagmi": "^1.0.1"
+    "viem": "~0.3.26",
+    "wagmi": "^1.0.5"
   },
   "devDependencies": {
     "@types/react": "^18.0.9",

--- a/examples/with-vite/package.json
+++ b/examples/with-vite/package.json
@@ -13,7 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "viem": "~0.3.33",
-    "wagmi": "^1.0.5"
+    "wagmi": "~1.0.5"
   },
   "devDependencies": {
     "@types/react": "^18.0.9",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@typescript-eslint/parser": "^5.5.0",
     "@vanilla-extract/esbuild-plugin": "^2.2.0",
     "@vanilla-extract/vite-plugin": "^3.8.0",
-    "@wagmi/core": "^1.0.5",
+    "@wagmi/core": "~1.0.5",
     "autoprefixer": "^10.4.0",
     "esbuild": "^0.14.39",
     "eslint": "7.32.0",
@@ -79,7 +79,7 @@
     "typescript": "^5.0.4",
     "vitest": "^0.30.0",
     "ethers": "^5.6.8",
-    "wagmi": "^1.0.5",
+    "wagmi": "~1.0.5",
     "viem": "~0.3.33"
   },
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "vitest": "^0.30.0",
     "ethers": "^5.6.8",
     "wagmi": "^1.0.5",
-    "viem": "~0.3.26"
+    "viem": "~0.3.29"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "vitest": "^0.30.0",
     "ethers": "^5.6.8",
     "wagmi": "^1.0.5",
-    "viem": "~0.3.29"
+    "viem": "~0.3.33"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "vitest": "^0.30.0",
     "ethers": "^5.6.8",
     "wagmi": "~1.0.5",
-    "viem": "~0.3.33"
+    "viem": "~0.3.35"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@typescript-eslint/parser": "^5.5.0",
     "@vanilla-extract/esbuild-plugin": "^2.2.0",
     "@vanilla-extract/vite-plugin": "^3.8.0",
-    "@wagmi/core": "^1.0.1",
+    "@wagmi/core": "^1.0.5",
     "autoprefixer": "^10.4.0",
     "esbuild": "^0.14.39",
     "eslint": "7.32.0",
@@ -79,8 +79,8 @@
     "typescript": "^5.0.4",
     "vitest": "^0.30.0",
     "ethers": "^5.6.8",
-    "wagmi": "^1.0.1",
-    "viem": "~0.3.19"
+    "wagmi": "^1.0.5",
+    "viem": "~0.3.26"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/create-rainbowkit/generated-test-app/package.json
+++ b/packages/create-rainbowkit/generated-test-app/package.json
@@ -13,8 +13,8 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.19",
-    "wagmi": "^1.0.1"
+    "viem": "~0.3.26",
+    "wagmi": "^1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/packages/create-rainbowkit/generated-test-app/package.json
+++ b/packages/create-rainbowkit/generated-test-app/package.json
@@ -13,7 +13,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.29",
+    "viem": "~0.3.33",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/packages/create-rainbowkit/generated-test-app/package.json
+++ b/packages/create-rainbowkit/generated-test-app/package.json
@@ -14,7 +14,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "viem": "~0.3.33",
-    "wagmi": "^1.0.5"
+    "wagmi": "~1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/packages/create-rainbowkit/generated-test-app/package.json
+++ b/packages/create-rainbowkit/generated-test-app/package.json
@@ -13,7 +13,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.33",
+    "viem": "~0.3.35",
     "wagmi": "~1.0.5"
   },
   "devDependencies": {

--- a/packages/create-rainbowkit/generated-test-app/package.json
+++ b/packages/create-rainbowkit/generated-test-app/package.json
@@ -13,7 +13,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.26",
+    "viem": "~0.3.29",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/packages/create-rainbowkit/templates/next-app/package.json
+++ b/packages/create-rainbowkit/templates/next-app/package.json
@@ -13,8 +13,8 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.19",
-    "wagmi": "^1.0.1"
+    "viem": "~0.3.26",
+    "wagmi": "^1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/packages/create-rainbowkit/templates/next-app/package.json
+++ b/packages/create-rainbowkit/templates/next-app/package.json
@@ -13,7 +13,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.29",
+    "viem": "~0.3.33",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/packages/create-rainbowkit/templates/next-app/package.json
+++ b/packages/create-rainbowkit/templates/next-app/package.json
@@ -14,7 +14,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "viem": "~0.3.33",
-    "wagmi": "^1.0.5"
+    "wagmi": "~1.0.5"
   },
   "devDependencies": {
     "@types/node": "^17.0.35",

--- a/packages/create-rainbowkit/templates/next-app/package.json
+++ b/packages/create-rainbowkit/templates/next-app/package.json
@@ -13,7 +13,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.33",
+    "viem": "~0.3.35",
     "wagmi": "~1.0.5"
   },
   "devDependencies": {

--- a/packages/create-rainbowkit/templates/next-app/package.json
+++ b/packages/create-rainbowkit/templates/next-app/package.json
@@ -13,7 +13,7 @@
     "next": "^12.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "viem": "~0.3.26",
+    "viem": "~0.3.29",
     "wagmi": "^1.0.5"
   },
   "devDependencies": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -13,7 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
-    "viem": "~0.3.33"
+    "viem": "~0.3.35"
   },
   "peerDependencies": {
     "wagmi": "~1.0.5"

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -13,7 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
-    "viem": "~0.3.29"
+    "viem": "~0.3.33"
   },
   "peerDependencies": {
     "wagmi": "^1.0.5"

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -13,7 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
-    "viem": "~0.3.26"
+    "viem": "~0.3.29"
   },
   "peerDependencies": {
     "wagmi": "^1.0.5"

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -16,7 +16,7 @@
     "viem": "~0.3.33"
   },
   "peerDependencies": {
-    "wagmi": "^1.0.5"
+    "wagmi": "~1.0.5"
   },
   "scripts": {
     "dev": "next dev",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -13,10 +13,10 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "siwe": "^2.1.4",
-    "viem": "~0.3.19"
+    "viem": "~0.3.26"
   },
   "peerDependencies": {
-    "wagmi": "^1.0.1"
+    "wagmi": "^1.0.5"
   },
   "scripts": {
     "dev": "next dev",

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -52,7 +52,7 @@
     "@vanilla-extract/private": "^1.0.3",
     "@vanilla-extract/css-utils": "0.1.2",
     "autoprefixer": "^10.4.0",
-    "viem": "~0.3.29",
+    "viem": "~0.3.33",
     "wagmi": "^1.0.5",
     "nock": "^13.2.4",
     "postcss": "^8.4.4",

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -52,7 +52,7 @@
     "@vanilla-extract/private": "^1.0.3",
     "@vanilla-extract/css-utils": "0.1.2",
     "autoprefixer": "^10.4.0",
-    "viem": "~0.3.26",
+    "viem": "~0.3.29",
     "wagmi": "^1.0.5",
     "nock": "^13.2.4",
     "postcss": "^8.4.4",

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -44,8 +44,8 @@
   "peerDependencies": {
     "react": ">=17",
     "react-dom": ">=17",
-    "viem": "0.3.x",
-    "wagmi": "1.0.x"
+    "viem": "~0.3.19",
+    "wagmi": "~1.0.1"
   },
   "devDependencies": {
     "@types/qrcode": "^1.4.2",

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -53,7 +53,7 @@
     "@vanilla-extract/css-utils": "0.1.2",
     "autoprefixer": "^10.4.0",
     "viem": "~0.3.33",
-    "wagmi": "^1.0.5",
+    "wagmi": "~1.0.5",
     "nock": "^13.2.4",
     "postcss": "^8.4.4",
     "react": "^18.2.0",

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -42,17 +42,18 @@
   "author": "Rainbow",
   "license": "MIT",
   "peerDependencies": {
-    "viem": "~0.3.19",
     "react": ">=17",
     "react-dom": ">=17",
-    "wagmi": "^1.0.1"
+    "viem": "0.3.x",
+    "wagmi": "1.0.x"
   },
   "devDependencies": {
     "@types/qrcode": "^1.4.2",
     "@vanilla-extract/private": "^1.0.3",
     "@vanilla-extract/css-utils": "0.1.2",
     "autoprefixer": "^10.4.0",
-    "viem": "~0.3.19",
+    "viem": "~0.3.26",
+    "wagmi": "^1.0.5",
     "nock": "^13.2.4",
     "postcss": "^8.4.4",
     "react": "^18.2.0",

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -52,7 +52,7 @@
     "@vanilla-extract/private": "^1.0.3",
     "@vanilla-extract/css-utils": "0.1.2",
     "autoprefixer": "^10.4.0",
-    "viem": "~0.3.33",
+    "viem": "~0.3.35",
     "wagmi": "~1.0.5",
     "nock": "^13.2.4",
     "postcss": "^8.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         specifier: ^3.8.0
         version: 3.8.0(@types/node@17.0.35)(vite@2.9.9)
       '@wagmi/core':
-        specifier: ^1.0.5
+        specifier: ~1.0.5
         version: 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
       autoprefixer:
         specifier: ^10.4.0
@@ -125,7 +125,7 @@ importers:
         specifier: ^0.30.0
         version: 0.30.0
       wagmi:
-        specifier: ^1.0.5
+        specifier: ~1.0.5
         version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
 
   examples/with-create-react-app:
@@ -372,7 +372,7 @@ importers:
         specifier: ~0.3.33
         version: 0.3.33(typescript@5.0.4)
       wagmi:
-        specifier: ^1.0.5
+        specifier: ~1.0.5
         version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
 
   packages/rainbowkit:
@@ -427,7 +427,7 @@ importers:
         specifier: ^0.30.0
         version: 0.30.0
       wagmi:
-        specifier: ^1.0.5
+        specifier: ~1.0.5
         version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
 
   packages/rainbowkit-siwe-next-auth:
@@ -545,7 +545,7 @@ importers:
         specifier: ~0.3.33
         version: 0.3.33(typescript@5.0.4)
       wagmi:
-        specifier: ^1.0.5
+        specifier: ~1.0.5
         version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
     devDependencies:
       contentlayer:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         version: 3.8.0(@types/node@17.0.35)(vite@2.9.9)
       '@wagmi/core':
         specifier: ~1.0.5
-        version: 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
+        version: 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.35)
       autoprefixer:
         specifier: ^10.4.0
         version: 10.4.0(postcss@8.4.6)
@@ -119,14 +119,14 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4
       viem:
-        specifier: ~0.3.33
-        version: 0.3.33(typescript@5.0.4)
+        specifier: ~0.3.35
+        version: 0.3.35(typescript@5.0.4)
       vitest:
         specifier: ^0.30.0
         version: 0.30.0
       wagmi:
         specifier: ~1.0.5
-        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.35)
 
   examples/with-create-react-app:
     dependencies:
@@ -369,11 +369,11 @@ importers:
         specifier: ^2.1.4
         version: 2.1.4(ethers@5.6.8)
       viem:
-        specifier: ~0.3.33
-        version: 0.3.33(typescript@5.0.4)
+        specifier: ~0.3.35
+        version: 0.3.35(typescript@5.0.4)
       wagmi:
         specifier: ~1.0.5
-        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.35)
 
   packages/rainbowkit:
     dependencies:
@@ -421,14 +421,14 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       viem:
-        specifier: ~0.3.33
-        version: 0.3.33(typescript@5.0.4)
+        specifier: ~0.3.35
+        version: 0.3.35(typescript@5.0.4)
       vitest:
         specifier: ^0.30.0
         version: 0.30.0
       wagmi:
         specifier: ~1.0.5
-        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.35)
 
   packages/rainbowkit-siwe-next-auth:
     dependencies:
@@ -542,11 +542,11 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       viem:
-        specifier: ~0.3.33
-        version: 0.3.33(typescript@5.0.4)
+        specifier: ~0.3.35
+        version: 0.3.35(typescript@5.0.4)
       wagmi:
         specifier: ~1.0.5
-        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.35)
     devDependencies:
       contentlayer:
         specifier: 0.2.8
@@ -8023,7 +8023,7 @@ packages:
     dependencies:
       typescript: 5.0.4
 
-  /@wagmi/connectors@1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33):
+  /@wagmi/connectors@1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.35):
     resolution: {integrity: sha512-5uB+dUDop8s9scdE+S4IhgcfP8oRwdULVvpJ2MusDp+C00+OgvS3SnwZM6+Pjc9tyj5pi143zqsYtDynxFrMEA==}
     peerDependencies:
       '@wagmi/chains': '>=0.2.23'
@@ -8046,7 +8046,7 @@ packages:
       abitype: 0.8.1(typescript@5.0.4)
       eventemitter3: 4.0.7
       typescript: 5.0.4
-      viem: 0.3.33(typescript@5.0.4)
+      viem: 0.3.35(typescript@5.0.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil
@@ -8058,7 +8058,7 @@ packages:
       - utf-8-validate
       - zod
 
-  /@wagmi/core@1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.33):
+  /@wagmi/core@1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.35):
     resolution: {integrity: sha512-n8Y84WJkofGjhd4a+vpZzPPEQiHnkIGMe0uHOXfkm4eKJZyaJqvVJFPMWE6xFJkk0hxZ+1zw5xn0ZhdroHwHvg==}
     peerDependencies:
       typescript: '>=4.9.4'
@@ -8068,11 +8068,11 @@ packages:
         optional: true
     dependencies:
       '@wagmi/chains': 0.2.23(typescript@5.0.4)
-      '@wagmi/connectors': 1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
+      '@wagmi/connectors': 1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.35)
       abitype: 0.8.1(typescript@5.0.4)
       eventemitter3: 4.0.7
       typescript: 5.0.4
-      viem: 0.3.33(typescript@5.0.4)
+      viem: 0.3.35(typescript@5.0.4)
       zustand: 4.3.8(react@18.2.0)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
@@ -21223,8 +21223,8 @@ packages:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
-  /viem@0.3.33(typescript@5.0.4):
-    resolution: {integrity: sha512-ITB7wiYIWMxSyOQePPVa+6YcCrQiBLY/S758iZcjIZFqyqF8i/9PBhAPiqbiUrdfydaqjjRtWR1PAaXlMxmgtg==}
+  /viem@0.3.35(typescript@5.0.4):
+    resolution: {integrity: sha512-r9GrjAwY5BAehRAMSDJQGpPWGM6sKbAftb3GVny/rLCdjjtK4Zz2B3HOcjOQEM7jo+3LfPWSd85rBkNEpWntiA==}
     dependencies:
       '@adraffy/ens-normalize': 1.9.0
       '@noble/curves': 1.0.0
@@ -21420,7 +21420,7 @@ packages:
       xml-name-validator: 3.0.0
     dev: false
 
-  /wagmi@1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33):
+  /wagmi@1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.35):
     resolution: {integrity: sha512-XsLhNPTD7c+QXaA9elMwDihvcNHBw4Jcu0S/otkn3N4FgWIUVSQGiUYwm3AQrm/UhON0+Q8Y3ICzxB47PSr46g==}
     peerDependencies:
       react: '>=17.0.0'
@@ -21433,12 +21433,12 @@ packages:
       '@tanstack/query-sync-storage-persister': 4.29.5
       '@tanstack/react-query': 4.29.5(react-dom@18.2.0)(react@18.2.0)
       '@tanstack/react-query-persist-client': 4.29.5(@tanstack/react-query@4.29.5)
-      '@wagmi/core': 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
+      '@wagmi/core': 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.35)
       abitype: 0.8.1(typescript@5.0.4)
       react: 18.2.0
       typescript: 5.0.4
       use-sync-external-store: 1.2.0(react@18.2.0)
-      viem: 0.3.33(typescript@5.0.4)
+      viem: 0.3.35(typescript@5.0.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
         specifier: ^3.8.0
         version: 3.8.0(@types/node@17.0.35)(vite@2.9.9)
       '@wagmi/core':
-        specifier: ^1.0.1
-        version: 1.0.1(react@18.2.0)(typescript@5.0.4)(viem@0.3.19)
+        specifier: ^1.0.5
+        version: 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
       autoprefixer:
         specifier: ^10.4.0
         version: 10.4.0(postcss@8.4.6)
@@ -119,14 +119,14 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4
       viem:
-        specifier: ~0.3.19
-        version: 0.3.19(typescript@5.0.4)
+        specifier: ~0.3.26
+        version: 0.3.26(typescript@5.0.4)
       vitest:
         specifier: ^0.30.0
         version: 0.30.0
       wagmi:
-        specifier: ^1.0.1
-        version: 1.0.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.19)
+        specifier: ^1.0.5
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
 
   examples/with-create-react-app:
     dependencies:
@@ -369,11 +369,11 @@ importers:
         specifier: ^2.1.4
         version: 2.1.4(ethers@5.6.8)
       viem:
-        specifier: ~0.3.19
-        version: 0.3.19(typescript@5.0.4)
+        specifier: ~0.3.26
+        version: 0.3.26(typescript@5.0.4)
       wagmi:
-        specifier: ^1.0.1
-        version: 1.0.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.19)
+        specifier: ^1.0.5
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
 
   packages/rainbowkit:
     dependencies:
@@ -398,9 +398,6 @@ importers:
       react-remove-scroll:
         specifier: 2.5.4
         version: 2.5.4(@types/react@18.0.9)(react@18.2.0)
-      wagmi:
-        specifier: ^1.0.1
-        version: 1.0.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.19)
     devDependencies:
       '@types/qrcode':
         specifier: ^1.4.2
@@ -424,11 +421,14 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       viem:
-        specifier: ~0.3.19
-        version: 0.3.19(typescript@5.0.4)
+        specifier: ~0.3.26
+        version: 0.3.26(typescript@5.0.4)
       vitest:
         specifier: ^0.30.0
         version: 0.30.0
+      wagmi:
+        specifier: ^1.0.5
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
 
   packages/rainbowkit-siwe-next-auth:
     dependencies:
@@ -542,11 +542,11 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       viem:
-        specifier: ~0.3.19
-        version: 0.3.19(typescript@5.0.4)
+        specifier: ~0.3.26
+        version: 0.3.26(typescript@5.0.4)
       wagmi:
-        specifier: ^1.0.1
-        version: 1.0.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.19)
+        specifier: ^1.0.5
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
     devDependencies:
       contentlayer:
         specifier: 0.2.8
@@ -4810,7 +4810,7 @@ packages:
     engines: {node: ^8.13.0 || >=10.10.0}
     dependencies:
       '@grpc/proto-loader': 0.7.7
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
     dev: true
 
   /@grpc/proto-loader@0.6.13:
@@ -4881,7 +4881,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -4893,7 +4893,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       chalk: 4.1.2
       jest-message-util: 28.1.3
       jest-util: 28.1.3
@@ -4951,7 +4951,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       jest-mock: 27.5.1
     dev: false
 
@@ -4961,7 +4961,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -4990,7 +4990,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -5103,7 +5103,7 @@ packages:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: false
@@ -7012,7 +7012,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       '@types/responselike': 1.0.0
     dev: true
 
@@ -7036,7 +7036,7 @@ packages:
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
 
   /@types/content-disposition@0.5.5:
     resolution: {integrity: sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA==}
@@ -7124,13 +7124,13 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
     dev: true
 
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
     dev: false
 
   /@types/hast@2.3.4:
@@ -7157,7 +7157,7 @@ packages:
   /@types/http-proxy@1.17.11:
     resolution: {integrity: sha512-HC8G7c1WmaF2ekqpnFq626xd3Zz0uvaqFmBJNRZCGEZCXkvSdJoNFn/8Ygbd9fKNQj8UzLdCETaI0UWPAjK7IA==}
     dependencies:
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
     dev: false
 
   /@types/istanbul-lib-coverage@2.0.4:
@@ -7196,7 +7196,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
     dev: true
 
   /@types/koa-compose@3.2.5:
@@ -7262,7 +7262,6 @@ packages:
 
   /@types/node@17.0.45:
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
-    dev: false
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -7342,7 +7341,7 @@ packages:
   /@types/resolve@1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
     dev: false
 
   /@types/resolve@1.20.2:
@@ -7352,7 +7351,7 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
     dev: true
 
   /@types/retry@0.12.0:
@@ -7373,7 +7372,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
     dev: false
 
   /@types/serve-index@1.9.1:
@@ -7418,7 +7417,7 @@ packages:
   /@types/ws@7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
     dependencies:
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
 
   /@types/ws@8.5.4:
     resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
@@ -8014,8 +8013,8 @@ packages:
     dependencies:
       typescript: 5.0.4
 
-  /@wagmi/chains@0.2.22(typescript@5.0.4):
-    resolution: {integrity: sha512-TdiOzJT6TO1JrztRNjTA5Quz+UmQlbvWFG8N41u9tta0boHA1JCAzGGvU6KuIcOmJfRJkKOUIt67wlbopCpVHg==}
+  /@wagmi/chains@0.2.23(typescript@5.0.4):
+    resolution: {integrity: sha512-oIc4ZpUL6bH/HdS7ROPWlFnP5U3XBujO/OiX4csRIezyLjMQ9FNXQRZShhi5ddL0Kj1RDbyVLe9K/QotEm1vig==}
     peerDependencies:
       typescript: '>=4.9.4'
     peerDependenciesMeta:
@@ -8024,10 +8023,10 @@ packages:
     dependencies:
       typescript: 5.0.4
 
-  /@wagmi/connectors@1.0.1(@wagmi/chains@0.2.22)(react@18.2.0)(typescript@5.0.4)(viem@0.3.19):
-    resolution: {integrity: sha512-fl01vym19DE1uoE+MlASw5zo3Orr/YXlJRjOKLaKYtV+Q7jOLY4TwHgq7sEMs+JYOvFICFBEAlWNNxidr51AqQ==}
+  /@wagmi/connectors@1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26):
+    resolution: {integrity: sha512-5uB+dUDop8s9scdE+S4IhgcfP8oRwdULVvpJ2MusDp+C00+OgvS3SnwZM6+Pjc9tyj5pi143zqsYtDynxFrMEA==}
     peerDependencies:
-      '@wagmi/chains': '>=0.2.0'
+      '@wagmi/chains': '>=0.2.23'
       typescript: '>=4.9.4'
       viem: ~0.3.18
     peerDependenciesMeta:
@@ -8040,14 +8039,14 @@ packages:
       '@ledgerhq/connect-kit-loader': 1.0.2
       '@safe-global/safe-apps-provider': 0.15.2
       '@safe-global/safe-apps-sdk': 7.11.0
-      '@wagmi/chains': 0.2.22(typescript@5.0.4)
-      '@walletconnect/ethereum-provider': 2.7.2(@web3modal/standalone@2.3.7)
+      '@wagmi/chains': 0.2.23(typescript@5.0.4)
+      '@walletconnect/ethereum-provider': 2.7.4(@web3modal/standalone@2.4.1)
       '@walletconnect/legacy-provider': 2.0.0
-      '@web3modal/standalone': 2.3.7(react@18.2.0)
+      '@web3modal/standalone': 2.4.1(react@18.2.0)
       abitype: 0.8.1(typescript@5.0.4)
       eventemitter3: 4.0.7
       typescript: 5.0.4
-      viem: 0.3.19(typescript@5.0.4)
+      viem: 0.3.26(typescript@5.0.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil
@@ -8059,8 +8058,8 @@ packages:
       - utf-8-validate
       - zod
 
-  /@wagmi/core@1.0.1(react@18.2.0)(typescript@5.0.4)(viem@0.3.19):
-    resolution: {integrity: sha512-Zzg4Ob92QMF9NsC+z5/8JZjMn3NCCnwVWGJlv79qRX9mp5Ku40OzJNvqDnjcSGjshe6H0L/KtFZAqTlmu8lT7w==}
+  /@wagmi/core@1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.26):
+    resolution: {integrity: sha512-n8Y84WJkofGjhd4a+vpZzPPEQiHnkIGMe0uHOXfkm4eKJZyaJqvVJFPMWE6xFJkk0hxZ+1zw5xn0ZhdroHwHvg==}
     peerDependencies:
       typescript: '>=4.9.4'
       viem: ~0.3.18
@@ -8068,12 +8067,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@wagmi/chains': 0.2.22(typescript@5.0.4)
-      '@wagmi/connectors': 1.0.1(@wagmi/chains@0.2.22)(react@18.2.0)(typescript@5.0.4)(viem@0.3.19)
+      '@wagmi/chains': 0.2.23(typescript@5.0.4)
+      '@wagmi/connectors': 1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
       abitype: 0.8.1(typescript@5.0.4)
       eventemitter3: 4.0.7
       typescript: 5.0.4
-      viem: 0.3.19(typescript@5.0.4)
+      viem: 0.3.26(typescript@5.0.4)
       zustand: 4.3.8(react@18.2.0)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
@@ -8087,8 +8086,8 @@ packages:
       - utf-8-validate
       - zod
 
-  /@walletconnect/core@2.7.2:
-    resolution: {integrity: sha512-gInSwh3uLpTEkDGArfOFoOVgiXW+zkZJpGqfARVi5fhSxsnL1jYNpqO2k8KAXUPfB4MIzLyaGruiaywncLAczA==}
+  /@walletconnect/core@2.7.4:
+    resolution: {integrity: sha512-nDJJZALZJI8l8JvjwZE4UmUzDzQBnTTJlQa/rc5MoGYtir0hfsQEl3sPkPcXbkkW5q+cHiynXsDcgM4740fmNQ==}
     dependencies:
       '@walletconnect/heartbeat': 1.2.1
       '@walletconnect/jsonrpc-provider': 1.0.12
@@ -8100,8 +8099,8 @@ packages:
       '@walletconnect/relay-auth': 1.0.4
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.7.2
-      '@walletconnect/utils': 2.7.2
+      '@walletconnect/types': 2.7.4
+      '@walletconnect/utils': 2.7.4
       events: 3.3.0
       lodash.isequal: 4.5.0
       uint8arrays: 3.1.1
@@ -8133,8 +8132,8 @@ packages:
     dependencies:
       tslib: 1.14.1
 
-  /@walletconnect/ethereum-provider@2.7.2(@web3modal/standalone@2.3.7):
-    resolution: {integrity: sha512-bvmutLrKKLlQ1WxKCvvX5p5YVox1D1f3Enp6hzAiZf4taN+n/M5rmwfAcLgLhp4cTAUDhl3zgtZErzDyJnvGvQ==}
+  /@walletconnect/ethereum-provider@2.7.4(@web3modal/standalone@2.4.1):
+    resolution: {integrity: sha512-R5hcByY9zIsvyTHFUS+3xqtzs2REezED4tZFyXk0snJjWlnlL2EdeHaCjr5n+SIZDin4CMj1EAFC0ZrM4KoA4Q==}
     peerDependencies:
       '@web3modal/standalone': '>=2'
     peerDependenciesMeta:
@@ -8145,11 +8144,11 @@ packages:
       '@walletconnect/jsonrpc-provider': 1.0.12
       '@walletconnect/jsonrpc-types': 1.0.2
       '@walletconnect/jsonrpc-utils': 1.0.7
-      '@walletconnect/sign-client': 2.7.2
-      '@walletconnect/types': 2.7.2
-      '@walletconnect/universal-provider': 2.7.2
-      '@walletconnect/utils': 2.7.2
-      '@web3modal/standalone': 2.3.7(react@18.2.0)
+      '@walletconnect/sign-client': 2.7.4
+      '@walletconnect/types': 2.7.4
+      '@walletconnect/universal-provider': 2.7.4
+      '@walletconnect/utils': 2.7.4
+      '@web3modal/standalone': 2.4.1(react@18.2.0)
       events: 3.3.0
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
@@ -8315,17 +8314,17 @@ packages:
     dependencies:
       tslib: 1.14.1
 
-  /@walletconnect/sign-client@2.7.2:
-    resolution: {integrity: sha512-JOYPmrgR4YG4M2comNcXaa8cLIws0ZJj/SCpF0XJzRZP2+OXWouK19UaI32ROQrcwNodBNeYFRfT5hSM5xjfKg==}
+  /@walletconnect/sign-client@2.7.4:
+    resolution: {integrity: sha512-hZoCB51GB4u32yxzYnxp8dpzXgo6E7ZWUVOgnihmoMPjgJahPtvB/Ip9jYxI3fuV+ZPQYNlxQgEvR9X+2fLz+g==}
     dependencies:
-      '@walletconnect/core': 2.7.2
+      '@walletconnect/core': 2.7.4
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.1
       '@walletconnect/jsonrpc-utils': 1.0.7
       '@walletconnect/logger': 2.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.7.2
-      '@walletconnect/utils': 2.7.2
+      '@walletconnect/types': 2.7.4
+      '@walletconnect/utils': 2.7.4
       events: 3.3.0
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
@@ -8338,8 +8337,8 @@ packages:
     dependencies:
       tslib: 1.14.1
 
-  /@walletconnect/types@2.7.2:
-    resolution: {integrity: sha512-1O2UefakZpT0ErRfEAXY7Ls3qdUrKDky/DsK088xR6klyfkQOx+aSVH0fJYLhmnqPTuvp3lrqNbsDc0s6/6nvg==}
+  /@walletconnect/types@2.7.4:
+    resolution: {integrity: sha512-Nagfz8DqLxf0UlVd7xopgBX60EJp1xUEq7J30ALlTbWqEhCHuLK/qPk5vGdJ9Q6+ZDpTW9ShLq1DNf+5nVpVDQ==}
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.1
@@ -8351,17 +8350,17 @@ packages:
       - '@react-native-async-storage/async-storage'
       - lokijs
 
-  /@walletconnect/universal-provider@2.7.2:
-    resolution: {integrity: sha512-5glu7vCmq3SFUYgniICf7CUZMwrd6FNS/qnCjrnfgW8T55Opms9YkhRpWTJFHpBdNRWF7n6z/Kss2J8olKTxKw==}
+  /@walletconnect/universal-provider@2.7.4:
+    resolution: {integrity: sha512-suH3o5LpTX7hlx5lU98oLdEM0Ws5ZysjQ4Zr6EWIK1DVT8EDdWbw49ggJSW9IYRLQ2xG22jDvmTIdFAexYOgng==}
     dependencies:
       '@walletconnect/jsonrpc-http-connection': 1.0.6
       '@walletconnect/jsonrpc-provider': 1.0.12
       '@walletconnect/jsonrpc-types': 1.0.2
       '@walletconnect/jsonrpc-utils': 1.0.7
       '@walletconnect/logger': 2.0.1
-      '@walletconnect/sign-client': 2.7.2
-      '@walletconnect/types': 2.7.2
-      '@walletconnect/utils': 2.7.2
+      '@walletconnect/sign-client': 2.7.4
+      '@walletconnect/types': 2.7.4
+      '@walletconnect/utils': 2.7.4
       eip1193-provider: 1.0.1
       events: 3.3.0
     transitivePeerDependencies:
@@ -8372,8 +8371,8 @@ packages:
       - lokijs
       - utf-8-validate
 
-  /@walletconnect/utils@2.7.2:
-    resolution: {integrity: sha512-b2lU/JoWqwCOLMudPSRTt3pliBnv6qQHCBWiMBYi1vL14AW3usO5QmK1wF90AVwpdPJ7wFZ6MgHymeWWfhYnGQ==}
+  /@walletconnect/utils@2.7.4:
+    resolution: {integrity: sha512-2WEeKB9h/FQvyNmIBYwLtjdLm3Oo55EwtJoxkC00SA7xjf8jYxZ8q2y4P/CJP8oO5ruxBK5Ft0smKvPHXsE58Q==}
     dependencies:
       '@stablelib/chacha20poly1305': 1.0.1
       '@stablelib/hkdf': 1.0.1
@@ -8384,7 +8383,7 @@ packages:
       '@walletconnect/relay-api': 1.0.9
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.7.2
+      '@walletconnect/types': 2.7.4
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       detect-browser: 5.3.0
@@ -8408,27 +8407,27 @@ packages:
   /@web3-storage/multipart-parser@1.0.0:
     resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
 
-  /@web3modal/core@2.3.7(react@18.2.0):
-    resolution: {integrity: sha512-ggl9+tkAzz43npj97iTj6p4oQYaklxADQyCKAX7AnMfglZg5bRseMDGnfmpvnjlDn8TI+DGGO6da3ITmYRIDYQ==}
+  /@web3modal/core@2.4.1(react@18.2.0):
+    resolution: {integrity: sha512-v6Y/eQJSI2YfUTv8rGqjFabqdk3ZPjx6Fe7j5Q8fw0ZWF1YRGM3mySG457qtKQ7D7E1kNKA3BHbaOZ3pgQoG6A==}
     dependencies:
       buffer: 6.0.3
-      valtio: 1.10.4(react@18.2.0)
+      valtio: 1.10.5(react@18.2.0)
     transitivePeerDependencies:
       - react
 
-  /@web3modal/standalone@2.3.7(react@18.2.0):
-    resolution: {integrity: sha512-zgavWcimRVXnLdup2WQ0fFEnBnH+Wwn+k1/XzhwVpdJ//mrExWNYQaXt139RijxGUcux68ExRCyMqm1jkXTq3g==}
+  /@web3modal/standalone@2.4.1(react@18.2.0):
+    resolution: {integrity: sha512-ZrI5LwWeT9sd8A3FdIX/gBp3ZrzrX882Ln1vJN0LTCmeP2OUsYcW5bPxjv1PcJ1YUBY7Tg4aTgMUnAVTTuqb+w==}
     dependencies:
-      '@web3modal/core': 2.3.7(react@18.2.0)
-      '@web3modal/ui': 2.3.7(react@18.2.0)
+      '@web3modal/core': 2.4.1(react@18.2.0)
+      '@web3modal/ui': 2.4.1(react@18.2.0)
     transitivePeerDependencies:
       - react
 
-  /@web3modal/ui@2.3.7(react@18.2.0):
-    resolution: {integrity: sha512-mNDXY4ElcvXXixKHZTLcEjKC9zs3O8BD1EtaC8cKIy+RKFyHMpLB1DOQmz77tn91jNjOkrvEryqUwCbsJ7hjfA==}
+  /@web3modal/ui@2.4.1(react@18.2.0):
+    resolution: {integrity: sha512-x1ceyd3mMJsIHs5UUTLvE+6qyCjhyjL6gB/wVmTDbwASHSQIVyshQJ+s7BwIEMP/pbAsYDg+/M8EiUuE+/E/kg==}
     dependencies:
-      '@web3modal/core': 2.3.7(react@18.2.0)
-      lit: 2.7.3
+      '@web3modal/core': 2.4.1(react@18.2.0)
+      lit: 2.7.4
       motion: 10.15.5
       qrcode: 1.5.3
     transitivePeerDependencies:
@@ -14550,7 +14549,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -14675,7 +14674,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -14693,7 +14692,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: false
@@ -14731,7 +14730,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -14801,7 +14800,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
     dev: false
 
   /jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
@@ -14862,7 +14861,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -14919,7 +14918,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       graceful-fs: 4.2.11
     dev: false
 
@@ -14970,7 +14969,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -15011,7 +15010,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -15036,7 +15035,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: false
@@ -15394,8 +15393,8 @@ packages:
     dependencies:
       '@types/trusted-types': 2.0.3
 
-  /lit@2.7.3:
-    resolution: {integrity: sha512-0a+u+vVbmgSfPu+fyvqjMPBX0Kwbyj9QOv9MbQFZhWGlV2cyk3lEwgfUQgYN+i/lx++1Z3wZknSIp3QCKxHLyg==}
+  /lit@2.7.4:
+    resolution: {integrity: sha512-cgD7xrZoYr21mbrkZIuIrj98YTMw/snJPg52deWVV4A8icLyNHI3bF70xsJeAgwTuiq5Kkd+ZR8gybSJDCPB7g==}
     dependencies:
       '@lit/reactive-element': 1.6.1
       lit-element: 3.3.2
@@ -18294,7 +18293,7 @@ packages:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/long': 4.0.2
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       long: 4.0.0
     dev: true
 
@@ -18312,7 +18311,7 @@ packages:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 17.0.35
+      '@types/node': 17.0.45
       long: 5.2.3
     dev: true
 
@@ -18323,8 +18322,8 @@ packages:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  /proxy-compare@2.5.0:
-    resolution: {integrity: sha512-f1us0OsVAJ3tdIMXGQx2lmseYS4YXe4W+sKF5g5ww/jV+5ogMadPt+sIZ+88Ga9kvMJsrRNWzCrKPpr6pMWYbA==}
+  /proxy-compare@2.5.1:
+    resolution: {integrity: sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA==}
 
   /pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
@@ -21187,8 +21186,8 @@ packages:
       builtins: 5.0.1
     dev: false
 
-  /valtio@1.10.4(react@18.2.0):
-    resolution: {integrity: sha512-gqGWh0DjtDMAy8Jaui8ufFoxlQB1k1NiA/QHrpKoTUk9EeY331WKeYhvtGn1u703RcefrDCez7PT+qeCu9lWEw==}
+  /valtio@1.10.5(react@18.2.0):
+    resolution: {integrity: sha512-jTp0k63VXf4r5hPoaC6a6LCG4POkVSh629WLi1+d5PlajLsbynTMd7qAgEiOSPxzoX5iNvbN7iZ/k/g29wrNiQ==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       react: '>=16.8'
@@ -21196,7 +21195,7 @@ packages:
       react:
         optional: true
     dependencies:
-      proxy-compare: 2.5.0
+      proxy-compare: 2.5.1
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
 
@@ -21224,8 +21223,8 @@ packages:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
-  /viem@0.3.19(typescript@5.0.4):
-    resolution: {integrity: sha512-7OlSgiB7e+OFz9OqTOZ/Mpx8GAAVKCxsaPDJRuR8QtixlruUHPfHBHOemkX+O/Drn6B7l04iCUZjCvSB8OtVKg==}
+  /viem@0.3.26(typescript@5.0.4):
+    resolution: {integrity: sha512-biT9oky9coUd4Ww+/gWRRIZl1OSVjLSGAqAuvYpfBJGSsX0Ya0kOncIiIu1ViapfGadTW0OclvIh3M1gNux24w==}
     dependencies:
       '@adraffy/ens-normalize': 1.9.0
       '@noble/curves': 1.0.0
@@ -21421,8 +21420,8 @@ packages:
       xml-name-validator: 3.0.0
     dev: false
 
-  /wagmi@1.0.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.19):
-    resolution: {integrity: sha512-+2UkZG9eA3tKqXj1wvlvI8mL0Bcff7Tf5CKfUOyQsdKcY+J5rfwYYya25G+jja57umpHFtfxRaL7xDkNjehrRg==}
+  /wagmi@1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26):
+    resolution: {integrity: sha512-XsLhNPTD7c+QXaA9elMwDihvcNHBw4Jcu0S/otkn3N4FgWIUVSQGiUYwm3AQrm/UhON0+Q8Y3ICzxB47PSr46g==}
     peerDependencies:
       react: '>=17.0.0'
       typescript: '>=4.9.4'
@@ -21434,12 +21433,12 @@ packages:
       '@tanstack/query-sync-storage-persister': 4.29.5
       '@tanstack/react-query': 4.29.5(react-dom@18.2.0)(react@18.2.0)
       '@tanstack/react-query-persist-client': 4.29.5(@tanstack/react-query@4.29.5)
-      '@wagmi/core': 1.0.1(react@18.2.0)(typescript@5.0.4)(viem@0.3.19)
+      '@wagmi/core': 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
       abitype: 0.8.1(typescript@5.0.4)
       react: 18.2.0
       typescript: 5.0.4
       use-sync-external-store: 1.2.0(react@18.2.0)
-      viem: 0.3.19(typescript@5.0.4)
+      viem: 0.3.26(typescript@5.0.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         version: 3.8.0(@types/node@17.0.35)(vite@2.9.9)
       '@wagmi/core':
         specifier: ^1.0.5
-        version: 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
+        version: 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
       autoprefixer:
         specifier: ^10.4.0
         version: 10.4.0(postcss@8.4.6)
@@ -119,14 +119,14 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4
       viem:
-        specifier: ~0.3.26
-        version: 0.3.26(typescript@5.0.4)
+        specifier: ~0.3.29
+        version: 0.3.29(typescript@5.0.4)
       vitest:
         specifier: ^0.30.0
         version: 0.30.0
       wagmi:
         specifier: ^1.0.5
-        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
 
   examples/with-create-react-app:
     dependencies:
@@ -369,11 +369,11 @@ importers:
         specifier: ^2.1.4
         version: 2.1.4(ethers@5.6.8)
       viem:
-        specifier: ~0.3.26
-        version: 0.3.26(typescript@5.0.4)
+        specifier: ~0.3.29
+        version: 0.3.29(typescript@5.0.4)
       wagmi:
         specifier: ^1.0.5
-        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
 
   packages/rainbowkit:
     dependencies:
@@ -421,14 +421,14 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       viem:
-        specifier: ~0.3.26
-        version: 0.3.26(typescript@5.0.4)
+        specifier: ~0.3.29
+        version: 0.3.29(typescript@5.0.4)
       vitest:
         specifier: ^0.30.0
         version: 0.30.0
       wagmi:
         specifier: ^1.0.5
-        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
 
   packages/rainbowkit-siwe-next-auth:
     dependencies:
@@ -542,11 +542,11 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       viem:
-        specifier: ~0.3.26
-        version: 0.3.26(typescript@5.0.4)
+        specifier: ~0.3.29
+        version: 0.3.29(typescript@5.0.4)
       wagmi:
         specifier: ^1.0.5
-        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
     devDependencies:
       contentlayer:
         specifier: 0.2.8
@@ -8023,7 +8023,7 @@ packages:
     dependencies:
       typescript: 5.0.4
 
-  /@wagmi/connectors@1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26):
+  /@wagmi/connectors@1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29):
     resolution: {integrity: sha512-5uB+dUDop8s9scdE+S4IhgcfP8oRwdULVvpJ2MusDp+C00+OgvS3SnwZM6+Pjc9tyj5pi143zqsYtDynxFrMEA==}
     peerDependencies:
       '@wagmi/chains': '>=0.2.23'
@@ -8046,7 +8046,7 @@ packages:
       abitype: 0.8.1(typescript@5.0.4)
       eventemitter3: 4.0.7
       typescript: 5.0.4
-      viem: 0.3.26(typescript@5.0.4)
+      viem: 0.3.29(typescript@5.0.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil
@@ -8058,7 +8058,7 @@ packages:
       - utf-8-validate
       - zod
 
-  /@wagmi/core@1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.26):
+  /@wagmi/core@1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.29):
     resolution: {integrity: sha512-n8Y84WJkofGjhd4a+vpZzPPEQiHnkIGMe0uHOXfkm4eKJZyaJqvVJFPMWE6xFJkk0hxZ+1zw5xn0ZhdroHwHvg==}
     peerDependencies:
       typescript: '>=4.9.4'
@@ -8068,11 +8068,11 @@ packages:
         optional: true
     dependencies:
       '@wagmi/chains': 0.2.23(typescript@5.0.4)
-      '@wagmi/connectors': 1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
+      '@wagmi/connectors': 1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
       abitype: 0.8.1(typescript@5.0.4)
       eventemitter3: 4.0.7
       typescript: 5.0.4
-      viem: 0.3.26(typescript@5.0.4)
+      viem: 0.3.29(typescript@5.0.4)
       zustand: 4.3.8(react@18.2.0)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
@@ -21223,8 +21223,8 @@ packages:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
-  /viem@0.3.26(typescript@5.0.4):
-    resolution: {integrity: sha512-biT9oky9coUd4Ww+/gWRRIZl1OSVjLSGAqAuvYpfBJGSsX0Ya0kOncIiIu1ViapfGadTW0OclvIh3M1gNux24w==}
+  /viem@0.3.29(typescript@5.0.4):
+    resolution: {integrity: sha512-uFoEnUn4bEKneG2R2Ot2Jgk5LkMScPCanSZp0z5elqK5jFfgBKl7V5bJNL+EaPYKyxSa2A14rSE1IBVQHPYxlw==}
     dependencies:
       '@adraffy/ens-normalize': 1.9.0
       '@noble/curves': 1.0.0
@@ -21420,7 +21420,7 @@ packages:
       xml-name-validator: 3.0.0
     dev: false
 
-  /wagmi@1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.26):
+  /wagmi@1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29):
     resolution: {integrity: sha512-XsLhNPTD7c+QXaA9elMwDihvcNHBw4Jcu0S/otkn3N4FgWIUVSQGiUYwm3AQrm/UhON0+Q8Y3ICzxB47PSr46g==}
     peerDependencies:
       react: '>=17.0.0'
@@ -21433,12 +21433,12 @@ packages:
       '@tanstack/query-sync-storage-persister': 4.29.5
       '@tanstack/react-query': 4.29.5(react-dom@18.2.0)(react@18.2.0)
       '@tanstack/react-query-persist-client': 4.29.5(@tanstack/react-query@4.29.5)
-      '@wagmi/core': 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.26)
+      '@wagmi/core': 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
       abitype: 0.8.1(typescript@5.0.4)
       react: 18.2.0
       typescript: 5.0.4
       use-sync-external-store: 1.2.0(react@18.2.0)
-      viem: 0.3.26(typescript@5.0.4)
+      viem: 0.3.29(typescript@5.0.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         version: 3.8.0(@types/node@17.0.35)(vite@2.9.9)
       '@wagmi/core':
         specifier: ^1.0.5
-        version: 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
+        version: 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
       autoprefixer:
         specifier: ^10.4.0
         version: 10.4.0(postcss@8.4.6)
@@ -119,14 +119,14 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4
       viem:
-        specifier: ~0.3.29
-        version: 0.3.29(typescript@5.0.4)
+        specifier: ~0.3.33
+        version: 0.3.33(typescript@5.0.4)
       vitest:
         specifier: ^0.30.0
         version: 0.30.0
       wagmi:
         specifier: ^1.0.5
-        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
 
   examples/with-create-react-app:
     dependencies:
@@ -369,11 +369,11 @@ importers:
         specifier: ^2.1.4
         version: 2.1.4(ethers@5.6.8)
       viem:
-        specifier: ~0.3.29
-        version: 0.3.29(typescript@5.0.4)
+        specifier: ~0.3.33
+        version: 0.3.33(typescript@5.0.4)
       wagmi:
         specifier: ^1.0.5
-        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
 
   packages/rainbowkit:
     dependencies:
@@ -421,14 +421,14 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       viem:
-        specifier: ~0.3.29
-        version: 0.3.29(typescript@5.0.4)
+        specifier: ~0.3.33
+        version: 0.3.33(typescript@5.0.4)
       vitest:
         specifier: ^0.30.0
         version: 0.30.0
       wagmi:
         specifier: ^1.0.5
-        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
 
   packages/rainbowkit-siwe-next-auth:
     dependencies:
@@ -542,11 +542,11 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       viem:
-        specifier: ~0.3.29
-        version: 0.3.29(typescript@5.0.4)
+        specifier: ~0.3.33
+        version: 0.3.33(typescript@5.0.4)
       wagmi:
         specifier: ^1.0.5
-        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
+        version: 1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
     devDependencies:
       contentlayer:
         specifier: 0.2.8
@@ -8023,7 +8023,7 @@ packages:
     dependencies:
       typescript: 5.0.4
 
-  /@wagmi/connectors@1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29):
+  /@wagmi/connectors@1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33):
     resolution: {integrity: sha512-5uB+dUDop8s9scdE+S4IhgcfP8oRwdULVvpJ2MusDp+C00+OgvS3SnwZM6+Pjc9tyj5pi143zqsYtDynxFrMEA==}
     peerDependencies:
       '@wagmi/chains': '>=0.2.23'
@@ -8046,7 +8046,7 @@ packages:
       abitype: 0.8.1(typescript@5.0.4)
       eventemitter3: 4.0.7
       typescript: 5.0.4
-      viem: 0.3.29(typescript@5.0.4)
+      viem: 0.3.33(typescript@5.0.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil
@@ -8058,7 +8058,7 @@ packages:
       - utf-8-validate
       - zod
 
-  /@wagmi/core@1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.29):
+  /@wagmi/core@1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.33):
     resolution: {integrity: sha512-n8Y84WJkofGjhd4a+vpZzPPEQiHnkIGMe0uHOXfkm4eKJZyaJqvVJFPMWE6xFJkk0hxZ+1zw5xn0ZhdroHwHvg==}
     peerDependencies:
       typescript: '>=4.9.4'
@@ -8068,11 +8068,11 @@ packages:
         optional: true
     dependencies:
       '@wagmi/chains': 0.2.23(typescript@5.0.4)
-      '@wagmi/connectors': 1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
+      '@wagmi/connectors': 1.0.3(@wagmi/chains@0.2.23)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
       abitype: 0.8.1(typescript@5.0.4)
       eventemitter3: 4.0.7
       typescript: 5.0.4
-      viem: 0.3.29(typescript@5.0.4)
+      viem: 0.3.33(typescript@5.0.4)
       zustand: 4.3.8(react@18.2.0)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
@@ -21223,8 +21223,8 @@ packages:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
-  /viem@0.3.29(typescript@5.0.4):
-    resolution: {integrity: sha512-uFoEnUn4bEKneG2R2Ot2Jgk5LkMScPCanSZp0z5elqK5jFfgBKl7V5bJNL+EaPYKyxSa2A14rSE1IBVQHPYxlw==}
+  /viem@0.3.33(typescript@5.0.4):
+    resolution: {integrity: sha512-ITB7wiYIWMxSyOQePPVa+6YcCrQiBLY/S758iZcjIZFqyqF8i/9PBhAPiqbiUrdfydaqjjRtWR1PAaXlMxmgtg==}
     dependencies:
       '@adraffy/ens-normalize': 1.9.0
       '@noble/curves': 1.0.0
@@ -21420,7 +21420,7 @@ packages:
       xml-name-validator: 3.0.0
     dev: false
 
-  /wagmi@1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.29):
+  /wagmi@1.0.5(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.33):
     resolution: {integrity: sha512-XsLhNPTD7c+QXaA9elMwDihvcNHBw4Jcu0S/otkn3N4FgWIUVSQGiUYwm3AQrm/UhON0+Q8Y3ICzxB47PSr46g==}
     peerDependencies:
       react: '>=17.0.0'
@@ -21433,12 +21433,12 @@ packages:
       '@tanstack/query-sync-storage-persister': 4.29.5
       '@tanstack/react-query': 4.29.5(react-dom@18.2.0)(react@18.2.0)
       '@tanstack/react-query-persist-client': 4.29.5(@tanstack/react-query@4.29.5)
-      '@wagmi/core': 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.29)
+      '@wagmi/core': 1.0.5(react@18.2.0)(typescript@5.0.4)(viem@0.3.33)
       abitype: 0.8.1(typescript@5.0.4)
       react: 18.2.0
       typescript: 5.0.4
       use-sync-external-store: 1.2.0(react@18.2.0)
-      viem: 0.3.29(typescript@5.0.4)
+      viem: 0.3.33(typescript@5.0.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil

--- a/site/package.json
+++ b/site/package.json
@@ -34,7 +34,7 @@
     "three": "^0.139.2",
     "unified": "10.1.2",
     "unist-util-visit": "4.1.0",
-    "viem": "~0.3.33"
+    "viem": "~0.3.35"
   },
   "devDependencies": {
     "contentlayer": "0.2.8",

--- a/site/package.json
+++ b/site/package.json
@@ -34,7 +34,7 @@
     "three": "^0.139.2",
     "unified": "10.1.2",
     "unist-util-visit": "4.1.0",
-    "viem": "~0.3.29"
+    "viem": "~0.3.33"
   },
   "devDependencies": {
     "contentlayer": "0.2.8",

--- a/site/package.json
+++ b/site/package.json
@@ -41,7 +41,7 @@
     "next-contentlayer": "0.2.8"
   },
   "peerDependencies": {
-    "wagmi": "^1.0.5"
+    "wagmi": "~1.0.5"
   },
   "scripts": {
     "dev": "next dev --port 3001",

--- a/site/package.json
+++ b/site/package.json
@@ -34,14 +34,14 @@
     "three": "^0.139.2",
     "unified": "10.1.2",
     "unist-util-visit": "4.1.0",
-    "viem": "~0.3.19"
+    "viem": "~0.3.26"
   },
   "devDependencies": {
     "contentlayer": "0.2.8",
     "next-contentlayer": "0.2.8"
   },
   "peerDependencies": {
-    "wagmi": "^1.0.1"
+    "wagmi": "^1.0.5"
   },
   "scripts": {
     "dev": "next dev --port 3001",

--- a/site/package.json
+++ b/site/package.json
@@ -34,7 +34,7 @@
     "three": "^0.139.2",
     "unified": "10.1.2",
     "unist-util-visit": "4.1.0",
-    "viem": "~0.3.26"
+    "viem": "~0.3.29"
   },
   "devDependencies": {
     "contentlayer": "0.2.8",


### PR DESCRIPTION
## Upgrades
- `wagmi`: `~1.0.5`
- `viem`: `~0.3.35`
## Changes
- adjusted `viem` peer dependency to `~0.3.19`
- adjusted `wagmi` peer dependency to `~1.0.1`