### PR TITLE
fix: trustWallet detection mobile in-app browser

### DIFF
--- a/.changeset/brown-elephants-rule.md
+++ b/.changeset/brown-elephants-rule.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fixed an issue with Trust Wallet detection in Trust's in-app mobile browser


### PR DESCRIPTION
## Changes
- favor `window.ethereum` over unreliable `window.trustwallet`
- favor `isTrust` on mobile, and `isTrustWallet` on desktop
- adopt shared utils for provider detection