### PR TITLE
Adding Rabby's open-sourced relay service after WalletConnect v1.0 relay servers' shutdown

### DIFF
--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -75,6 +75,10 @@ export function getWalletConnectConnector({
     },
   };
 
+  if (version === '1' && !config.options.bridge) {
+    config.options.bridge = 'https://derelay.rabby.io';
+  }
+
   const serializedConfig = JSON.stringify(config);
   const sharedConnector = sharedConnectors.get(serializedConfig);
 


### PR DESCRIPTION
## Issue

WalletConnect v1.0 relay server is expected to be offline on 28 June, 2023. To ensure uninterrupted usage and connectivity following the official v1.0 server shutdown, we are proposing the integration of [Rabby](https://github.com/RabbyHub/)'s open-sourced relay service. This relay service, maintained by Rabby, will guarantee continued connection between Dapps and Wallets using WalletConnect for users.

## Solution

We have included Rabby's self-host relay(https://derelay.rabby.io/) address in the web3 Wallet Connect kit, ensuring that users can connect to Dapp using WalletConnect. This address will become effective once the official relay server shuts down.

## Testing plan

We have thoroughly tested the solution in both the testing environment and the live online environment. Based on our testing, we are confident that the solution will enable users to connect to Dapps using WalletConnect without any issues.