### PR TITLE
docs: fix media-kit url

### DIFF
--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -292,7 +292,10 @@ export default function Home() {
               </Link>
             </Text>
             <Text size="4" weight="bold">
-              <Link href="https://rainbow.me/media-kit.zip" variant="gray">
+              <Link
+                href="https://www.figma.com/community/file/1139300796265858893/rainbow-brand-assets"
+                variant="gray"
+              >
                 <span data-emoji>⬇️</span> media kit
               </Link>
             </Text>


### PR DESCRIPTION
## Changes
- Adopting Rainbow's Figma Community brand assets URL