### PR TITLE
fix: don't close connect modal on disconnect

### DIFF
--- a/packages/rainbowkit/src/components/RainbowKitProvider/ModalContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/ModalContext.tsx
@@ -82,7 +82,7 @@ export function ModalProvider({ children }: ModalProviderProps) {
   const isUnauthenticated = useAuthenticationStatus() === 'unauthenticated';
   useAccount({
     onConnect: () => closeModals({ keepConnectModalOpen: isUnauthenticated }),
-    onDisconnect: () => closeModals(),
+    onDisconnect: () => closeModals({ keepConnectModalOpen: true }),
   });
 
   return (


### PR DESCRIPTION
Connect modal should only be closed by connecting.

It's rare for it to be open when a disconnect happens, since you'd expect a disconnect to happen from an already connected state. But it can happen, e.g. if you have a handler to open the connect modal on disconnect, which causes a race condition with the handler to close the connect modal on disconnect.