### PR TITLE
fix: ethereum.providers support for coinbaseWallet

### DIFF
--- a/.changeset/little-panthers-cough.md
+++ b/.changeset/little-panthers-cough.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Improved Coinbase Wallet detection when multiple wallets are active

--- a/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
@@ -2,6 +2,7 @@ import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { isIOS } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
+import { hasInjectedProvider } from '../../getInjectedConnector';
 
 export interface CoinbaseWalletOptions {
   appName: string;
@@ -13,8 +14,7 @@ export const coinbaseWallet = ({
   chains,
   ...options
 }: CoinbaseWalletOptions): Wallet => {
-  const isCoinbaseWalletInjected =
-    typeof window !== 'undefined' && window.ethereum?.isCoinbaseWallet === true;
+  const isCoinbaseWalletInjected = hasInjectedProvider('isCoinbaseWallet');
 
   return {
     id: 'coinbase',


### PR DESCRIPTION
## Changes
- use standardized `hasInjectedProvider` util to detect Coinbase Wallet more reliably