### PR TITLE
chore: lock packageManager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "vitest": "^0.32.4",
     "wagmi": "~1.3.10"
   },
+  "packageManager": "pnpm@8.7.1",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"


### PR DESCRIPTION
- Statically specify the necessary pnpm version to resolve periodic issues with the WagmiConfig singleton