### PR TITLE
fix: legacy connector type safety

### DIFF
--- a/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
@@ -42,7 +42,8 @@ export const rainbowWallet = ({
   walletConnectOptions,
   walletConnectVersion = '2',
   ...options
-}: RainbowWalletOptions & InjectedConnectorOptions): Wallet => {
+}: (RainbowWalletLegacyOptions | RainbowWalletOptions) &
+  InjectedConnectorOptions): Wallet => {
   const isRainbowInjected =
     typeof window !== 'undefined' &&
     typeof window.ethereum !== 'undefined' &&

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -76,7 +76,8 @@ export const trustWallet = ({
   walletConnectOptions,
   walletConnectVersion = '2',
   ...options
-}: TrustWalletOptions & InjectedConnectorOptions): Wallet => {
+}: (TrustWalletLegacyOptions | TrustWalletOptions) &
+  InjectedConnectorOptions): Wallet => {
   const isTrustWalletInjected = Boolean(getTrustWalletInjectedProvider());
   const shouldUseWalletConnect = !isTrustWalletInjected;
 


### PR DESCRIPTION
- fixed missing `RainbowWalletLegacyOptions` 
- fixed missing `TrustWalletLegacyOptions`