### PR TITLE
fix: fix popover content is overflow in PropsTable

### DIFF
--- a/site/components/Popover/Popover.css.ts
+++ b/site/components/Popover/Popover.css.ts
@@ -14,6 +14,7 @@ export const content = style([
     'maxWidth': 320,
     'minWidth': 200,
     'wordBreak': 'break-word',
+    'whiteSpace': 'initial',
     ':focus': { outline: 'none' },
   }),
 ]);


### PR DESCRIPTION
While researching the documentation of rainbowkit, I identified a small issue related to the UI here.

The problem originates from the data cell `td` element that was a style `white-space: nowrap`. The popover children subsequently inherit this style, causing a UI glitch. So, I have reset the `white-space` within the popover content.

Please find the before and after screenshots below for a better understanding of the changes:

**Before:**
<img width="1150" alt="image" src="https://github.com/rainbow-me/rainbowkit/assets/30283022/91e3565d-ab81-4d3f-9a98-638d2fdb8cb0">

**After:**
<img width="1150" alt="image" src="https://github.com/rainbow-me/rainbowkit/assets/30283022/a36bebcd-2510-4cd0-bd43-275cb1639af4">