### PR TITLE
fix: chain modal overflows when button is clicked

### DIFF
--- a/.changeset/eleven-dingos-relate.md
+++ b/.changeset/eleven-dingos-relate.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fixed a bug where if a user clicks on one of the chains there will be a millisecond overflow scroll effect to the chain modal

--- a/.changeset/eleven-dingos-relate.md
+++ b/.changeset/eleven-dingos-relate.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Fixed a bug where if a user clicks on one of the chains there will be a millisecond overflow scroll effect to the chain modal
+Fixed scroll bar inconsistencies in the Chain selector for large chain lists or when animating upon user interaction

--- a/packages/rainbowkit/src/components/ChainModal/ChainModal.css.ts
+++ b/packages/rainbowkit/src/components/ChainModal/ChainModal.css.ts
@@ -3,6 +3,7 @@ import { style } from '@vanilla-extract/css';
 export const DesktopScrollClassName = style({
   maxHeight: 454,
   overflowY: 'auto',
+  overflowX: 'hidden',
 });
 
 export const MobileScrollClassName = style({

--- a/packages/rainbowkit/src/components/ChainModal/ChainModal.css.ts
+++ b/packages/rainbowkit/src/components/ChainModal/ChainModal.css.ts
@@ -1,13 +1,13 @@
 import { style } from '@vanilla-extract/css';
 
 export const DesktopScrollClassName = style({
-  maxHeight: 454,
+  maxHeight: 456,
   overflowY: 'auto',
   overflowX: 'hidden',
 });
 
 export const MobileScrollClassName = style({
-  maxHeight: 454,
+  maxHeight: 456,
   overflowY: 'auto',
   overflowX: 'hidden',
   scrollbarWidth: 'none',


### PR DESCRIPTION
Releated to this issue: https://github.com/rainbow-me/rainbowkit/issues/1557