### PR TITLE
chore: trust wallet connector maintenance

### DIFF
--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -124,7 +124,6 @@ export const trustWallet = ({
             chains,
             options: {
               name: 'Trust Wallet',
-              shimChainChangedDisconnect: true,
               getProvider: getTrustWalletInjectedProvider,
               ...options,
             },

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -123,7 +123,6 @@ export const trustWallet = ({
         : new InjectedConnector({
             chains,
             options: {
-              name: 'Trust Wallet',
               getProvider: getTrustWalletInjectedProvider,
               ...options,
             },


### PR DESCRIPTION
- Deprecated `shimChainChangedDisconnect`
- Deprecated `name` supplied to `InjectedConnector`