### PR TITLE
example: with-next-app, remove `appDir` next config option

### DIFF
--- a/examples/with-next-app/next.config.js
+++ b/examples/with-next-app/next.config.js
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: {
-    appDir: true,
-  },
   webpack: config => {
     config.resolve.fallback = { fs: false, net: false, tls: false };
     config.externals.push('pino-pretty', 'lokijs', 'encoding');


### PR DESCRIPTION
As per https://nextjs.org/docs/app/api-reference/next-config-js/appDir , the `appDir` option is no longer needed.