### PR TITLE
Update custom-wallets.mdx

### DIFF
--- a/site/data/docs/custom-wallets.mdx
+++ b/site/data/docs/custom-wallets.mdx
@@ -238,14 +238,18 @@ export const rainbow = ({
       mobile: {
         getUri: async () => {
           const provider = await connector.getProvider();
-          const uri = await new Promise<string>(resolve => provider.once('display_uri', resolve));
+          const uri = await new Promise<string>(resolve =>
+            provider.once('display_uri', resolve)
+          );
           return uri;
         },
       },
       qrCode: {
         getUri: async () => {
           const provider = await connector.getProvider();
-          const uri = await new Promise<string>(resolve => provider.once('display_uri', resolve));
+          const uri = await new Promise<string>(resolve =>
+            provider.once('display_uri', resolve)
+          );
           return uri;
         },
         instructions: {

--- a/site/data/docs/custom-wallets.mdx
+++ b/site/data/docs/custom-wallets.mdx
@@ -237,13 +237,17 @@ export const rainbow = ({
       connector,
       mobile: {
         getUri: async () => {
-          const { uri } = (await connector.getProvider()).connector;
+          const provider = await connector.getProvider();
+          const uri = await new Promise<string>(resolve => provider.once('display_uri', resolve));
           return uri;
         },
       },
       qrCode: {
-        getUri: async () =>
-          (await connector.getProvider()).connector.uri,
+        getUri: async () => {
+          const provider = await connector.getProvider();
+          const uri = await new Promise<string>(resolve => provider.once('display_uri', resolve));
+          return uri;
+        },
         instructions: {
           learnMoreUrl: 'https://my-wallet/learn-more',
           steps: [


### PR DESCRIPTION
Updated `getUri()` function.
Since WalletConnect does not support V1, needed to make `getUri()` compatible with V2.

In V1, the way to get the URI was - 
```js
const { uri } = (await connector.getProvider()).connector;
```

But this does not work anymore, so need to update the docs 

```js
const provider = await connector.getProvider();
const uri = await new Promise<string>(resolve => provider.once('display_uri', resolve))
return uri
```