### PR TITLE
docs: legacy cleanup

### DIFF
--- a/examples/with-next-rainbow-button/pages/_app.tsx
+++ b/examples/with-next-rainbow-button/pages/_app.tsx
@@ -13,7 +13,7 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
 
 const projectId = "YOUR_PROJECT_ID";
 
-const wagmiClient = createConfig({
+const config = createConfig({
   autoConnect: true,
   connectors: [new RainbowConnector({ chains, projectId })],
   publicClient,
@@ -22,7 +22,7 @@ const wagmiClient = createConfig({
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <WagmiConfig config={wagmiClient}>
+    <WagmiConfig config={config}>
       <RainbowButtonProvider>
         <Component {...pageProps} />
       </RainbowButtonProvider>

--- a/examples/with-next-wallet-button/pages/_app.tsx
+++ b/examples/with-next-wallet-button/pages/_app.tsx
@@ -23,7 +23,7 @@ const connectors = connectorsForWallets([
   metaMaskWallet({ projectId, chains }),
 ]);
 
-const wagmiClient = createConfig({
+const config = createConfig({
   autoConnect: true,
   connectors: [
     ...connectors,
@@ -46,7 +46,7 @@ const wagmiClient = createConfig({
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <WagmiConfig config={wagmiClient}>
+    <WagmiConfig config={config}>
       <RainbowKitProvider chains={chains}>
         <Component {...pageProps} />
       </RainbowKitProvider>

--- a/packages/rainbow-button/CHANGELOG.md
+++ b/packages/rainbow-button/CHANGELOG.md
@@ -25,15 +25,17 @@
     RainbowConnector,
   } from "@rainbow-me/rainbow-button";
 
-  const wagmiClient = createConfig({
+  const config = createConfig({
     connectors: [new RainbowConnector({ chains, projectId })],
     publicClient,
   });
 
   function MyApp({ Component, pageProps }: AppProps) {
     return (
-      <WagmiConfig config={wagmiClient}>
-        <RainbowButtonProvider>{/* Your App */}</RainbowButtonProvider>
+      <WagmiConfig config={config}>
+        <RainbowButtonProvider>
+          {/* Your App */}
+        </RainbowButtonProvider>
       </WagmiConfig>
     );
   }

--- a/packages/rainbowkit/CHANGELOG.md
+++ b/packages/rainbowkit/CHANGELOG.md
@@ -2083,7 +2083,7 @@
     return (
       <WagmiProvider autoConnect connectors={connectors} provider={provider}>
         <RainbowKitProvider chains={chains}>
-          <YourApp />
+          {/* Your App */}
         </RainbowKitProvider>
       </WagmiProvider>
     );
@@ -2105,7 +2105,7 @@
     return (
       <WagmiProvider client={wagmiClient}>
         <RainbowKitProvider chains={chains}>
-          <YourApp />
+          {/* Your App */}
         </RainbowKitProvider>
       </WagmiProvider>
     );
@@ -2270,7 +2270,7 @@
     return (
       <WagmiProvider client={wagmiClient}>
         <RainbowKitProvider chains={chains}>
-          <YourApp />
+          {/* Your App */}
         </RainbowKitProvider>
       </WagmiProvider>
     );
@@ -2310,7 +2310,7 @@
     return (
       <WagmiProvider client={wagmiClient}>
         <RainbowKitProvider chains={chains}>
-          <YourApp />
+          {/* Your App */}
         </RainbowKitProvider>
       </WagmiProvider>
     );

--- a/site/data/ar/docs/custom-chains.mdx
+++ b/site/data/ar/docs/custom-chains.mdx
@@ -65,7 +65,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/ar/docs/installation.mdx
+++ b/site/data/ar/docs/installation.mdx
@@ -100,7 +100,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/en-US/docs/custom-chains.mdx
+++ b/site/data/en-US/docs/custom-chains.mdx
@@ -65,7 +65,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/en-US/docs/installation.mdx
+++ b/site/data/en-US/docs/installation.mdx
@@ -100,7 +100,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/en-US/guides/rainbow-button.mdx
+++ b/site/data/en-US/guides/rainbow-button.mdx
@@ -24,14 +24,14 @@ Pass an instance of the `RainbowConnector` to your Wagmi connector list, and wra
 import '@rainbow-me/rainbow-button/styles.css';
 import { RainbowButtonProvider, RainbowConnector } from "@rainbow-me/rainbow-button";
 
-const wagmiClient = createConfig({
+const config = createConfig({
   connectors: [new RainbowConnector({ chains, projectId })],
   publicClient
 });
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <WagmiConfig config={wagmiClient}>
+    <WagmiConfig config={config}>
       <RainbowButtonProvider>
         {/* Your App */}
       </RainbowButtonProvider>

--- a/site/data/es-419/docs/custom-chains.mdx
+++ b/site/data/es-419/docs/custom-chains.mdx
@@ -65,7 +65,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/es-419/docs/installation.mdx
+++ b/site/data/es-419/docs/installation.mdx
@@ -100,7 +100,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/fr/docs/custom-chains.mdx
+++ b/site/data/fr/docs/custom-chains.mdx
@@ -65,7 +65,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/fr/docs/installation.mdx
+++ b/site/data/fr/docs/installation.mdx
@@ -100,7 +100,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/hi/docs/custom-chains.mdx
+++ b/site/data/hi/docs/custom-chains.mdx
@@ -65,7 +65,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/hi/docs/installation.mdx
+++ b/site/data/hi/docs/installation.mdx
@@ -100,7 +100,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/id/docs/custom-chains.mdx
+++ b/site/data/id/docs/custom-chains.mdx
@@ -65,7 +65,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/id/docs/installation.mdx
+++ b/site/data/id/docs/installation.mdx
@@ -100,7 +100,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/ja/docs/custom-chains.mdx
+++ b/site/data/ja/docs/custom-chains.mdx
@@ -65,7 +65,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/ja/docs/installation.mdx
+++ b/site/data/ja/docs/installation.mdx
@@ -100,7 +100,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/ko/docs/custom-chains.mdx
+++ b/site/data/ko/docs/custom-chains.mdx
@@ -65,7 +65,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/ko/docs/installation.mdx
+++ b/site/data/ko/docs/installation.mdx
@@ -100,7 +100,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/pt-BR/docs/custom-chains.mdx
+++ b/site/data/pt-BR/docs/custom-chains.mdx
@@ -65,7 +65,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/pt-BR/docs/installation.mdx
+++ b/site/data/pt-BR/docs/installation.mdx
@@ -100,7 +100,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/ru/docs/custom-chains.mdx
+++ b/site/data/ru/docs/custom-chains.mdx
@@ -65,7 +65,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/ru/docs/installation.mdx
+++ b/site/data/ru/docs/installation.mdx
@@ -100,7 +100,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/th/docs/custom-chains.mdx
+++ b/site/data/th/docs/custom-chains.mdx
@@ -65,7 +65,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/th/docs/installation.mdx
+++ b/site/data/th/docs/installation.mdx
@@ -100,7 +100,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/tr/docs/custom-chains.mdx
+++ b/site/data/tr/docs/custom-chains.mdx
@@ -65,7 +65,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/tr/docs/installation.mdx
+++ b/site/data/tr/docs/installation.mdx
@@ -100,7 +100,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/zh-CN/docs/custom-chains.mdx
+++ b/site/data/zh-CN/docs/custom-chains.mdx
@@ -65,7 +65,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/site/data/zh-CN/docs/installation.mdx
+++ b/site/data/zh-CN/docs/installation.mdx
@@ -100,7 +100,7 @@ const App = () => {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains}>
-        <YourApp />
+        {/* Your App */}
       </RainbowKitProvider>
     </WagmiConfig>
   );


### PR DESCRIPTION
## Changes
- standardize adoption of `{/* Your App */}`
- use `config` over legacy `wagmiClient` naming in docs/examples