### PR TITLE
feat: modal state inclusion in modal hooks

### DIFF
--- a/.changeset/yellow-lizards-hunt.md
+++ b/.changeset/yellow-lizards-hunt.md
@@ -1,0 +1,11 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Modal Hooks including `useConnectModal`, `useAccountModal`, and `useChainModal` now each return a boolean with the status of the modal.
+
+```tsx
+const { connectModalOpen } = useConnectModal();
+const { accountModalOpen } = useAccountModal();
+const { chainModalOpen } = useChainModal();
+```

--- a/packages/rainbowkit/src/components/RainbowKitProvider/ModalContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/ModalContext.tsx
@@ -136,16 +136,16 @@ export function useModalState() {
 }
 
 export function useAccountModal() {
-  const { openAccountModal } = useContext(ModalContext);
-  return { openAccountModal };
+  const { accountModalOpen, openAccountModal } = useContext(ModalContext);
+  return { accountModalOpen, openAccountModal };
 }
 
 export function useChainModal() {
-  const { openChainModal } = useContext(ModalContext);
-  return { openChainModal };
+  const { chainModalOpen, openChainModal } = useContext(ModalContext);
+  return { chainModalOpen, openChainModal };
 }
 
 export function useConnectModal() {
-  const { openConnectModal } = useContext(ModalContext);
-  return { openConnectModal };
+  const { connectModalOpen, openConnectModal } = useContext(ModalContext);
+  return { connectModalOpen, openConnectModal };
 }

--- a/site/data/docs/modal-hooks.mdx
+++ b/site/data/docs/modal-hooks.mdx
@@ -50,3 +50,15 @@ export const YourApp = () => {
   );
 };
 ```
+
+Each hook also returns a boolean for the status of the modal. It is typically recommended that you rely purely on Wagmi hooks (i.e. `useAccount`) to react to a user's wallet connection status directly, rather than relying on the state of the Connect Modal.
+
+```tsx
+const { connectModalOpen } = useConnectModal();
+const { accountModalOpen } = useAccountModal();
+const { chainModalOpen } = useChainModal();
+```
+
+RainbowKit is designed to be non-interruptive and responsive, so dApps should always render an interface for users whether or not they have connected their wallet. A user could connect or disconnect their wallet directly from MetaMask, so the dApp must be responsive to the underlying connection status directly.
+
+dApps that rely on mechanisms like Sign-in with Ethereum for user verification should instead rely on the [Authentication](/docs/authentication) feature.


### PR DESCRIPTION
## API Changes
```tsx
const { connectModalOpen } = useConnectModal();
const { accountModalOpen } = useAccountModal();
const { chainModalOpen } = useChainModal();
```
## Docs Updates
- added usage guide for `connectModalOpen`, `accountModalOpen` and `chainModalOpen`
- added guidance for devs on the recommended usage of this hook API
- added wallet connection UX guidance for dApp devs

Reference the updated docs [here](https://rainbowkit-site-git-daniel-modal-state-rainbowdotme.vercel.app/docs/modal-hooks#:~:text=Each%20hook%20also%20returns%20a%20boolean)