### PR TITLE
chore: base network examples and templates

### DIFF
--- a/.changeset/two-moles-poke.md
+++ b/.changeset/two-moles-poke.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/create-rainbowkit': patch
+---
+
+Upgraded templates for `base` network support

--- a/examples/with-create-react-app/src/index.tsx
+++ b/examples/with-create-react-app/src/index.tsx
@@ -12,6 +12,7 @@ import {
   polygon,
   optimism,
   arbitrum,
+  base,
   zora,
   goerli,
 } from 'wagmi/chains';
@@ -24,6 +25,7 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
     polygon,
     optimism,
     arbitrum,
+    base,
     zora,
     ...(process.env.REACT_APP_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],

--- a/examples/with-next-app/app/providers.tsx
+++ b/examples/with-next-app/app/providers.tsx
@@ -17,6 +17,7 @@ import {
   polygon,
   optimism,
   arbitrum,
+  base,
   zora,
   goerli,
 } from 'wagmi/chains';
@@ -28,6 +29,7 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
     polygon,
     optimism,
     arbitrum,
+    base,
     zora,
     ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],

--- a/examples/with-next-custom-button/pages/_app.tsx
+++ b/examples/with-next-custom-button/pages/_app.tsx
@@ -17,6 +17,7 @@ import {
   polygon,
   optimism,
   arbitrum,
+  base,
   zora,
   goerli,
 } from 'wagmi/chains';
@@ -28,6 +29,7 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
     polygon,
     optimism,
     arbitrum,
+    base,
     zora,
     ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],

--- a/examples/with-next-siwe-iron-session/pages/_app.tsx
+++ b/examples/with-next-siwe-iron-session/pages/_app.tsx
@@ -22,6 +22,7 @@ import {
   polygon,
   optimism,
   arbitrum,
+  base,
   zora,
   goerli,
 } from 'wagmi/chains';
@@ -35,6 +36,7 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
     polygon,
     optimism,
     arbitrum,
+    base,
     zora,
     ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],

--- a/examples/with-next-siwe-next-auth/pages/_app.tsx
+++ b/examples/with-next-siwe-next-auth/pages/_app.tsx
@@ -17,6 +17,7 @@ import {
   polygon,
   optimism,
   arbitrum,
+  base,
   zora,
   goerli,
 } from 'wagmi/chains';
@@ -34,6 +35,7 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
     polygon,
     optimism,
     arbitrum,
+    base,
     zora,
     ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],

--- a/examples/with-next/pages/_app.tsx
+++ b/examples/with-next/pages/_app.tsx
@@ -17,6 +17,7 @@ import {
   polygon,
   optimism,
   arbitrum,
+  base,
   zora,
   goerli,
 } from 'wagmi/chains';
@@ -28,6 +29,7 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
     polygon,
     optimism,
     arbitrum,
+    base,
     zora,
     ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],

--- a/examples/with-remix/app/root.tsx
+++ b/examples/with-remix/app/root.tsx
@@ -20,6 +20,7 @@ import {
   polygon,
   optimism,
   arbitrum,
+  base,
   zora,
   goerli,
 } from 'wagmi/chains';
