### PR TITLE
refactor: removed walletconnect v1 to decrease bundle size by 40kb

### DIFF
--- a/.changeset/ten-otters-bathe.md
+++ b/.changeset/ten-otters-bathe.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': major
+---
+
+WalletConnect v1 support has been removed to reduce bundle size by ~40kb

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -64,10 +64,7 @@ function WalletButton({
           if (getMobileUri) {
             const mobileUri = await getMobileUri();
 
-            if (
-              connector.id === 'walletConnect' ||
-              connector.id === 'walletConnectLegacy'
-            ) {
+            if (connector.id === 'walletConnect') {
               // In Web3Modal, an equivalent setWalletConnectDeepLink routine gets called after
               // successful connection and then the universal provider uses it on requests. We call
               // it upon onConnecting; this now needs to be called for both v1 and v2 Wagmi connectors.

--- a/packages/rainbowkit/src/utils/getWalletConnectUri.ts
+++ b/packages/rainbowkit/src/utils/getWalletConnectUri.ts
@@ -1,11 +1,8 @@
 import type { Connector } from 'wagmi/connectors';
 
 export async function getWalletConnectUri(
-  connector: Connector,
-  version: '1' | '2'
+  connector: Connector
 ): Promise<string> {
   const provider = await connector.getProvider();
-  return version === '2'
-    ? new Promise<string>(resolve => provider.once('display_uri', resolve))
-    : provider.connector.uri;
+  return new Promise<string>(resolve => provider.once('display_uri', resolve));
 }

--- a/packages/rainbowkit/src/wallets/connectorsForWallets.test.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { Connector } from 'wagmi';
 import { mainnet } from 'wagmi/chains';
 import { InjectedConnector } from 'wagmi/connectors/injected';
-import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy';
+import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
 import { connectorsForWallets } from '..';
 import { WalletInstance } from './Wallet';
 import { injectedWallet } from './walletConnectors';
@@ -27,7 +27,7 @@ describe('connectorsForWallets', () => {
           wallets: [
             {
               createConnector: () => ({
-                connector: new WalletConnectLegacyConnector({
+                connector: new WalletConnectConnector({
                   chains,
                   options: {},
                 }),
@@ -73,7 +73,7 @@ describe('connectorsForWallets', () => {
             },
             {
               createConnector: () => ({
-                connector: new WalletConnectLegacyConnector({
+                connector: new WalletConnectConnector({
                   chains,
                   options: {},
                 }),
@@ -131,7 +131,7 @@ describe('connectorsForWallets', () => {
           wallets: [
             {
               createConnector: () => ({
-                connector: new WalletConnectLegacyConnector({
+                connector: new WalletConnectConnector({
                   chains,
                   options: {},
                 }),
@@ -199,7 +199,7 @@ describe('connectorsForWallets', () => {
             injectedWallet({ chains }),
             {
               createConnector: () => ({
-                connector: new WalletConnectLegacyConnector({
+                connector: new WalletConnectConnector({
                   chains,
                   options: {},
                 }),

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.test.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import { mainnet, polygon } from 'wagmi/chains';
+import { mainnet } from 'wagmi/chains';
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
-import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy';
 import { getWalletConnectConnector } from './getWalletConnectConnector';
 
 /*
@@ -14,10 +13,6 @@ describe('getWalletConnectConnector', () => {
   const projectId = 'test-project-id';
 
   describe('generic', () => {
-    it('without projectId', () => {
-      // eslint-disable-next-line jest/require-to-throw-message
-      expect(() => getWalletConnectConnector({ chains })).toThrowError();
-    });
     it('with projectId', () => {
       const connector = getWalletConnectConnector({ chains, projectId });
       expect(connector.id).toBe('walletConnect');
@@ -27,49 +22,12 @@ describe('getWalletConnectConnector', () => {
       const connector = getWalletConnectConnector({ chains, projectId });
       expect(connector.options.showQrModal).toBe(false);
     });
-    it('v1 qrcode defaults', () => {
-      const connector = getWalletConnectConnector({
-        chains,
-        projectId,
-        version: '1',
-      });
-      expect(connector.options.qrcode).toBe(false);
-    });
     it('v2 qrcode defaults', () => {
       const connector = getWalletConnectConnector({
         chains,
         projectId,
-        version: '2',
       });
       expect(connector.options.showQrModal).toBe(false);
-    });
-  });
-
-  describe("version '1'", () => {
-    it('without options', () => {
-      const connector = getWalletConnectConnector({
-        chains: [polygon],
-        version: '1',
-      });
-      expect(connector.id).toBe('walletConnectLegacy');
-      expectTypeOf(connector).toMatchTypeOf<WalletConnectLegacyConnector>();
-      expect(connector.options.qrcode).toBe(false);
-    });
-    it('with options', () => {
-      const connector = getWalletConnectConnector({
-        chains,
-        options: {
-          qrcode: true,
-          qrcodeModalOptions: {
-            desktopLinks: ['ledger'],
-            mobileLinks: ['rainbow'],
-          },
-        },
-        version: '1',
-      });
-      expect(connector.id).toBe('walletConnectLegacy');
-      expectTypeOf(connector).toMatchTypeOf<WalletConnectLegacyConnector>();
-      expect(connector.options.qrcode).toBe(true);
     });
   });
 
@@ -78,7 +36,6 @@ describe('getWalletConnectConnector', () => {
       const connector = getWalletConnectConnector({
         chains,
         projectId,
-        version: '2',
       });
       expect(connector.id).toBe('walletConnect');
       expectTypeOf(connector).toMatchTypeOf<WalletConnectConnector>();
@@ -90,7 +47,6 @@ describe('getWalletConnectConnector', () => {
           showQrModal: true,
         },
         projectId,
-        version: '2',
       });
       expect(connector.id).toBe('walletConnect');
       expectTypeOf(connector).toMatchTypeOf<WalletConnectConnector>();

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -1,16 +1,9 @@
-/* eslint-disable @typescript-eslint/unified-signatures */
 /* eslint-disable no-redeclare */
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
-import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy';
 import { Chain } from '../components/RainbowKitProvider/RainbowKitChainContext';
 
 type SerializedOptions = string;
-const sharedConnectors = new Map<
-  SerializedOptions,
-  WalletConnectLegacyConnector | WalletConnectConnector
->();
-
-type WalletConnectVersion = '1' | '2';
+const sharedConnectors = new Map<SerializedOptions, WalletConnectConnector>();
 
 type WalletConnectConnectorConfig = ConstructorParameters<
   typeof WalletConnectConnector
@@ -19,40 +12,21 @@ export type WalletConnectConnectorOptions =
   // @ts-ignore
   WalletConnectConnectorConfig['options'];
 
-type WalletConnectLegacyConnectorConfig = ConstructorParameters<
-  typeof WalletConnectLegacyConnector
->[0];
-export type WalletConnectLegacyConnectorOptions =
-  // @ts-ignore
-  WalletConnectLegacyConnectorConfig['options'];
-
 function createConnector(
-  version: WalletConnectVersion,
-  config: WalletConnectLegacyConnectorConfig | WalletConnectConnectorConfig
-): WalletConnectLegacyConnector | WalletConnectConnector {
-  const connector =
-    version === '1'
-      ? new WalletConnectLegacyConnector(config)
-      : new WalletConnectConnector(config);
+  config: WalletConnectConnectorConfig
+): WalletConnectConnector {
+  const connector = new WalletConnectConnector(config);
   sharedConnectors.set(JSON.stringify(config), connector);
   return connector;
 }
 
 export function getWalletConnectConnector(config: {
-  version?: WalletConnectVersion;
-  projectId?: string;
+  projectId: string;
   chains: Chain[];
   options?: WalletConnectConnectorOptions;
 }): WalletConnectConnector;
 
 export function getWalletConnectConnector(config: {
-  version: '1';
-  chains: Chain[];
-  options?: WalletConnectLegacyConnectorOptions;
-}): WalletConnectLegacyConnector;
-
-export function getWalletConnectConnector(config: {
-  version: '2';
   projectId: string;
   chains: Chain[];
   options?: WalletConnectConnectorOptions;
@@ -62,34 +36,27 @@ export function getWalletConnectConnector({
   chains,
   options = {},
   projectId,
-  version = '2',
 }: {
   chains: Chain[];
-  projectId?: string;
-  version?: WalletConnectVersion;
-  options?: WalletConnectLegacyConnectorOptions | WalletConnectConnectorOptions;
-}): WalletConnectConnector | WalletConnectLegacyConnector {
-  if (version === '2' && !projectId)
+  projectId: string;
+  options?: WalletConnectConnectorOptions;
+}): WalletConnectConnector {
+  if (!projectId)
     throw new Error(
       'No projectId found. Every dApp must now provide a WalletConnect Cloud projectId to enable WalletConnect v2 https://www.rainbowkit.com/docs/installation'
     );
+
   const config = {
     chains,
-    options:
-      version === '1'
-        ? {
-            qrcode: false,
-            ...options,
-          }
-        : {
-            projectId,
-            showQrModal: false,
-            ...options,
-          },
+    options: {
+      projectId,
+      showQrModal: false,
+      ...options,
+    },
   };
 
   const serializedConfig = JSON.stringify(config);
   const sharedConnector = sharedConnectors.get(serializedConfig);
 
-  return sharedConnector ?? createConnector(version, config);
+  return sharedConnector ?? createConnector(config);
 }

--- a/packages/rainbowkit/src/wallets/walletConnectors/argentWallet/argentWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/argentWallet/argentWallet.ts
@@ -4,22 +4,11 @@ import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isAndroid } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
-import type {
-  WalletConnectConnectorOptions,
-  WalletConnectLegacyConnectorOptions,
-} from '../../getWalletConnectConnector';
-
-export interface ArgentWalletLegacyOptions {
-  projectId?: string;
-  chains: Chain[];
-  walletConnectVersion: '1';
-  walletConnectOptions?: WalletConnectLegacyConnectorOptions;
-}
+import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
 export interface ArgentWalletOptions {
   projectId: string;
   chains: Chain[];
-  walletConnectVersion?: '2';
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
@@ -27,8 +16,7 @@ export const argentWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  walletConnectVersion = '2',
-}: ArgentWalletLegacyOptions | ArgentWalletOptions): Wallet => ({
+}: ArgentWalletOptions): Wallet => ({
   id: 'argent',
   name: 'Argent',
   iconUrl: async () => (await import('./argentWallet.svg')).default,
@@ -44,7 +32,6 @@ export const argentWallet = ({
     const connector = getWalletConnectConnector({
       projectId,
       chains,
-      version: walletConnectVersion,
       options: walletConnectOptions,
     });
 
@@ -52,18 +39,14 @@ export const argentWallet = ({
       connector,
       mobile: {
         getUri: async () => {
-          const uri = await getWalletConnectUri(
-            connector,
-            walletConnectVersion
-          );
+          const uri = await getWalletConnectUri(connector);
           return isAndroid()
             ? uri
             : `argent://app/wc?uri=${encodeURIComponent(uri)}`;
         },
       },
       qrCode: {
-        getUri: async () =>
-          getWalletConnectUri(connector, walletConnectVersion),
+        getUri: async () => getWalletConnectUri(connector),
         instructions: {
           learnMoreUrl: 'https://argent.xyz/learn/what-is-a-crypto-wallet/',
           steps: [

--- a/packages/rainbowkit/src/wallets/walletConnectors/imTokenWallet/imTokenWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/imTokenWallet/imTokenWallet.ts
@@ -3,22 +3,11 @@ import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainCon
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
-import type {
-  WalletConnectConnectorOptions,
-  WalletConnectLegacyConnectorOptions,
-} from '../../getWalletConnectConnector';
-
-export interface ImTokenWalletLegacyOptions {
-  projectId?: string;
-  chains: Chain[];
-  walletConnectVersion: '1';
-  walletConnectOptions?: WalletConnectLegacyConnectorOptions;
-}
+import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
 export interface ImTokenWalletOptions {
   projectId: string;
   chains: Chain[];
-  walletConnectVersion?: '2';
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
@@ -26,8 +15,7 @@ export const imTokenWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  walletConnectVersion = '2',
-}: ImTokenWalletLegacyOptions | ImTokenWalletOptions): Wallet => ({
+}: ImTokenWalletOptions): Wallet => ({
   id: 'imToken',
   name: 'imToken',
   iconUrl: async () => (await import('./imTokenWallet.svg')).default,
@@ -42,7 +30,6 @@ export const imTokenWallet = ({
     const connector = getWalletConnectConnector({
       projectId,
       chains,
-      version: walletConnectVersion,
       options: walletConnectOptions,
     });
 
@@ -50,16 +37,12 @@ export const imTokenWallet = ({
       connector,
       mobile: {
         getUri: async () => {
-          const uri = await getWalletConnectUri(
-            connector,
-            walletConnectVersion
-          );
+          const uri = await getWalletConnectUri(connector);
           return `imtokenv2://wc?uri=${encodeURIComponent(uri)}`;
         },
       },
       qrCode: {
-        getUri: async () =>
-          getWalletConnectUri(connector, walletConnectVersion),
+        getUri: async () => getWalletConnectUri(connector),
         instructions: {
           learnMoreUrl:
             typeof window !== 'undefined' &&

--- a/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
@@ -4,17 +4,7 @@ import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isAndroid } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
-import type {
-  WalletConnectConnectorOptions,
-  WalletConnectLegacyConnectorOptions,
-} from '../../getWalletConnectConnector';
-
-export interface LedgerWalletLegacyOptions {
-  projectId?: string;
-  chains: Chain[];
-  walletConnectVersion: '1';
-  walletConnectOptions?: WalletConnectLegacyConnectorOptions;
-}
+import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
 export interface LedgerWalletOptions {
   projectId: string;
@@ -27,8 +17,7 @@ export const ledgerWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  walletConnectVersion = '2',
-}: LedgerWalletLegacyOptions | LedgerWalletOptions): Wallet => ({
+}: LedgerWalletOptions): Wallet => ({
   id: 'ledger',
   iconBackground: '#000',
   name: 'Ledger Live',
@@ -43,7 +32,6 @@ export const ledgerWallet = ({
     const connector = getWalletConnectConnector({
       projectId,
       chains,
-      version: walletConnectVersion,
       options: walletConnectOptions,
     });
 
@@ -51,10 +39,7 @@ export const ledgerWallet = ({
       connector,
       mobile: {
         getUri: async () => {
-          const uri = await getWalletConnectUri(
-            connector,
-            walletConnectVersion
-          );
+          const uri = await getWalletConnectUri(connector);
           return isAndroid()
             ? uri
             : `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
@@ -62,10 +47,7 @@ export const ledgerWallet = ({
       },
       desktop: {
         getUri: async () => {
-          const uri = await getWalletConnectUri(
-            connector,
-            walletConnectVersion
-          );
+          const uri = await getWalletConnectUri(connector);
           return `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
         },
       },

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -6,22 +6,11 @@ import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isAndroid, isIOS } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
-import type {
-  WalletConnectConnectorOptions,
-  WalletConnectLegacyConnectorOptions,
-} from '../../getWalletConnectConnector';
-
-export interface MetaMaskWalletLegacyOptions {
-  projectId?: string;
-  chains: Chain[];
-  walletConnectVersion: '1';
-  walletConnectOptions?: WalletConnectLegacyConnectorOptions;
-}
+import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
 export interface MetaMaskWalletOptions {
   projectId: string;
   chains: Chain[];
-  walletConnectVersion?: '2';
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
@@ -73,10 +62,8 @@ export const metaMaskWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  walletConnectVersion = '2',
   ...options
-}: (MetaMaskWalletLegacyOptions | MetaMaskWalletOptions) &
-  MetaMaskConnectorOptions): Wallet => {
+}: MetaMaskWalletOptions & MetaMaskConnectorOptions): Wallet => {
   const providers = typeof window !== 'undefined' && window.ethereum?.providers;
 
   // Not using the explicit isMetaMask fn to check for MetaMask
@@ -114,7 +101,6 @@ export const metaMaskWallet = ({
         ? getWalletConnectConnector({
             projectId,
             chains,
-            version: walletConnectVersion,
             options: walletConnectOptions,
           })
         : new MetaMaskConnector({
@@ -131,7 +117,7 @@ export const metaMaskWallet = ({
           });
 
       const getUri = async () => {
-        const uri = await getWalletConnectUri(connector, walletConnectVersion);
+        const uri = await getWalletConnectUri(connector);
         return isAndroid()
           ? uri
           : isIOS()

--- a/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
@@ -6,22 +6,11 @@ import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isAndroid } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
-import type {
-  WalletConnectConnectorOptions,
-  WalletConnectLegacyConnectorOptions,
-} from '../../getWalletConnectConnector';
-
-export interface OKXWalletLegacyOptions {
-  projectId?: string;
-  chains: Chain[];
-  walletConnectVersion: '1';
-  walletConnectOptions?: WalletConnectLegacyConnectorOptions;
-}
+import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
 export interface OKXWalletOptions {
   projectId: string;
   chains: Chain[];
-  walletConnectVersion?: '2';
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
@@ -29,10 +18,8 @@ export const okxWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  walletConnectVersion = '2',
   ...options
-}: (OKXWalletLegacyOptions | OKXWalletOptions) &
-  InjectedConnectorOptions): Wallet => {
+}: OKXWalletOptions & InjectedConnectorOptions): Wallet => {
   // `isOkxWallet` or `isOKExWallet` needs to be added to the wagmi `Ethereum` object
   const isOKXInjected =
     typeof window !== 'undefined' &&
@@ -64,7 +51,6 @@ export const okxWallet = ({
         ? getWalletConnectConnector({
             projectId,
             chains,
-            version: walletConnectVersion,
             options: walletConnectOptions,
           })
         : new InjectedConnector({
@@ -81,10 +67,7 @@ export const okxWallet = ({
         mobile: {
           getUri: shouldUseWalletConnect
             ? async () => {
-                const uri = await getWalletConnectUri(
-                  connector,
-                  walletConnectVersion
-                );
+                const uri = await getWalletConnectUri(connector);
                 return isAndroid()
                   ? uri
                   : `okex://main/wc?uri=${encodeURIComponent(uri)}`;
@@ -93,8 +76,7 @@ export const okxWallet = ({
         },
         qrCode: shouldUseWalletConnect
           ? {
-              getUri: async () =>
-                getWalletConnectUri(connector, walletConnectVersion),
+              getUri: async () => getWalletConnectUri(connector),
               instructions: {
                 learnMoreUrl: 'https://okx.com/web3/',
                 steps: [

--- a/packages/rainbowkit/src/wallets/walletConnectors/omniWallet/omniWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/omniWallet/omniWallet.ts
@@ -4,22 +4,11 @@ import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isAndroid } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
-import type {
-  WalletConnectConnectorOptions,
-  WalletConnectLegacyConnectorOptions,
-} from '../../getWalletConnectConnector';
-
-export interface OmniWalletLegacyOptions {
-  projectId?: string;
-  chains: Chain[];
-  walletConnectVersion: '1';
-  walletConnectOptions?: WalletConnectLegacyConnectorOptions;
-}
+import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
 export interface OmniWalletOptions {
   projectId: string;
   chains: Chain[];
-  walletConnectVersion?: '2';
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
@@ -27,8 +16,7 @@ export const omniWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  walletConnectVersion = '2',
-}: OmniWalletLegacyOptions | OmniWalletOptions): Wallet => ({
+}: OmniWalletOptions): Wallet => ({
   id: 'omni',
   name: 'Omni',
   iconUrl: async () => (await import('./omniWallet.svg')).default,
@@ -43,7 +31,6 @@ export const omniWallet = ({
     const connector = getWalletConnectConnector({
       projectId,
       chains,
-      version: walletConnectVersion,
       options: walletConnectOptions,
     });
 
@@ -51,16 +38,12 @@ export const omniWallet = ({
       connector,
       mobile: {
         getUri: async () => {
-          const uri = await getWalletConnectUri(
-            connector,
-            walletConnectVersion
-          );
+          const uri = await getWalletConnectUri(connector);
           return isAndroid() ? uri : `omni://wc?uri=${encodeURIComponent(uri)}`;
         },
       },
       qrCode: {
-        getUri: async () =>
-          getWalletConnectUri(connector, walletConnectVersion),
+        getUri: async () => getWalletConnectUri(connector),
         instructions: {
           learnMoreUrl: 'https://omni.app/support',
           steps: [

--- a/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
@@ -6,22 +6,11 @@ import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isAndroid, isIOS } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
-import type {
-  WalletConnectConnectorOptions,
-  WalletConnectLegacyConnectorOptions,
-} from '../../getWalletConnectConnector';
-
-export interface RainbowWalletLegacyOptions {
-  projectId?: string;
-  chains: Chain[];
-  walletConnectVersion: '1';
-  walletConnectOptions?: WalletConnectLegacyConnectorOptions;
-}
+import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
 export interface RainbowWalletOptions {
   projectId: string;
   chains: Chain[];
-  walletConnectVersion?: '2';
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
@@ -40,7 +29,6 @@ export const rainbowWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  walletConnectVersion = '2',
   ...options
 }: RainbowWalletOptions & InjectedConnectorOptions): Wallet => {
   const isRainbowInjected =
@@ -69,7 +57,6 @@ export const rainbowWallet = ({
         ? getWalletConnectConnector({
             projectId,
             chains,
-            version: walletConnectVersion,
             options: walletConnectOptions,
           })
         : new InjectedConnector({
@@ -78,7 +65,7 @@ export const rainbowWallet = ({
           });
 
       const getUri = async () => {
-        const uri = await getWalletConnectUri(connector, walletConnectVersion);
+        const uri = await getWalletConnectUri(connector);
         return isAndroid()
           ? uri
           : isIOS()

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -5,22 +5,12 @@ import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainCon
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { InstructionStepName, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
-import type {
-  WalletConnectConnectorOptions,
-  WalletConnectLegacyConnectorOptions,
-} from '../../getWalletConnectConnector';
+import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
 declare global {
   interface Window {
     trustwallet: Window['ethereum'];
   }
-}
-
-export interface TrustWalletLegacyOptions {
-  projectId?: string;
-  chains: Chain[];
-  walletConnectVersion: '1';
-  walletConnectOptions?: WalletConnectLegacyConnectorOptions;
 }
 
 export interface TrustWalletOptions {
@@ -74,7 +64,6 @@ export const trustWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  walletConnectVersion = '2',
   ...options
 }: TrustWalletOptions & InjectedConnectorOptions): Wallet => {
   const isTrustWalletInjected = Boolean(getTrustWalletInjectedProvider());
@@ -102,13 +91,13 @@ export const trustWallet = ({
     },
     createConnector: () => {
       const getUriMobile = async () => {
-        const uri = await getWalletConnectUri(connector, walletConnectVersion);
+        const uri = await getWalletConnectUri(connector);
 
         return `trust://wc?uri=${encodeURIComponent(uri)}`;
       };
 
       const getUriQR = async () => {
-        const uri = await getWalletConnectUri(connector, walletConnectVersion);
+        const uri = await getWalletConnectUri(connector);
 
         return uri;
       };
@@ -117,7 +106,6 @@ export const trustWallet = ({
         ? getWalletConnectConnector({
             projectId,
             chains,
-            version: walletConnectVersion,
             options: walletConnectOptions,
           })
         : new InjectedConnector({

--- a/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.test.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import { mainnet } from 'wagmi/chains';
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
-import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy';
 import { walletConnectWallet } from './walletConnectWallet';
 
 describe('walletConnectWallet', () => {
@@ -22,49 +21,13 @@ describe('walletConnectWallet', () => {
     expectTypeOf(connector).toMatchTypeOf<WalletConnectConnector>();
   });
 
-  it('v1 options', () => {
-    const wallet = walletConnectWallet({
-      chains,
-      options: {
-        qrcode: true,
-        qrcodeModalOptions: {
-          desktopLinks: ['ledger'],
-          mobileLinks: ['rainbow'],
-        },
-      },
-      version: '1',
-    });
-    const { connector } = wallet.createConnector();
-
-    expect(connector.id).toBe('walletConnectLegacy');
-    expectTypeOf(connector).toMatchTypeOf<WalletConnectLegacyConnector>();
-
-    expect(connector.options.qrcode).toBe(true);
-    expect(connector.options.qrcodeModalOptions.desktopLinks).toHaveLength(1);
-  });
-
-  it('v1 custom bridge option', () => {
-    const wallet = walletConnectWallet({
-      chains,
-      options: {
-        bridge: 'https://bridge.myhostedserver.com',
-      },
-      version: '1',
-    });
-    const { connector } = wallet.createConnector();
-
-    expect(connector.id).toBe('walletConnectLegacy');
-    expectTypeOf(connector).toMatchTypeOf<WalletConnectLegacyConnector>();
-  });
-
-  it('v2 options', () => {
+  it('options', () => {
     const wallet = walletConnectWallet({
       chains,
       options: {
         showQrModal: true,
       },
       projectId,
-      version: '2',
     });
     const { connector } = wallet.createConnector();
 
@@ -75,14 +38,13 @@ describe('walletConnectWallet', () => {
     expect(connector.options.showQrModal).toBe(true);
   });
 
-  it('v2 walletConnectOptions', () => {
+  it('walletConnectOptions', () => {
     const wallet = walletConnectWallet({
       chains,
       options: {
         showQrModal: true,
       },
       projectId,
-      version: '2',
     });
     const { connector } = wallet.createConnector();
 

--- a/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.ts
@@ -4,17 +4,7 @@ import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isIOS } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
-import type {
-  WalletConnectConnectorOptions,
-  WalletConnectLegacyConnectorOptions,
-} from '../../getWalletConnectConnector';
-
-export interface WalletConnectWalletLegacyOptions {
-  projectId?: string;
-  chains: Chain[];
-  version: '1';
-  options?: WalletConnectLegacyConnectorOptions;
-}
+import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
 export interface WalletConnectWalletOptions {
   projectId: string;
@@ -27,8 +17,7 @@ export const walletConnectWallet = ({
   chains,
   options,
   projectId,
-  version = '2',
-}: WalletConnectWalletLegacyOptions | WalletConnectWalletOptions): Wallet => ({
+}: WalletConnectWalletOptions): Wallet => ({
   id: 'walletConnect',
   name: 'WalletConnect',
   iconUrl: async () => (await import('./walletConnectWallet.svg')).default,
@@ -36,27 +25,16 @@ export const walletConnectWallet = ({
   createConnector: () => {
     const ios = isIOS();
 
-    const connector =
-      version === '1'
-        ? getWalletConnectConnector({
-            version: '1',
-            chains,
-            options: {
-              qrcode: ios,
-              ...options,
-            },
-          })
-        : getWalletConnectConnector({
-            version: '2',
-            chains,
-            projectId,
-            options: {
-              showQrModal: ios,
-              ...options,
-            },
-          });
+    const connector = getWalletConnectConnector({
+      chains,
+      projectId,
+      options: {
+        showQrModal: ios,
+        ...options,
+      },
+    });
 
-    const getUri = async () => getWalletConnectUri(connector, version);
+    const getUri = async () => getWalletConnectUri(connector);
 
     return {
       connector,

--- a/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
@@ -6,22 +6,11 @@ import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isIOS } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
-import type {
-  WalletConnectConnectorOptions,
-  WalletConnectLegacyConnectorOptions,
-} from '../../getWalletConnectConnector';
-
-export interface ZerionWalletLegacyOptions {
-  projectId?: string;
-  chains: Chain[];
-  walletConnectVersion: '1';
-  walletConnectOptions?: WalletConnectLegacyConnectorOptions;
-}
+import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
 export interface ZerionWalletOptions {
   projectId: string;
   chains: Chain[];
-  walletConnectVersion?: '2';
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
@@ -29,10 +18,8 @@ export const zerionWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  walletConnectVersion = '2',
   ...options
-}: (ZerionWalletOptions | ZerionWalletLegacyOptions) &
-  InjectedConnectorOptions): Wallet => {
+}: ZerionWalletOptions & InjectedConnectorOptions): Wallet => {
   const isZerionInjected =
     typeof window !== 'undefined' &&
     ((typeof window.ethereum !== 'undefined' && window.ethereum.isZerion) ||
@@ -63,7 +50,6 @@ export const zerionWallet = ({
         ? getWalletConnectConnector({
             projectId,
             chains,
-            version: walletConnectVersion,
             options: walletConnectOptions,
           })
         : new InjectedConnector({
@@ -79,7 +65,7 @@ export const zerionWallet = ({
           });
 
       const getUri = async () => {
-        const uri = await getWalletConnectUri(connector, walletConnectVersion);
+        const uri = await getWalletConnectUri(connector);
         return isIOS() ? `zerion://wc?uri=${encodeURIComponent(uri)}` : uri;
       };
 


### PR DESCRIPTION
Now that WalletConnect v1 is shut down, WalletConnect v1 support is removed in this PR to decrease RainbowKit's overall bundle size by 40kb.