### PR TITLE
fix: next-auth adapter app router safety

### DIFF
--- a/.changeset/angry-kings-stare.md
+++ b/.changeset/angry-kings-stare.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit-siwe-next-auth": patch
+---
+
+Adopted `'use client'` directive for safe App Router usage

--- a/packages/rainbowkit-siwe-next-auth/build.js
+++ b/packages/rainbowkit-siwe-next-auth/build.js
@@ -4,6 +4,9 @@ const isWatching = process.argv.includes('--watch');
 
 esbuild
   .build({
+    banner: {
+      js: '"use client";', // Required for Next 13 App Router
+    },
     bundle: true,
     entryPoints: ['src/index.ts'],
     format: 'esm',


### PR DESCRIPTION
## Changes
- Adopted `'use client'` directive for safe App Router usage