### PR TITLE
feat: version fingerprinting for debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@wagmi/core": "~1.3.8",
     "autoprefixer": "^10.4.0",
     "esbuild": "^0.14.39",
+    "esbuild-plugin-replace": "^1.4.0",
     "eslint": "7.32.0",
     "eslint-config-rainbow": "^3.0.0",
     "eslint-plugin-jsx-a11y": "^6.5.1",

--- a/packages/rainbowkit/build.js
+++ b/packages/rainbowkit/build.js
@@ -2,6 +2,7 @@
 import { vanillaExtractPlugin } from '@vanilla-extract/esbuild-plugin';
 import autoprefixer from 'autoprefixer';
 import * as esbuild from 'esbuild';
+import { replace } from 'esbuild-plugin-replace';
 import postcss from 'postcss';
 import prefixSelector from 'postcss-prefix-selector';
 import readdir from 'recursive-readdir-files';
@@ -54,6 +55,9 @@ const baseBuildConfig = {
         }));
       },
     },
+    replace({
+      __buildVersion: process.env.npm_package_version,
+    }),
   ],
   splitting: true, // Required for tree shaking
 };

--- a/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
@@ -19,6 +19,7 @@ import {
   RainbowKitChainProvider,
 } from './RainbowKitChainContext';
 import { ShowRecentTransactionsContext } from './ShowRecentTransactionsContext';
+import { useFingerprint } from './useFingerprint';
 import { usePreloadImages } from './usePreloadImages';
 import { clearWalletConnectDeepLink } from './walletConnectDeepLink';
 
@@ -80,6 +81,7 @@ export function RainbowKitProvider({
   theme = defaultTheme,
 }: RainbowKitProviderProps) {
   usePreloadImages();
+  useFingerprint();
 
   useAccount({ onDisconnect: clearWalletConnectDeepLink });
 

--- a/packages/rainbowkit/src/components/RainbowKitProvider/useFingerprint.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/useFingerprint.ts
@@ -1,0 +1,17 @@
+import { useCallback, useEffect } from 'react';
+import { version } from '../../../package.json';
+
+const storageKey = 'rk-version';
+
+function setRainbowKitVersion({ version }: { version: string }) {
+  localStorage.setItem(storageKey, version);
+}
+
+export function useFingerprint() {
+  const fingerprint = useCallback(() => {
+    setRainbowKitVersion({ version });
+  }, [version]);
+  useEffect(() => {
+    fingerprint();
+  }, [fingerprint]);
+}

--- a/packages/rainbowkit/src/components/RainbowKitProvider/useFingerprint.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/useFingerprint.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect } from 'react';
-import { version } from '../../../package.json';
 
 const storageKey = 'rk-version';
 
@@ -9,8 +8,8 @@ function setRainbowKitVersion({ version }: { version: string }) {
 
 export function useFingerprint() {
   const fingerprint = useCallback(() => {
-    setRainbowKitVersion({ version });
-  }, [version]);
+    setRainbowKitVersion({ version: '__buildVersion' });
+  }, []);
   useEffect(() => {
     fingerprint();
   }, [fingerprint]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       esbuild:
         specifier: ^0.14.39
         version: 0.14.39
+      esbuild-plugin-replace:
+        specifier: ^1.4.0
+        version: 1.4.0
       eslint:
         specifier: 7.32.0
         version: 7.32.0
@@ -11881,6 +11884,12 @@ packages:
     os: [openbsd]
     optional: true
 
+  /esbuild-plugin-replace@1.4.0:
+    resolution: {integrity: sha512-lP3ZAyzyRa5JXoOd59lJbRKNObtK8pJ/RO7o6vdjwLi71GfbL32NR22ZuS7/cLZkr10/L1lutoLma8E4DLngYg==}
+    dependencies:
+      magic-string: 0.25.9
+    dev: true
+
   /esbuild-sunos-64@0.14.22:
     resolution: {integrity: sha512-/mbJdXTW7MTcsPhtfDsDyPEOju9EOABvCjeUU2OJ7fWpX/Em/H3WYDa86tzLUbcVg++BScQDzqV/7RYw5XNY0g==}
     engines: {node: '>=12'}
@@ -20564,6 +20573,7 @@ packages:
 
   /sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   /space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}


### PR DESCRIPTION
- added `useFingerprint()` hook to the provider
- using `rk-version` in localstorage to save the rainbowkit version