### PR TITLE
feat: allow loading wallets on demand; can reduce first load by 80+ KB gzipped

### DIFF
--- a/packages/rainbowkit/build.js
+++ b/packages/rainbowkit/build.js
@@ -65,10 +65,7 @@ const mainBuild = esbuild.build({
 
     // esbuild needs these additional entry points in order to support tree shaking while also supporting CSS
     ...(await getAllEntryPoints('src/themes')),
-
-    // The build output is cleaner when bundling all components into a single chunk
-    // This is done assuming that consumers use most of the components in the package, which is a reasonable assumption for now
-    './src/components/index.ts',
+    ...(await getAllEntryPoints('src/wallets')),
   ],
   outdir: 'dist',
   watch: isWatching

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -10,6 +10,8 @@
   "type": "module",
   "exports": {
     ".": "./dist/index.js",
+    "./dist/*": "./dist/*.js",
+    "./dist/": "./dist/",
     "./styles.css": "./dist/index.css",
     "./wallets": "./dist/wallets/walletConnectors/index.js"
   },


### PR DESCRIPTION
resolves https://github.com/rainbow-me/rainbowkit/discussions/1349 (EDIT: just found another workaround, see discussion OP)

Demo of a lazy loading use case:

https://github.com/rainbow-me/rainbowkit/assets/5601392/3c5c2995-9798-4b37-a1ac-2030944db084

savings can be more than 80KB (which is just the `getDefaultWallets()` savings) if lazy loading more than the default wallets. although the big one I suspect is WalletConnect?