### PR TITLE
wip: bundle only used locales

### DIFF
--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -12,6 +12,14 @@ import {
   lightTheme,
   midnightTheme,
 } from '@rainbow-me/rainbowkit';
+
+// import pt_BR from '@rainbow-me/rainbowkit/locales/pt_BR';
+import all from '@rainbow-me/rainbowkit/locales';
+
+// pt_BR.connect.label = 'Sign in';
+
+RainbowKitProvider.i18n.store(all);
+
 import {
   GetSiweMessageOptions,
   RainbowKitSiweNextAuthProvider,
@@ -58,7 +66,7 @@ import { SessionProvider, signOut } from 'next-auth/react';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   WagmiConfig,
   configureChains,

--- a/packages/rainbowkit/build.js
+++ b/packages/rainbowkit/build.js
@@ -101,7 +101,25 @@ const walletsBuild = esbuild.build({
     : undefined,
 });
 
-Promise.all([mainBuild, walletsBuild])
+const localesBuild = esbuild.build({
+  ...baseBuildConfig,
+  entryPoints: (await readdir('src/locales')).map(({ path }) => path),
+  outdir: 'dist/locales',
+  assetNames: '[name]',
+  splitting: true,
+  banner: undefined,
+  loader: { '.json': 'json' },
+  watch: isWatching
+    ? {
+        onRebuild(error, result) {
+          if (error) console.error('locales build failed:', error);
+          else console.log('locales build succeeded:', result);
+        },
+      }
+    : undefined,
+});
+
+Promise.all([mainBuild, walletsBuild, localesBuild])
   .then(() => {
     if (isWatching) {
       console.log('watching...');

--- a/packages/rainbowkit/locales/package.json
+++ b/packages/rainbowkit/locales/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../dist/locales/index.js",
+  "sideEffects": false
+}

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -11,7 +11,9 @@
   "exports": {
     ".": "./dist/index.js",
     "./styles.css": "./dist/index.css",
-    "./wallets": "./dist/wallets/walletConnectors/index.js"
+    "./wallets": "./dist/wallets/walletConnectors/index.js",
+    "./locales": "./dist/locales/index.js",
+    "./locales/*": "./dist/locales/*.js"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/rainbowkit/src/components/RainbowKitProvider/I18nContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/I18nContext.tsx
@@ -1,7 +1,14 @@
 import React, { ReactNode, createContext, useMemo } from 'react';
 
-import { Locale, i18n as _i18n } from '../../locales';
+import { I18n } from 'i18n-js';
+import { type Locale, en_US } from '../../locales';
 import { detectedBrowserLocale } from '../../utils/locale';
+
+// en is the default and fallback locale
+export const _i18n = new I18n({ en: en_US, 'en-US': en_US });
+_i18n.defaultLocale = 'en-US';
+_i18n.locale = 'en-US';
+_i18n.enableFallback = true;
 
 export const I18nContext = createContext<typeof _i18n>(_i18n);
 
@@ -28,3 +35,5 @@ export const I18nProvider = ({ children, locale }: I18nProviderProps) => {
 
   return <I18nContext.Provider value={i18n}>{children}</I18nContext.Provider>;
 };
+
+I18nProvider.i18n = _i18n;

--- a/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, createContext, useContext } from 'react';
 import { useAccount } from 'wagmi';
 import { cssStringFromTheme } from '../../css/cssStringFromTheme';
 import { ThemeVars } from '../../css/sprinkles.css';
-import { Locale } from '../../locales';
+import { type Locale } from '../../locales';
 import { lightTheme } from '../../themes/lightTheme';
 import { TransactionStoreProvider } from '../../transactions/TransactionStoreContext';
 import { AppContext, DisclaimerComponent, defaultAppInfo } from './AppContext';
@@ -161,3 +161,5 @@ export function RainbowKitProvider({
     </RainbowKitChainProvider>
   );
 }
+
+RainbowKitProvider.i18n = I18nProvider.i18n;

--- a/packages/rainbowkit/src/locales/index.ts
+++ b/packages/rainbowkit/src/locales/index.ts
@@ -1,19 +1,16 @@
-import type * as I18nTypes from 'i18n-js';
-import { I18n } from 'i18n-js/dist/require/index.js';
-
-import ar_AR from './ar_AR.json';
-import en_US from './en_US.json';
-import es_419 from './es_419.json';
-import fr_FR from './fr_FR.json';
-import hi_IN from './hi_IN.json';
-import id_ID from './id_ID.json';
-import ja_JP from './ja_JP.json';
-import ko_KR from './ko_KR.json';
-import pt_BR from './pt_BR.json';
-import ru_RU from './ru_RU.json';
-import th_TH from './th_TH.json';
-import tr_TR from './tr_TR.json';
-import zh_CN from './zh_CN.json';
+export { default as ar_AR } from './ar_AR.json';
+export { default as en_US } from './en_US.json';
+export { default as es_419 } from './es_419.json';
+export { default as fr_FR } from './fr_FR.json';
+export { default as hi_IN } from './hi_IN.json';
+export { default as id_ID } from './id_ID.json';
+export { default as ja_JP } from './ja_JP.json';
+export { default as ko_KR } from './ko_KR.json';
+export { default as pt_BR } from './pt_BR.json';
+export { default as ru_RU } from './ru_RU.json';
+export { default as th_TH } from './th_TH.json';
+export { default as tr_TR } from './tr_TR.json';
+export { default as zh_CN } from './zh_CN.json';
 
 export type Locale =
   | 'ar'
@@ -43,36 +40,45 @@ export type Locale =
   | 'zh'
   | 'zh-CN';
 
-// biome-ignore format: locale keys
-export const i18n: I18nTypes.I18n = new I18n({
-  'ar': ar_AR,
-  'ar-AR': ar_AR,
-  'en': en_US,
-  'en-US': en_US,
-  'es': es_419,
-  'es-419': es_419,
-  'fr': fr_FR,
-  'fr-FR': fr_FR,
-  'hi': hi_IN,
-  'hi-IN': hi_IN,
-  'id': id_ID,
-  'id-ID': id_ID,
-  'ja': ja_JP,
-  'ja-JP': ja_JP,
-  'ko': ko_KR,
-  'ko-KR': ko_KR,
-  'pt': pt_BR,
-  'pt-BR': pt_BR,
-  'ru': ru_RU,
-  'ru-RU': ru_RU,
-  'th': th_TH,
-  'th-TH': th_TH,
-  'tr': tr_TR,
-  'tr-TR': tr_TR,
-  'zh': zh_CN,
-  'zh-CN': zh_CN,
-});
+import ar_AR from './ar_AR.json';
+import en_US from './en_US.json';
+import es_419 from './es_419.json';
+import fr_FR from './fr_FR.json';
+import hi_IN from './hi_IN.json';
+import id_ID from './id_ID.json';
+import ja_JP from './ja_JP.json';
+import ko_KR from './ko_KR.json';
+import pt_BR from './pt_BR.json';
+import ru_RU from './ru_RU.json';
+import th_TH from './th_TH.json';
+import tr_TR from './tr_TR.json';
+import zh_CN from './zh_CN.json';
 
-i18n.defaultLocale = 'en-US';
-i18n.locale = 'en-US';
-i18n.enableFallback = true;
+export default {
+  ar: ar_AR,
+  'ar-AR': ar_AR,
+  en: en_US,
+  'en-US': en_US,
+  es: es_419,
+  'es-419': es_419,
+  fr: fr_FR,
+  'fr-FR': fr_FR,
+  hi: hi_IN,
+  'hi-IN': hi_IN,
+  id: id_ID,
+  'id-ID': id_ID,
+  ja: ja_JP,
+  'ja-JP': ja_JP,
+  ko: ko_KR,
+  'ko-KR': ko_KR,
+  pt: pt_BR,
+  'pt-BR': pt_BR,
+  ru: ru_RU,
+  'ru-RU': ru_RU,
+  th: th_TH,
+  'th-TH': th_TH,
+  tr: tr_TR,
+  'tr-TR': tr_TR,
+  zh: zh_CN,
+  'zh-CN': zh_CN,
+}; //satisfies Record<Locale, object>;


### PR DESCRIPTION
current bundle size (always) / optimal bundle with single lang (like a ssr nextjs page)
<img width="1100" alt="Screenshot 2023-11-29 at 12 36 52" src="https://github.com/rainbow-me/rainbowkit/assets/6232729/d959d494-1ac7-40e7-ace3-58328f870ef8">
<img width="1100" alt="Screenshot 2023-11-29 at 12 36 18" src="https://github.com/rainbow-me/rainbowkit/assets/6232729/45a776b6-96f8-4183-bf69-f86bf7442698">

the way I could make it work as expected is using a new entry point for each lang
some info on why barrel files are a pain here https://vercel.com/blog/how-we-optimized-package-imports-in-next-js
```ts
// imports just pt_BR messages, (besides en_US that's the default and used as fallback) 
import pt_BR from '@rainbow-me/rainbowkit/locales/pt_BR'; // (~12kb gzipped)
// imports all translations 
import all from '@rainbow-me/rainbowkit/locales'; // (~200kb gzipped)
```

I think this `RainbowKitProvider.i18n.store` api deserves some love I did it this way test quickly
another option I can think is a `messages` prop in `RainbowKitProvider` that when undefined lazy loads all locales
```ts
// after importing the locales you wish to use, store then in the provider i18n obj
RainbowKitProvider.i18n.store(all); 
// or
RainbowKitProvider.i18n.store({ 'pt-BR': pt_BR });
```
