### PR TITLE
chore: walletconnect verify txt record for example dApp

### DIFF
--- a/packages/example/public/.well-known/walletconnect.txt
+++ b/packages/example/public/.well-known/walletconnect.txt
@@ -1,0 +1,1 @@
+6c67d79f-ff18-4add-9fcd-4dee80c0619b=896dd5ef6db55791f919a86ddf424eadb99b9ba9abfddd9f29e03bdc4088c206


### PR DESCRIPTION
## Changes
- Added `/.well-known/walletconnect.txt` record to example dApp deployment. This allow us to verify the dApp domain and test the Verify API in wallets.