### PR TITLE
fix: metamask deep link

### DIFF
--- a/.changeset/rich-mugs-occur.md
+++ b/.changeset/rich-mugs-occur.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Fixed an issue with MetaMask Mobile's connector that blocked WalletConnect pairings

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -136,7 +136,7 @@ export const metaMaskWallet = ({
           ? uri
           : isIOS()
           ? // currently broken in MetaMask v6.5.0 https://github.com/MetaMask/metamask-mobile/issues/6457
-            `metamask:///wc?uri=${encodeURIComponent(uri)}`
+            `metamask://wc?uri=${encodeURIComponent(uri)}`
           : `https://metamask.app.link/wc?uri=${encodeURIComponent(uri)}`;
       };
 


### PR DESCRIPTION

### Referance:

The way WalletConnect uses to generate deep link
https://github.com/WalletConnect/modal/blob/main/packages/modal-core/src/utils/CoreUtil.ts#L39

Here is the MetaMask data from https://explorer-api.walletconnect.com/w3m/v1/getAllListings?projectId={projectId}
```json
"id": "c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96",
"name": "MetaMask",
"homepage": "https://metamask.io/",
"image_id": "5195e9db-94d8-4579-6f11-ef553be95100",
"order": 10,
"app": {
"browser": null,
"ios": "https://apps.apple.com/us/app/metamask/id1438144202",
"android": "https://play.google.com/store/apps/details?id=io.metamask",
"mac": null,
"windows": null,
"linux": null,
"chrome": "https://chrome.google.com/webstore/detail/metamask/nkbihfbeogaeaoehlefnkodbefgpgknn",
"firefox": "https://addons.mozilla.org/en-US/firefox/addon/ether-metamask/",
"safari": null,
"edge": "https://microsoftedge.microsoft.com/addons/detail/metamask/ejbalbakoplchlghecdalmeeeajnimhm?hl=en-US",
"opera": "https://addons.opera.com/en-gb/extensions/details/metamask-10/"
},
"injected": [
    {
        "injected_id": "isMetaMask",
        "namespace": "eip155"
    }
],
"mobile": {
    "native": "metamask://",
    "universal": "https://metamask.app.link/"
},
"desktop": {
    "native": null,
    "universal": ""
}
```


issue: #1340 