### PR TITLE
feat: configurable auth button label

### DIFF
--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -116,6 +116,7 @@ const wagmiConfig = createConfig({
 
 const demoAppInfo = {
   appName: 'Rainbowkit Demo',
+  authButtonLabel: 'Sign message',
 };
 
 const DisclaimerDemo: DisclaimerComponent = ({ Link, Text }) => {

--- a/packages/rainbowkit/src/components/RainbowKitProvider/AppContext.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/AppContext.ts
@@ -7,6 +7,7 @@ export type DisclaimerComponent = React.FunctionComponent<{
 
 export const defaultAppInfo = {
   appName: undefined,
+  authButtonLabel: undefined,
   disclaimer: undefined,
   learnMoreUrl:
     'https://learn.rainbow.me/understanding-web3?utm_source=rainbowkit&utm_campaign=learnmore',
@@ -14,6 +15,7 @@ export const defaultAppInfo = {
 
 export const AppContext = createContext<{
   appName?: string;
+  authButtonLabel?: string;
   learnMoreUrl?: string;
   disclaimer?: DisclaimerComponent;
 }>(defaultAppInfo);

--- a/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
@@ -57,9 +57,9 @@ export interface RainbowKitProviderProps {
   showRecentTransactions?: boolean;
   appInfo?: {
     appName?: string;
+    authButtonLabel?: string;
     learnMoreUrl?: string;
     disclaimer?: DisclaimerComponent;
-    authButtonText?: string;
   };
   coolMode?: boolean;
   avatar?: AvatarComponent;

--- a/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
@@ -59,6 +59,7 @@ export interface RainbowKitProviderProps {
     appName?: string;
     learnMoreUrl?: string;
     disclaimer?: DisclaimerComponent;
+    authButtonText?: string;
   };
   coolMode?: boolean;
   avatar?: AvatarComponent;

--- a/packages/rainbowkit/src/components/SignIn/SignIn.tsx
+++ b/packages/rainbowkit/src/components/SignIn/SignIn.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useContext, useRef } from 'react';
 import { UserRejectedRequestError } from 'viem';
 import { useAccount, useDisconnect, useNetwork, useSignMessage } from 'wagmi';
 import { touchableStyles } from '../../css/touchableStyles';
@@ -7,6 +7,7 @@ import { AsyncImage } from '../AsyncImage/AsyncImage';
 import { Box } from '../Box/Box';
 import { ActionButton } from '../Button/ActionButton';
 import { CloseButton } from '../CloseButton/CloseButton';
+import { AppContext } from '../RainbowKitProvider/AppContext';
 import { useAuthenticationAdapter } from '../RainbowKitProvider/AuthenticationContext';
 import { Text } from '../Text/Text';
 
@@ -19,6 +20,7 @@ export function SignIn({ onClose }: { onClose: () => void }) {
     nonce?: string;
   }>({ status: 'idle' });
 
+  const { authButtonLabel } = useContext(AppContext);
   const authAdapter = useAuthenticationAdapter();
 
   const getNonce = useCallback(async () => {
@@ -203,6 +205,8 @@ export function SignIn({ onClose }: { onClose: () => void }) {
                 ? 'Waiting for signature...'
                 : status === 'verifying'
                 ? 'Verifying signature...'
+                : authButtonLabel
+                ? authButtonLabel
                 : 'Send message'
             }
             onClick={signIn}


### PR DESCRIPTION
The button label of the SignIn component can be configured in AppContext. The default value remains "Send message", as it currently is.

This PR comes as a follow up to this Twitter thread
https://twitter.com/paulofonseca__/status/1671535529513426944


![Screenshot 2023-06-21 at 22 58 17](https://github.com/rainbow-me/rainbowkit/assets/8058187/184cd97f-38d8-400a-8f97-eae790b4f5de)
