### PR TITLE
fix: i18n-js module resolution for esm

### DIFF
--- a/.changeset/smooth-students-knock.md
+++ b/.changeset/smooth-students-knock.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fixed a dependency resolution issue for `ESModule` projects related to `i18n-js`

--- a/packages/rainbowkit/src/components/RainbowKitProvider/I18nContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/I18nContext.tsx
@@ -1,9 +1,9 @@
-import { I18n as _I18N } from 'i18n-js';
 import React, { ReactNode, createContext, useMemo } from 'react';
+
 import { Locale, i18n as _i18n } from '../../locales';
 import { detectedBrowserLocale } from '../../utils/locale';
 
-export const I18nContext = createContext<_I18N>(_i18n);
+export const I18nContext = createContext<typeof _i18n>(_i18n);
 
 interface I18nProviderProps {
   children: ReactNode;

--- a/packages/rainbowkit/src/global.d.ts
+++ b/packages/rainbowkit/src/global.d.ts
@@ -7,3 +7,5 @@ declare module '*.png' {
   const dataUrl: string;
   export default dataUrl;
 }
+
+declare module 'i18n-js/dist/require/index.js';

--- a/packages/rainbowkit/src/locales/index.ts
+++ b/packages/rainbowkit/src/locales/index.ts
@@ -1,4 +1,6 @@
-import { I18n } from 'i18n-js';
+import type * as I18nTypes from 'i18n-js';
+// `index.js` required for CRA webpack builds
+import { I18n } from 'i18n-js/dist/require/index.js';
 import ar_AR from './ar_AR.json';
 import en_US from './en_US.json';
 import es_419 from './es_419.json';
@@ -42,7 +44,7 @@ export type Locale =
   | 'zh-CN';
 
 // biome-ignore format: locale keys
-export const i18n = new I18n({
+export const i18n: I18nTypes.I18n = new I18n({
   'ar': ar_AR,
   'ar-AR': ar_AR,
   'en': en_US,

--- a/packages/rainbowkit/src/locales/index.ts
+++ b/packages/rainbowkit/src/locales/index.ts
@@ -1,5 +1,4 @@
-import type * as I18nTypes from 'i18n-js';
-import { I18n } from 'i18n-js/dist/require/index.js';
+import { I18n } from 'i18n-js';
 import ar_AR from './ar_AR.json';
 import en_US from './en_US.json';
 import es_419 from './es_419.json';
@@ -43,33 +42,33 @@ export type Locale =
   | 'zh-CN';
 
 // biome-ignore format: locale keys
-export const i18n: I18nTypes.I18n = new I18n({
-  ar: ar_AR,
-  "ar-AR": ar_AR,
-  en: en_US,
-  "en-US": en_US,
-  es: es_419,
-  "es-419": es_419,
-  fr: fr_FR,
-  "fr-FR": fr_FR,
-  hi: hi_IN,
-  "hi-IN": hi_IN,
-  id: id_ID,
-  "id-ID": id_ID,
-  ja: ja_JP,
-  "ja-JP": ja_JP,
-  ko: ko_KR,
-  "ko-KR": ko_KR,
-  pt: pt_BR,
-  "pt-BR": pt_BR,
-  ru: ru_RU,
-  "ru-RU": ru_RU,
-  th: th_TH,
-  "th-TH": th_TH,
-  tr: tr_TR,
-  "tr-TR": tr_TR,
-  zh: zh_CN,
-  "zh-CN": zh_CN,
+export const i18n = new I18n({
+  'ar': ar_AR,
+  'ar-AR': ar_AR,
+  'en': en_US,
+  'en-US': en_US,
+  'es': es_419,
+  'es-419': es_419,
+  'fr': fr_FR,
+  'fr-FR': fr_FR,
+  'hi': hi_IN,
+  'hi-IN': hi_IN,
+  'id': id_ID,
+  'id-ID': id_ID,
+  'ja': ja_JP,
+  'ja-JP': ja_JP,
+  'ko': ko_KR,
+  'ko-KR': ko_KR,
+  'pt': pt_BR,
+  'pt-BR': pt_BR,
+  'ru': ru_RU,
+  'ru-RU': ru_RU,
+  'th': th_TH,
+  'th-TH': th_TH,
+  'tr': tr_TR,
+  'tr-TR': tr_TR,
+  'zh': zh_CN,
+  'zh-CN': zh_CN,
 });
 
 i18n.defaultLocale = 'en-US';

--- a/packages/rainbowkit/src/locales/index.ts
+++ b/packages/rainbowkit/src/locales/index.ts
@@ -1,4 +1,5 @@
-import { I18n } from 'i18n-js';
+import type * as I18nTypes from 'i18n-js';
+import { I18n } from 'i18n-js/dist/require';
 import ar_AR from './ar_AR.json';
 import en_US from './en_US.json';
 import es_419 from './es_419.json';
@@ -42,33 +43,33 @@ export type Locale =
   | 'zh-CN';
 
 // biome-ignore format: locale keys
-export const i18n = new I18n({
-  'ar': ar_AR,
-  'ar-AR': ar_AR,
-  'en': en_US,
-  'en-US': en_US,
-  'es': es_419,
-  'es-419': es_419,
-  'fr': fr_FR,
-  'fr-FR': fr_FR,
-  'hi': hi_IN,
-  'hi-IN': hi_IN,
-  'id': id_ID,
-  'id-ID': id_ID,
-  'ja': ja_JP,
-  'ja-JP': ja_JP,
-  'ko': ko_KR,
-  'ko-KR': ko_KR,
-  'pt': pt_BR,
-  'pt-BR': pt_BR,
-  'ru': ru_RU,
-  'ru-RU': ru_RU,
-  'th': th_TH,
-  'th-TH': th_TH,
-  'tr': tr_TR,
-  'tr-TR': tr_TR,
-  'zh': zh_CN,
-  'zh-CN': zh_CN,
+export const i18n: I18nTypes.I18n = new I18n({
+  ar: ar_AR,
+  "ar-AR": ar_AR,
+  en: en_US,
+  "en-US": en_US,
+  es: es_419,
+  "es-419": es_419,
+  fr: fr_FR,
+  "fr-FR": fr_FR,
+  hi: hi_IN,
+  "hi-IN": hi_IN,
+  id: id_ID,
+  "id-ID": id_ID,
+  ja: ja_JP,
+  "ja-JP": ja_JP,
+  ko: ko_KR,
+  "ko-KR": ko_KR,
+  pt: pt_BR,
+  "pt-BR": pt_BR,
+  ru: ru_RU,
+  "ru-RU": ru_RU,
+  th: th_TH,
+  "th-TH": th_TH,
+  tr: tr_TR,
+  "tr-TR": tr_TR,
+  zh: zh_CN,
+  "zh-CN": zh_CN,
 });
 
 i18n.defaultLocale = 'en-US';

--- a/packages/rainbowkit/src/locales/index.ts
+++ b/packages/rainbowkit/src/locales/index.ts
@@ -1,5 +1,6 @@
 import type * as I18nTypes from 'i18n-js';
-import { I18n } from 'i18n-js/dist/require';
+// @ts-ignore
+import { I18n } from 'i18n-js/dist/require/index.js';
 import ar_AR from './ar_AR.json';
 import en_US from './en_US.json';
 import es_419 from './es_419.json';

--- a/packages/rainbowkit/src/locales/index.ts
+++ b/packages/rainbowkit/src/locales/index.ts
@@ -1,5 +1,4 @@
 import type * as I18nTypes from 'i18n-js';
-// @ts-ignore
 import { I18n } from 'i18n-js/dist/require/index.js';
 import ar_AR from './ar_AR.json';
 import en_US from './en_US.json';

--- a/packages/rainbowkit/src/locales/index.ts
+++ b/packages/rainbowkit/src/locales/index.ts
@@ -1,6 +1,6 @@
 import type * as I18nTypes from 'i18n-js';
-// `index.js` required for CRA webpack builds
 import { I18n } from 'i18n-js/dist/require/index.js';
+
 import ar_AR from './ar_AR.json';
 import en_US from './en_US.json';
 import es_419 from './es_419.json';

--- a/packages/rainbowkit/src/types/i18n-js.d.ts
+++ b/packages/rainbowkit/src/types/i18n-js.d.ts
@@ -1,0 +1,1 @@
+declare module 'i18n-js/dist/require';

--- a/packages/rainbowkit/src/types/i18n-js.d.ts
+++ b/packages/rainbowkit/src/types/i18n-js.d.ts
@@ -1,1 +1,0 @@
-declare module 'i18n-js/dist/require/index.js';

--- a/packages/rainbowkit/src/types/i18n-js.d.ts
+++ b/packages/rainbowkit/src/types/i18n-js.d.ts
@@ -1,1 +1,1 @@
-declare module "i18n-js/dist/require";
+declare module 'i18n-js/dist/require';

--- a/packages/rainbowkit/src/types/i18n-js.d.ts
+++ b/packages/rainbowkit/src/types/i18n-js.d.ts
@@ -1,1 +1,1 @@
-declare module 'i18n-js/dist/require';
+declare module "i18n-js/dist/require";

--- a/packages/rainbowkit/src/types/i18n-js.d.ts
+++ b/packages/rainbowkit/src/types/i18n-js.d.ts
@@ -1,1 +1,1 @@
-declare module 'i18n-js/dist/require';
+declare module 'i18n-js/dist/require/index.js';


### PR DESCRIPTION
In this PR, we've transitioned to `i18n-js/require/index.js` to correctly utilize the `i18n-js` CommonJS module handler and have made the necessary module declarations.

Releated Github Issue: https://github.com/fnando/i18n/issues/44#issuecomment-1362209550