### PR TITLE
fix: rainbowWallet window.ethereum.providers support

### DIFF
--- a/packages/rainbowkit/src/wallets/getInjectedConnector.test.ts
+++ b/packages/rainbowkit/src/wallets/getInjectedConnector.test.ts
@@ -1,0 +1,139 @@
+/* eslint-disable sort-keys-fix/sort-keys-fix */
+import { describe, expect, it } from 'vitest';
+import type { WindowProvider } from 'wagmi';
+import { mainnet } from 'wagmi/chains';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from './getInjectedConnector';
+
+describe('getInjectedConnector', () => {
+  const chains = [mainnet];
+
+  it('only rainbow provider', () => {
+    window.ethereum = { isMetaMask: true, isRainbow: true } as WindowProvider;
+    const connector = getInjectedConnector({
+      flag: 'isRainbow',
+      chains,
+    });
+    expect(connector.name).toEqual('Rainbow');
+  });
+
+  it('only metamask provider', () => {
+    window.ethereum = { isMetaMask: true } as WindowProvider;
+    const connector = getInjectedConnector({
+      flag: 'isRainbow',
+      chains,
+    });
+    expect(connector.name).toEqual('MetaMask');
+  });
+
+  describe('rainbow and metamask providers', () => {
+    it('rainbow default enabled', () => {
+      window.ethereum = {
+        isMetaMask: true,
+        isRainbow: true,
+        providers: [
+          { isMetaMask: true, isRainbow: true },
+          { isMetaMask: true },
+        ],
+      } as WindowProvider;
+      const connector = getInjectedConnector({
+        flag: 'isRainbow',
+        chains,
+      });
+      expect(connector.name).toEqual('Rainbow');
+    });
+
+    it('rainbow default disabled rainbow connector', () => {
+      window.ethereum = {
+        isMetaMask: true,
+        providers: [
+          { isMetaMask: true },
+          { isMetaMask: true, isRainbow: true },
+        ],
+      } as WindowProvider;
+      const connector = getInjectedConnector({
+        flag: 'isRainbow',
+        chains,
+      });
+      expect(connector.name).toEqual('Rainbow');
+    });
+
+    it('rainbow default disabled metamask connector', () => {
+      window.ethereum = {
+        isMetaMask: true,
+        providers: [
+          { isMetaMask: true },
+          { isMetaMask: true, isRainbow: true },
+        ],
+      } as WindowProvider;
+      const connector = getInjectedConnector({
+        flag: 'isMetaMask',
+        chains,
+      });
+      expect(connector.name).toEqual('MetaMask');
+    });
+  });
+});
+
+describe('hasInjectedProvider', () => {
+  it('only rainbow provider', () => {
+    window.ethereum = { isMetaMask: true, isRainbow: true } as WindowProvider;
+    const hasRainbow = hasInjectedProvider('isRainbow');
+    expect(hasRainbow).toEqual(true);
+  });
+
+  it('only metamask provider', () => {
+    window.ethereum = { isMetaMask: true } as WindowProvider;
+    const hasRainbow = hasInjectedProvider('isRainbow');
+    expect(hasRainbow).toEqual(false);
+  });
+
+  it('only coinbase provider', () => {
+    window.ethereum = {
+      isMetaMask: true,
+      isCoinbaseWallet: true,
+    } as WindowProvider;
+    const hasCoinbase = hasInjectedProvider('isCoinbaseWallet');
+    expect(hasCoinbase).toEqual(true);
+  });
+
+  it('has rainbow and coinbase wallet', () => {
+    window.ethereum = {
+      isMetaMask: true,
+      isCoinbaseWallet: true,
+      providers: [
+        { isMetaMask: true, isCoinbaseWallet: true },
+        { isMetaMask: true, isRainbow: true },
+      ],
+    } as WindowProvider;
+
+    const hasCoinbase = hasInjectedProvider('isCoinbaseWallet');
+    expect(hasCoinbase).toEqual(true);
+
+    const hasRainbow = hasInjectedProvider('isRainbow');
+    expect(hasRainbow).toEqual(true);
+  });
+
+  it('has rainbow, coinbase wallet, and metamask', () => {
+    window.ethereum = {
+      isMetaMask: true,
+      isCoinbaseWallet: true,
+      providers: [
+        { isMetaMask: true, isCoinbaseWallet: true },
+        { isMetaMask: true, isRainbow: true },
+        { isMetaMask: true },
+      ],
+    } as WindowProvider;
+
+    const hasCoinbase = hasInjectedProvider('isCoinbaseWallet');
+    expect(hasCoinbase).toEqual(true);
+
+    const hasRainbow = hasInjectedProvider('isRainbow');
+    expect(hasRainbow).toEqual(true);
+
+    const hasMetaMask = hasInjectedProvider('isMetaMask');
+    expect(hasMetaMask).toEqual(true);
+  });
+});

