### PR TITLE
fix: connectModalOpen state after successful sign-in

### DIFF
--- a/.changeset/curly-forks-flash.md
+++ b/.changeset/curly-forks-flash.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Fixed an issue where the state of the connect modal would not get reset (`connectModalOpen === false`) after a successful sign-in.

--- a/packages/rainbowkit/src/components/SignIn/SignIn.tsx
+++ b/packages/rainbowkit/src/components/SignIn/SignIn.tsx
@@ -95,6 +95,7 @@ export function SignIn({ onClose }: { onClose: () => void }) {
         const verified = await authAdapter.verify({ message, signature });
 
         if (verified) {
+          onClose();
           return;
         } else {
           throw new Error();


### PR DESCRIPTION
Fixes #1503 