### PR TITLE
fix: sign out if wallet is switched

### DIFF
--- a/.changeset/polite-maps-decide.md
+++ b/.changeset/polite-maps-decide.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Implemented logout on wallet switch
+Implemented logout on wallet switch in `<RainbowKitAuthenticationProvider />`

--- a/.changeset/polite-maps-decide.md
+++ b/.changeset/polite-maps-decide.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Implemented logout on wallet switch in `<RainbowKitAuthenticationProvider />`
+Fixed an issue where a user would not automatically be logged out after switching their wallet in MetaMask or other browser wallets

--- a/.changeset/polite-maps-decide.md
+++ b/.changeset/polite-maps-decide.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Fixed an issue where a user would not automatically be logged out after switching their wallet in MetaMask or other browser wallets
+Fixed an issue where a user would not get automatically logged out from the Authentication API after switching their wallet in MetaMask or other browser wallets. Users must now sign a new SIWE message after switching wallets.

--- a/.changeset/polite-maps-decide.md
+++ b/.changeset/polite-maps-decide.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Implemented logout on wallet switch

--- a/packages/rainbowkit/src/components/RainbowKitProvider/AuthenticationContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/AuthenticationContext.tsx
@@ -6,12 +6,7 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
-import { useAccount } from 'wagmi';
-
-interface ConnectorData {
-  account: string;
-  chain: number;
-}
+import { ConnectorData, useAccount } from 'wagmi';
 
 export type AuthenticationStatus =
   | 'loading'
@@ -87,6 +82,9 @@ export function RainbowKitAuthenticationProvider<Message = unknown>({
     if (account) adapter.signOut();
   };
 
+  // Wait for user authentication before listening to "change" event.
+  // Avoid listening immediately after wallet connection due to potential SIWE authentication delay.
+  // Ensure to turn off the "change" event listener for cleanup.
   // biome-ignore lint/nursery/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (connector && status === 'authenticated') {


### PR DESCRIPTION
Whenever user does a wallet switch he needs to be logged out immediately. This is not what's happening as of now.