### PR TITLE
chore: fix safe wallet connector comment

### DIFF
--- a/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
@@ -23,7 +23,7 @@ export const safeWallet = ({
     !(typeof window === 'undefined') && window?.parent !== window,
   downloadUrls: {
     // We're opting not to provide a download prompt if the application is not 
-    // already running in an embedded app within the safe wallet site,
+    // already running as a Safe App within the context of the Safe browser,
     // since it's unlikely to be a desired behavior for users.
   },
   createConnector: () => ({

--- a/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
@@ -22,10 +22,9 @@ export const safeWallet = ({
     // borrowed from wagmi safe connector
     !(typeof window === 'undefined') && window?.parent !== window,
   downloadUrls: {
-    // We're opting not to provide a download prompt if Safe isn't the current
-    // browser since it's unlikely to be a desired behavior for users. It's
-    // more of a convenience for users who are already using Brave rather than
-    // an explicit wallet choice for users coming from other browsers.
+    // We're opting not to provide a download prompt if the application is not 
+    // already running in an embedded app within the safe wallet site,
+    // since it's unlikely to be a desired behavior for users.
   },
   createConnector: () => ({
     connector: new SafeConnector({ chains, options }),


### PR DESCRIPTION
Fixed comment on why safe wallet is not proposed among the various downloads. The previous description was a copy and paste of the brave connector.