### PR TITLE
fix: `alchemyProvider` params

### DIFF
--- a/packages/rainbowkit/CHANGELOG.md
+++ b/packages/rainbowkit/CHANGELOG.md
@@ -1448,7 +1448,7 @@
   +const { chains } = configureChains(
   +  [chain.mainnet],
   +  [
-  +    alchemyProvider({ alchemyId: process.env.ALCHEMY_ID }),
+  +    alchemyProvider({ apiKey: process.env.ALCHEMY_ID }),
   +    publicProvider(),
   +  ]
   +);

--- a/site/data/docs/migration-guide.mdx
+++ b/site/data/docs/migration-guide.mdx
@@ -69,10 +69,10 @@ Every dApp that relies on WalletConnect now needs to obtain a `projectId` from [
 Provide the `projectId` to `getDefaultWallets` and individual RainbowKit wallet connectors like the following:
 
 ```ts
-const projectId = 'YOUR_PROJECT_ID';
+const projectId = "YOUR_PROJECT_ID";
 
 const { wallets } = getDefaultWallets({
-  appName: 'My RainbowKit App',
+  appName: "My RainbowKit App",
   projectId,
   chains,
 });
@@ -80,7 +80,7 @@ const { wallets } = getDefaultWallets({
 const connectors = connectorsForWallets([
   ...wallets,
   {
-    groupName: 'Other',
+    groupName: "Other",
     wallets: [
       argentWallet({ projectId, chains }),
       trustWallet({ projectId, chains }),
@@ -246,7 +246,7 @@ export interface MyWalletOptions {
 +const { chains } = configureChains(
 +  [chain.mainnet],
 +  [
-+    alchemyProvider({ alchemyId: process.env.ALCHEMY_ID }),
++    alchemyProvider({ apiKey: process.env.ALCHEMY_ID }),
 +    publicProvider(),
 +  ]
 +);


### PR DESCRIPTION
Fixed, 

`alchemyProvider({ alchemyId: process.env.ALCHEMY_ID }) --> alchemyProvider({ apiKey: process.env.ALCHEMY_ID }),`