### PR TITLE
fix: default projectId for example and docs site

### DIFF
--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -76,7 +76,8 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
   ]
 );
 
-const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || '';
+const projectId =
+  process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID ?? 'YOUR_PROJECT_ID';
 
 const { wallets } = getDefaultWallets({
   appName: 'RainbowKit demo',

--- a/site/components/Provider/Provider.tsx
+++ b/site/components/Provider/Provider.tsx
@@ -23,7 +23,8 @@ export const { chains, publicClient } = configureChains(
   ]
 );
 
-const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || '';
+const projectId =
+  process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || 'YOUR_PROJECT_ID';
 
 const { wallets } = getDefaultWallets({
   appName: 'rainbowkit.com',


### PR DESCRIPTION
This is necessary to import a fork of `rainbowkit` in a project. (For `file:` syntax in `package.json` `dependencies`, it may not be enough; user may also have to nuke the `node_modules` and reinstall just `qrcode`)

Another option would be allowing empty string for the `projectId` (more aligned with the TypeScript typing)