### PR TITLE
fix: signin close button disconnect on auth signature rejection

### DIFF
--- a/.changeset/rude-windows-heal.md
+++ b/.changeset/rude-windows-heal.md
@@ -2,4 +2,4 @@
 '@rainbow-me/rainbowkit': patch
 ---
 
-Resolved an issue with the Authentication modal where a user's wallet would remain connected if the modal was dismissed with the Close button rather than explicity using the Cancel button. This fix ensures that dApps can reliably require a user to complete Authentication before RainbowKit enters a connected state.
+Resolved an issue with the Authentication modal where a user's wallet would remain connected if the modal was dismissed with the Close button rather than explicitly using the Cancel button. This fix ensures that dApps can reliably require a user to complete Authentication before RainbowKit enters a connected state.

--- a/.changeset/rude-windows-heal.md
+++ b/.changeset/rude-windows-heal.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Resolved an issue with the Authentication modal where a user's wallet would remain connected if the modal was dismissed with the Close button rather than explicity using the Cancel button. This fix ensures that dApps can reliably require a user to complete Authentication before RainbowKit enters a connected state.

--- a/packages/rainbowkit/src/components/ConnectModal/ConnectModal.tsx
+++ b/packages/rainbowkit/src/components/ConnectModal/ConnectModal.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
+import { useDisconnect } from 'wagmi';
 import { useConnectionStatus } from '../../hooks/useConnectionStatus';
 import ConnectOptions from '../ConnectOptions/ConnectOptions';
 import { Dialog } from '../Dialog/Dialog';
 import { DialogContent } from '../Dialog/DialogContent';
 import { SignIn } from '../SignIn/SignIn';
-import { useDisconnect } from 'wagmi';
 
 export interface ConnectModalProps {
   open: boolean;

--- a/packages/rainbowkit/src/components/ConnectModal/ConnectModal.tsx
+++ b/packages/rainbowkit/src/components/ConnectModal/ConnectModal.tsx
@@ -15,7 +15,7 @@ export function ConnectModal({ onClose, open }: ConnectModalProps) {
   const titleId = 'rk_connect_title';
   const connectionStatus = useConnectionStatus();
 
-  // when a user rejects the SIWE signature, close the modal and disconnect
+  // when a user cancels or dismisses the SignIn modal for SIWE, disconnect and call onClose
   const { disconnect } = useDisconnect();
   const onAuthCancel = React.useCallback(() => {
     onClose();

--- a/packages/rainbowkit/src/components/ConnectModal/ConnectModal.tsx
+++ b/packages/rainbowkit/src/components/ConnectModal/ConnectModal.tsx
@@ -4,6 +4,8 @@ import ConnectOptions from '../ConnectOptions/ConnectOptions';
 import { Dialog } from '../Dialog/Dialog';
 import { DialogContent } from '../Dialog/DialogContent';
 import { SignIn } from '../SignIn/SignIn';
+import { useDisconnect } from 'wagmi';
+
 export interface ConnectModalProps {
   open: boolean;
   onClose: () => void;
@@ -12,6 +14,13 @@ export interface ConnectModalProps {
 export function ConnectModal({ onClose, open }: ConnectModalProps) {
   const titleId = 'rk_connect_title';
   const connectionStatus = useConnectionStatus();
+
+  // when a user rejects the SIWE signature, close the modal and disconnect
+  const { disconnect } = useDisconnect();
+  const onAuthCancel = React.useCallback(() => {
+    onClose();
+    disconnect();
+  }, [onClose, disconnect]);
 
   if (connectionStatus === 'disconnected') {
     return (
@@ -25,9 +34,9 @@ export function ConnectModal({ onClose, open }: ConnectModalProps) {
 
   if (connectionStatus === 'unauthenticated') {
     return (
-      <Dialog onClose={onClose} open={open} titleId={titleId}>
+      <Dialog onClose={onAuthCancel} open={open} titleId={titleId}>
         <DialogContent bottomSheetOnMobile padding="0">
-          <SignIn onClose={onClose} />
+          <SignIn onClose={onAuthCancel} />
         </DialogContent>
       </Dialog>
     );

--- a/packages/rainbowkit/src/components/SignIn/SignIn.tsx
+++ b/packages/rainbowkit/src/components/SignIn/SignIn.tsx
@@ -51,7 +51,11 @@ export function SignIn({ onClose }: { onClose: () => void }) {
   const { chain: activeChain } = useNetwork();
   const { signMessageAsync } = useSignMessage();
   const { disconnect } = useDisconnect();
-  const cancel = () => disconnect();
+
+  const cancel = React.useCallback(() => {
+    onClose();
+    disconnect();
+  }, [onClose, disconnect]);
 
   const signIn = async () => {
     try {
@@ -125,7 +129,7 @@ export function SignIn({ onClose }: { onClose: () => void }) {
         position="absolute"
         right="0"
       >
-        <CloseButton onClose={onClose} />
+        <CloseButton onClose={cancel} />
       </Box>
       <Box
         alignItems="center"

--- a/packages/rainbowkit/src/components/SignIn/SignIn.tsx
+++ b/packages/rainbowkit/src/components/SignIn/SignIn.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef } from 'react';
 import { UserRejectedRequestError } from 'viem';
-import { useAccount, useDisconnect, useNetwork, useSignMessage } from 'wagmi';
+import { useAccount, useNetwork, useSignMessage } from 'wagmi';
 import { touchableStyles } from '../../css/touchableStyles';
 import { isMobile } from '../../utils/isMobile';
 import { AsyncImage } from '../AsyncImage/AsyncImage';

--- a/packages/rainbowkit/src/components/SignIn/SignIn.tsx
+++ b/packages/rainbowkit/src/components/SignIn/SignIn.tsx
@@ -50,12 +50,6 @@ export function SignIn({ onClose }: { onClose: () => void }) {
   const { address } = useAccount();
   const { chain: activeChain } = useNetwork();
   const { signMessageAsync } = useSignMessage();
-  const { disconnect } = useDisconnect();
-
-  const cancel = React.useCallback(() => {
-    onClose();
-    disconnect();
-  }, [onClose, disconnect]);
 
   const signIn = async () => {
     try {
@@ -129,7 +123,7 @@ export function SignIn({ onClose }: { onClose: () => void }) {
         position="absolute"
         right="0"
       >
-        <CloseButton onClose={cancel} />
+        <CloseButton onClose={onClose} />
       </Box>
       <Box
         alignItems="center"
@@ -217,7 +211,7 @@ export function SignIn({ onClose }: { onClose: () => void }) {
           {mobile ? (
             <ActionButton
               label="Cancel"
-              onClick={cancel}
+              onClick={onClose}
               size="large"
               type="secondary"
             />
@@ -227,7 +221,7 @@ export function SignIn({ onClose }: { onClose: () => void }) {
               borderRadius="full"
               className={touchableStyles({ active: 'shrink', hover: 'grow' })}
               display="block"
-              onClick={cancel}
+              onClick={onClose}
               paddingX="10"
               paddingY="5"
               rel="noreferrer"


### PR DESCRIPTION
## Changes
- added `onAuthCancel` callback to wrap `disconnect()` and `onClose()` in ConnectModal for Authentication flow

## Known issues
- Wagmi's `disconnect()` function is slow for WalletConnect connectors