### PR TITLE
fix: isolate esbuild-replace scope

### DIFF
--- a/.changeset/wicked-camels-add.md
+++ b/.changeset/wicked-camels-add.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Resolved an issue that prevented some PNG icons within RainbowKit from rendering.

--- a/packages/rainbowkit/build.js
+++ b/packages/rainbowkit/build.js
@@ -32,6 +32,12 @@ const baseBuildConfig = {
   },
   platform: 'browser',
   plugins: [
+    replace({
+      include: /src\/components\/RainbowKitProvider\/useFingerprint.ts$/,
+      values: {
+        __buildVersion: process.env.npm_package_version,
+      },
+    }),
     vanillaExtractPlugin({
       identifiers: isCssMinified ? 'short' : 'debug',
       processCss: async css => {
@@ -55,9 +61,6 @@ const baseBuildConfig = {
         }));
       },
     },
-    replace({
-      __buildVersion: process.env.npm_package_version,
-    }),
   ],
   splitting: true, // Required for tree shaking
 };


### PR DESCRIPTION
## Changes
- fixed malformed bundled pngs with strict scoping for `esbuild-plugin-replace`