@@ -72,7 +73,7 @@ export default function App() {
     const testChains = ENV.PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : [];
 
     const { chains, publicClient } = configureChains(
-      [mainnet, polygon, optimism, arbitrum, zora, ...testChains],
+      [mainnet, polygon, optimism, arbitrum, base, zora, ...testChains],
       [publicProvider()]
     );
 

--- a/examples/with-vite/src/main.tsx
+++ b/examples/with-vite/src/main.tsx
@@ -3,14 +3,14 @@ import './global.css';
 import '@rainbow-me/rainbowkit/styles.css';
 import { getDefaultWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit';
 import { configureChains, createConfig, WagmiConfig } from 'wagmi';
-import { mainnet, polygon, optimism, arbitrum, zora } from 'wagmi/chains';
+import { mainnet, polygon, optimism, arbitrum, base, zora } from 'wagmi/chains';
 import { publicProvider } from 'wagmi/providers/public';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 
 const { chains, publicClient } = configureChains(
-  [mainnet, polygon, optimism, arbitrum, zora],
+  [mainnet, polygon, optimism, arbitrum, base, zora],
   [publicProvider()]
 );
 

--- a/packages/create-rainbowkit/generated-test-app/pages/_app.tsx
+++ b/packages/create-rainbowkit/generated-test-app/pages/_app.tsx
@@ -3,7 +3,15 @@ import '@rainbow-me/rainbowkit/styles.css';
 import { getDefaultWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit';
 import type { AppProps } from 'next/app';
 import { configureChains, createConfig, WagmiConfig } from 'wagmi';
-import { arbitrum, goerli, mainnet, optimism, polygon } from 'wagmi/chains';
+import {
+  arbitrum,
+  goerli,
+  mainnet,
+  optimism,
+  polygon,
+  base,
+  zora,
+} from 'wagmi/chains';
 import { publicProvider } from 'wagmi/providers/public';
 
 const { chains, publicClient, webSocketPublicClient } = configureChains(
@@ -12,6 +20,8 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
     polygon,
     optimism,
     arbitrum,
+    base,
+    zora,
     ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],
   [publicProvider()]

--- a/packages/create-rainbowkit/templates/next-app/pages/_app.tsx
+++ b/packages/create-rainbowkit/templates/next-app/pages/_app.tsx
@@ -9,6 +9,7 @@ import {
   mainnet,
   optimism,
   polygon,
+  base,
   zora,
 } from 'wagmi/chains';
 import { publicProvider } from 'wagmi/providers/public';
@@ -19,6 +20,7 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
     polygon,
     optimism,
     arbitrum,
+    base,
     zora,
     ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],

--- a/packages/rainbowkit/test/index.tsx
+++ b/packages/rainbowkit/test/index.tsx
@@ -5,7 +5,7 @@ import { createWalletClient, http } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { configureChains, createConfig, WagmiConfig } from 'wagmi';
 import type { Chain } from 'wagmi';
-import { arbitrum, mainnet, optimism, polygon, zora } from 'wagmi/chains';
+import { arbitrum, base, mainnet, optimism, polygon, zora } from 'wagmi/chains';
 import { MockConnector } from 'wagmi/connectors/mock';
 import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
@@ -13,7 +13,7 @@ import { RainbowKitProvider } from '../src/components/RainbowKitProvider/Rainbow
 import type { RainbowKitProviderProps } from '../src/components/RainbowKitProvider/RainbowKitProvider';
 import { getDefaultWallets } from '../src/wallets/getDefaultWallets';
 
-const defaultChains = [mainnet, polygon, optimism, arbitrum, zora];
+const defaultChains = [mainnet, polygon, optimism, arbitrum, base, zora];
 
 export function renderWithProviders(
   component: ReactElement,
@@ -38,7 +38,7 @@ export function renderWithProviders(
   });
 
   const { chains, publicClient } = configureChains(
-    [mainnet, polygon, optimism, arbitrum, zora],
+    [mainnet, polygon, optimism, arbitrum, base, zora],
     [
       alchemyProvider({ apiKey: process.env.ALCHEMY_ID ?? '' }),
       publicProvider(),

--- a/site/components/Provider/Provider.tsx
+++ b/site/components/Provider/Provider.tsx
@@ -11,12 +11,20 @@ import {
 } from '@rainbow-me/rainbowkit/wallets';
 import React from 'react';
 import { configureChains, createConfig, WagmiConfig } from 'wagmi';
-import { arbitrum, bsc, mainnet, optimism, polygon, zora } from 'wagmi/chains';
+import {
+  arbitrum,
+  base,
+  bsc,
+  mainnet,
+  optimism,
+  polygon,
+  zora,
+} from 'wagmi/chains';
 import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 
 export const { chains, publicClient } = configureChains(
-  [mainnet, polygon, optimism, arbitrum, bsc, zora],
+  [mainnet, polygon, optimism, arbitrum, base, zora, bsc],
   [
     alchemyProvider({ apiKey: process.env.NEXT_PUBLIC_ALCHEMY_ID ?? '' }),
     publicProvider(),

--- a/site/data/docs/installation.mdx
+++ b/site/data/docs/installation.mdx
@@ -50,6 +50,7 @@ import {
   polygon,
   optimism,
   arbitrum,
+  base,
   zora,
 } from 'wagmi/chains';
 import { alchemyProvider } from 'wagmi/providers/alchemy';
@@ -68,7 +69,7 @@ import { alchemyProvider } from 'wagmi/providers/alchemy';
 import { publicProvider } from 'wagmi/providers/public';
 
 const { chains, publicClient } = configureChains(
-  [mainnet, polygon, optimism, arbitrum, zora],
+  [mainnet, polygon, optimism, arbitrum, base, zora],
   [
     alchemyProvider({ apiKey: process.env.ALCHEMY_ID }),
     publicProvider()


### PR DESCRIPTION
- Added `base` to RainbowKit examples
- Added `base` to `create-rainbowkit` templates