### PR TITLE
feat: colloquial chain names

### DIFF
--- a/.changeset/nice-wombats-exist.md
+++ b/.changeset/nice-wombats-exist.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+RainbowKit now adopts standardized colloquial chain names like `Arbitrum` and `Optimism` for mainnet chains to simplify the chain switching experience

--- a/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
+++ b/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
@@ -72,111 +72,117 @@ export function ChainModal({ onClose, open }: ChainModalProps) {
           )}
           <Box display="flex" flexDirection="column" gap="4" padding="2">
             {switchNetwork ? (
-              rainbowkitChains.map(({ iconBackground, iconUrl, id }, idx) => {
-                const chain = chains.find(c => c.id === id);
-                if (!chain) return null;
+              rainbowkitChains.map(
+                ({ iconBackground, iconUrl, id, name }, idx) => {
+                  const chain = chains.find(c => c.id === id);
+                  if (!chain) return null;
 
-                const isCurrentChain = chain.id === activeChain?.id;
-                const switching =
-                  !isCurrentChain && chain.id === pendingChainId;
+                  const isCurrentChain = chain.id === activeChain?.id;
+                  const switching =
+                    !isCurrentChain && chain.id === pendingChainId;
 
-                return (
-                  <Fragment key={chain.id}>
-                    <MenuButton
-                      currentlySelected={isCurrentChain}
-                      onClick={
-                        isCurrentChain
-                          ? undefined
-                          : () => switchNetwork(chain.id)
-                      }
-                      testId={`chain-option-${chain.id}`}
-                    >
-                      <Box fontFamily="body" fontSize="16" fontWeight="bold">
-                        <Box
-                          alignItems="center"
-                          display="flex"
-                          flexDirection="row"
-                          justifyContent="space-between"
-                        >
+                  return (
+                    <Fragment key={chain.id}>
+                      <MenuButton
+                        currentlySelected={isCurrentChain}
+                        onClick={
+                          isCurrentChain
+                            ? undefined
+                            : () => switchNetwork(chain.id)
+                        }
+                        testId={`chain-option-${chain.id}`}
+                      >
+                        <Box fontFamily="body" fontSize="16" fontWeight="bold">
                           <Box
                             alignItems="center"
                             display="flex"
                             flexDirection="row"
-                            gap="4"
-                            height={chainIconSize}
+                            justifyContent="space-between"
                           >
-                            {iconUrl && (
-                              <Box height="full" marginRight="8">
-                                <AsyncImage
-                                  alt={chain.name}
-                                  background={iconBackground}
+                            <Box
+                              alignItems="center"
+                              display="flex"
+                              flexDirection="row"
+                              gap="4"
+                              height={chainIconSize}
+                            >
+                              {iconUrl && (
+                                <Box height="full" marginRight="8">
+                                  <AsyncImage
+                                    alt={name ?? chain.name}
+                                    background={iconBackground}
+                                    borderRadius="full"
+                                    height={chainIconSize}
+                                    src={iconUrl}
+                                    width={chainIconSize}
+                                  />
+                                </Box>
+                              )}
+                              <div>{name ?? chain.name}</div>
+                            </Box>
+                            {isCurrentChain && (
+                              <Box
+                                alignItems="center"
+                                display="flex"
+                                flexDirection="row"
+                                marginRight="6"
+                              >
+                                <Text
+                                  color="accentColorForeground"
+                                  size="14"
+                                  weight="medium"
+                                >
+                                  Connected
+                                </Text>
+                                <Box
+                                  background="connectionIndicator"
+                                  borderColor="selectedOptionBorder"
                                   borderRadius="full"
-                                  height={chainIconSize}
-                                  src={iconUrl}
-                                  width={chainIconSize}
+                                  borderStyle="solid"
+                                  borderWidth="1"
+                                  height="8"
+                                  marginLeft="8"
+                                  width="8"
                                 />
                               </Box>
                             )}
-                            <div>{chain.name}</div>
-                          </Box>
-                          {isCurrentChain && (
-                            <Box
-                              alignItems="center"
-                              display="flex"
-                              flexDirection="row"
-                              marginRight="6"
-                            >
-                              <Text
-                                color="accentColorForeground"
-                                size="14"
-                                weight="medium"
+                            {switching && (
+                              <Box
+                                alignItems="center"
+                                display="flex"
+                                flexDirection="row"
+                                marginRight="6"
                               >
-                                Connected
-                              </Text>
-                              <Box
-                                background="connectionIndicator"
-                                borderColor="selectedOptionBorder"
-                                borderRadius="full"
-                                borderStyle="solid"
-                                borderWidth="1"
-                                height="8"
-                                marginLeft="8"
-                                width="8"
-                              />
-                            </Box>
-                          )}
-                          {switching && (
-                            <Box
-                              alignItems="center"
-                              display="flex"
-                              flexDirection="row"
-                              marginRight="6"
-                            >
-                              <Text color="modalText" size="14" weight="medium">
-                                Confirm in Wallet
-                              </Text>
-                              <Box
-                                background="standby"
-                                borderRadius="full"
-                                height="8"
-                                marginLeft="8"
-                                width="8"
-                              />
-                            </Box>
-                          )}
+                                <Text
+                                  color="modalText"
+                                  size="14"
+                                  weight="medium"
+                                >
+                                  Confirm in Wallet
+                                </Text>
+                                <Box
+                                  background="standby"
+                                  borderRadius="full"
+                                  height="8"
+                                  marginLeft="8"
+                                  width="8"
+                                />
+                              </Box>
+                            )}
+                          </Box>
                         </Box>
-                      </Box>
-                    </MenuButton>
-                    {mobile && idx < rainbowkitChains.length - 1 && (
-                      <Box
-                        background="generalBorderDim"
-                        height="1"
-                        marginX="8"
-                      />
-                    )}
-                  </Fragment>
-                );
-              })
+                      </MenuButton>
+                      {mobile && idx < rainbowkitChains.length - 1 && (
+                        <Box
+                          background="generalBorderDim"
+                          height="1"
+                          marginX="8"
+                        />
+                      )}
+                    </Fragment>
+                  );
+                }
+              )
             ) : (
               <Box
                 background="generalBorder"

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
@@ -70,6 +70,7 @@ export function ConnectButtonRenderer({
   const rainbowKitChain = activeChain
     ? rainbowkitChainsById[activeChain.id]
     : undefined;
+  const chainName = rainbowKitChain?.name ?? undefined;
   const chainIconUrl = rainbowKitChain?.iconUrl ?? undefined;
   const chainIconBackground = rainbowKitChain?.iconBackground ?? undefined;
 
@@ -118,7 +119,7 @@ export function ConnectButtonRenderer({
               iconBackground: chainIconBackground,
               iconUrl: resolvedChainIconUrl,
               id: activeChain.id,
-              name: activeChain.name,
+              name: chainName ?? activeChain.name,
               unsupported: activeChain.unsupported,
             }
           : undefined,

--- a/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitChainContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitChainContext.tsx
@@ -4,6 +4,7 @@ import { provideRainbowKitChains } from './provideRainbowKitChains';
 
 export interface RainbowKitChain {
   id: number;
+  name?: string;
   iconUrl?: string | (() => Promise<string>) | null;
   iconBackground?: string;
 }

--- a/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
@@ -95,7 +95,7 @@ const chainMetadataByName: Record<ChainName, ChainMetadata | null> = {
   avalanche: { chainId: 43_114, ...avalancheIcon },
   avalancheFuji: { chainId: 43_113, ...avalancheIcon },
   baseGoerli: { chainId: 84531, ...baseIcon },
-  bsc: { chainId: 56, ...bscIcon },
+  bsc: { chainId: 56, name: 'BSC', ...bscIcon },
   bscTestnet: { chainId: 97, ...bscIcon },
   cronos: { chainId: 25, ...cronosIcon },
   cronosTestnet: { chainId: 338, ...cronosIcon },

--- a/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
@@ -36,6 +36,7 @@ type IconMetadata = {
 
 type ChainMetadata = {
   chainId: number;
+  name?: string;
 } & IconMetadata;
 
 const arbitrumIcon: IconMetadata = {
@@ -89,7 +90,7 @@ const zoraIcon: IconMetadata = {
 };
 
 const chainMetadataByName: Record<ChainName, ChainMetadata | null> = {
-  arbitrum: { chainId: 42_161, ...arbitrumIcon },
+  arbitrum: { chainId: 42_161, name: 'Arbitrum', ...arbitrumIcon },
   arbitrumGoerli: { chainId: 421_613, ...arbitrumIcon },
   avalanche: { chainId: 43_114, ...avalancheIcon },
   avalancheFuji: { chainId: 43_113, ...avalancheIcon },
@@ -103,7 +104,7 @@ const chainMetadataByName: Record<ChainName, ChainMetadata | null> = {
   kovan: { chainId: 42, ...ethereumIcon },
   localhost: { chainId: 1_337, ...ethereumIcon },
   mainnet: { chainId: 1, ...ethereumIcon },
-  optimism: { chainId: 10, ...optimismIcon },
+  optimism: { chainId: 10, name: 'Optimism', ...optimismIcon },
   optimismGoerli: { chainId: 420, ...optimismIcon },
   optimismKovan: { chainId: 69, ...optimismIcon },
   polygon: { chainId: 137, ...polygonIcon },
@@ -121,11 +122,11 @@ const chainMetadataById = Object.fromEntries(
     .map(({ chainId, ...metadata }) => [chainId, metadata])
 );
 
-/** @description Decorates an array of wagmi `Chain` objects with RainbowKitChain properties if not already provided */
+/** @description Decorates an array of wagmi `Chain` objects with RainbowKitChain property overrides */
 export const provideRainbowKitChains = <Chain extends RainbowKitChain>(
   chains: Chain[]
 ): Chain[] =>
   chains.map(chain => ({
-    ...(chainMetadataById[chain.id] ?? {}),
     ...chain,
+    ...(chainMetadataById[chain.id] ?? {}),
   }));


### PR DESCRIPTION
## Changes
- adopted `Arbitrum` over `Arbitrum One`
- adopted `Optimism` over `OP Mainnet`
- adopted `BSC` over `BNB Smart Chain`
- `RainbowKitChain` and `ChainMetadata` type support for `name`
- amended `ConnectButtonRenderer` and `ChainModal` to favor `RainbowKitChain` name overrrides