--- a/packages/rainbowkit/src/wallets/getInjectedConnector.ts
+++ b/packages/rainbowkit/src/wallets/getInjectedConnector.ts
@@ -1,0 +1,60 @@
+import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
+import { InjectedConnector } from 'wagmi/connectors/injected';
+import type { InjectedProviderFlags, WindowProvider } from 'wagmi/window';
+import type { Chain } from '../components/RainbowKitProvider/RainbowKitChainContext';
+
+/*
+ * Returns the explicit window provider that matches the flag and the flag is true
+ */
+function getExplicitInjectedProvider(
+  flag: keyof InjectedProviderFlags
+): WindowProvider | undefined {
+  if (typeof window === 'undefined' || typeof window.ethereum === 'undefined')
+    return;
+  const providers = window.ethereum.providers;
+  return providers
+    ? providers.find(provider => provider[flag])
+    : window.ethereum[flag]
+    ? window.ethereum
+    : undefined;
+}
+
+export function hasInjectedProvider(
+  flag: keyof InjectedProviderFlags
+): boolean {
+  return Boolean(getExplicitInjectedProvider(flag));
+}
+
+/*
+ * Returns an injected provider that favors the flag match, but falls back to window.ethereum
+ */
+function getInjectedProvider(
+  flag: keyof InjectedProviderFlags
+): WindowProvider | undefined {
+  if (typeof window === 'undefined' || typeof window.ethereum === 'undefined')
+    return;
+  const providers = window.ethereum.providers;
+  const provider = getExplicitInjectedProvider(flag);
+  if (provider) return provider;
+  else if (typeof providers !== 'undefined' && providers.length > 0)
+    return providers[0];
+  else return window.ethereum;
+}
+
+export function getInjectedConnector({
+  chains,
+  flag,
+  options,
+}: {
+  flag: keyof InjectedProviderFlags;
+  chains: Chain[];
+  options?: InjectedConnectorOptions;
+}): InjectedConnector {
+  return new InjectedConnector({
+    chains,
+    options: {
+      getProvider: () => getInjectedProvider(flag),
+      ...options,
+    },
+  });
+}

--- a/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
@@ -1,10 +1,13 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isAndroid, isIOS } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import type {
   WalletConnectConnectorOptions,
@@ -33,13 +36,8 @@ export const rainbowWallet = ({
   ...options
 }: (RainbowWalletLegacyOptions | RainbowWalletOptions) &
   InjectedConnectorOptions): Wallet => {
-  const isRainbowInjected =
-    typeof window !== 'undefined' &&
-    typeof window.ethereum !== 'undefined' &&
-    (window.ethereum.providers?.some(p => p.isRainbow) ||
-      window.ethereum.isRainbow);
+  const isRainbowInjected = hasInjectedProvider('isRainbow');
   const shouldUseWalletConnect = !isRainbowInjected;
-
   return {
     id: 'rainbow',
     name: 'Rainbow',
@@ -63,10 +61,7 @@ export const rainbowWallet = ({
             version: walletConnectVersion,
             options: walletConnectOptions,
           })
-        : new InjectedConnector({
-            chains,
-            options,
-          });
+        : getInjectedConnector({ flag: 'isRainbow', chains, options });
 
       const getUri = async () => {
         const uri = await getWalletConnectUri(connector, walletConnectVersion);

--- a/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
@@ -25,17 +25,6 @@ export interface RainbowWalletOptions {
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
-function isRainbow(ethereum: NonNullable<typeof window['ethereum']>) {
-  // `isRainbow` needs to be added to the wagmi `Ethereum` object
-  const isRainbow = Boolean(ethereum.isRainbow);
-
-  if (!isRainbow) {
-    return false;
-  }
-
-  return true;
-}
-
 export const rainbowWallet = ({
   chains,
   projectId,
@@ -47,9 +36,10 @@ export const rainbowWallet = ({
   const isRainbowInjected =
     typeof window !== 'undefined' &&
     typeof window.ethereum !== 'undefined' &&
-    isRainbow(window.ethereum);
-
+    (window.ethereum.providers?.some(p => p.isRainbow) ||
+      window.ethereum.isRainbow);
   const shouldUseWalletConnect = !isRainbowInjected;
+
   return {
     id: 'rainbow',
     name: 'Rainbow',


### PR DESCRIPTION
- checking window.ethereum.providers for `isRainbow`
- refactor to simplify provider detection