### PR TITLE
feat: getDefaultConfig

### DIFF
--- a/packages/create-rainbowkit/generated-test-app/pages/_app.tsx
+++ b/packages/create-rainbowkit/generated-test-app/pages/_app.tsx
@@ -2,9 +2,8 @@ import '../styles/globals.css';
 import '@rainbow-me/rainbowkit/styles.css';
 import type { AppProps } from 'next/app';
 
-import { getDefaultWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit';
-import { configureChains, createConfig, WagmiConfig } from 'wagmi';
-import { publicProvider } from 'wagmi/providers/public';
+import { getDefaultConfig, RainbowKitProvider } from '@rainbow-me/rainbowkit';
+import { WagmiConfig } from 'wagmi';
 import {
   arbitrum,
   base,
@@ -15,30 +14,20 @@ import {
   zora,
 } from 'wagmi/chains';
 
-const { chains, publicClient, webSocketPublicClient } = configureChains(
-  [
-    mainnet,
-    polygon,
-    optimism,
-    arbitrum,
-    base,
-    zora,
-    ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [sepolia] : []),
-  ],
-  [publicProvider()]
-);
+const chains = [
+  mainnet,
+  polygon,
+  optimism,
+  arbitrum,
+  base,
+  zora,
+  ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [sepolia] : []),
+];
 
-const { connectors } = getDefaultWallets({
+const wagmiConfig = getDefaultConfig({
   appName: 'RainbowKit App',
   projectId: 'YOUR_PROJECT_ID',
   chains,
-});
-
-const wagmiConfig = createConfig({
-  autoConnect: true,
-  connectors,
-  publicClient,
-  webSocketPublicClient,
 });
 
 function MyApp({ Component, pageProps }: AppProps) {

--- a/packages/create-rainbowkit/templates/next-app/pages/_app.tsx
+++ b/packages/create-rainbowkit/templates/next-app/pages/_app.tsx
@@ -2,9 +2,8 @@ import '../styles/globals.css';
 import '@rainbow-me/rainbowkit/styles.css';
 import type { AppProps } from 'next/app';
 
-import { getDefaultWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit';
-import { configureChains, createConfig, WagmiConfig } from 'wagmi';
-import { publicProvider } from 'wagmi/providers/public';
+import { getDefaultConfig, RainbowKitProvider } from '@rainbow-me/rainbowkit';
+import { WagmiConfig } from 'wagmi';
 import {
   arbitrum,
   base,
@@ -15,30 +14,20 @@ import {
   zora,
 } from 'wagmi/chains';
 
-const { chains, publicClient, webSocketPublicClient } = configureChains(
-  [
-    mainnet,
-    polygon,
-    optimism,
-    arbitrum,
-    base,
-    zora,
-    ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [sepolia] : []),
-  ],
-  [publicProvider()]
-);
+const chains = [
+  mainnet,
+  polygon,
+  optimism,
+  arbitrum,
+  base,
+  zora,
+  ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [sepolia] : []),
+];
 
-const { connectors } = getDefaultWallets({
+const wagmiConfig = getDefaultConfig({
   appName: 'RainbowKit App',
   projectId: 'YOUR_PROJECT_ID',
   chains,
-});
-
-const wagmiConfig = createConfig({
-  autoConnect: true,
-  connectors,
-  publicClient,
-  webSocketPublicClient,
 });
 
 function MyApp({ Component, pageProps }: AppProps) {

--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -6,8 +6,8 @@ import {
   DisclaimerComponent,
   Locale,
   RainbowKitProvider,
-  connectorsForWallets,
   darkTheme,
+  getDefaultConfig,
   getDefaultWallets,
   lightTheme,
   midnightTheme,
@@ -59,12 +59,7 @@ import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
-import {
-  WagmiConfig,
-  configureChains,
-  createConfig,
-  useDisconnect,
-} from 'wagmi';
+import { WagmiConfig, useDisconnect } from 'wagmi';
 import {
   arbitrum,
   arbitrumSepolia,
@@ -83,98 +78,88 @@ import {
   zora,
   zoraSepolia,
 } from 'wagmi/chains';
-import { alchemyProvider } from 'wagmi/providers/alchemy';
-import { publicProvider } from 'wagmi/providers/public';
 import { AppContextProps } from '../lib/AppContextProps';
 
 const RAINBOW_TERMS = 'https://rainbow.me/terms-of-use';
 
-const { chains, publicClient, webSocketPublicClient } = configureChains(
-  [
-    mainnet,
-    polygon,
-    optimism,
-    arbitrum,
-    base,
-    zora,
-    bsc,
-    zkSync,
-    ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true'
-      ? [
-          goerli,
-          sepolia,
-          holesky,
-          polygonMumbai,
-          optimismSepolia,
-          arbitrumSepolia,
-          baseSepolia,
-          zoraSepolia,
-        ]
-      : []),
-  ],
-  [
-    alchemyProvider({ apiKey: process.env.NEXT_PUBLIC_ALCHEMY_ID ?? '' }),
-    publicProvider(),
-  ],
-);
-
 const projectId =
   process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID ?? 'YOUR_PROJECT_ID';
 
+const chains = [
+  mainnet,
+  polygon,
+  optimism,
+  arbitrum,
+  base,
+  zora,
+  bsc,
+  zkSync,
+  ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true'
+    ? [
+        goerli,
+        sepolia,
+        holesky,
+        polygonMumbai,
+        optimismSepolia,
+        arbitrumSepolia,
+        baseSepolia,
+        zoraSepolia,
+      ]
+    : []),
+];
+
 const { wallets } = getDefaultWallets({
-  appName: 'RainbowKit demo',
-  chains,
+  appName: 'RainbowKit Demo',
   projectId,
+  chains,
 });
 
-const connectors = connectorsForWallets([
-  ...wallets,
-  {
-    groupName: 'Other',
-    wallets: [
-      argentWallet({ chains, projectId }),
-      bifrostWallet({ chains, projectId }),
-      bitgetWallet({ chains, projectId }),
-      bitskiWallet({ chains }),
-      clvWallet({ chains, projectId }),
-      coin98Wallet({ chains, projectId }),
-      coreWallet({ chains, projectId }),
-      dawnWallet({ chains }),
-      desigWallet({ chains }),
-      enkryptWallet({ chains }),
-      foxWallet({ chains, projectId }),
-      frameWallet({ chains }),
-      frontierWallet({ chains, projectId }),
-      imTokenWallet({ chains, projectId }),
-      ledgerWallet({ chains, projectId }),
-      mewWallet({ chains }),
-      oktoWallet({ chains, projectId }),
-      okxWallet({ chains, projectId }),
-      omniWallet({ chains, projectId }),
-      oneKeyWallet({ chains }),
-      phantomWallet({ chains }),
-      rabbyWallet({ chains }),
-      safeheronWallet({ chains }),
-      safepalWallet({ chains, projectId }),
-      subWallet({ chains, projectId }),
-      tahoWallet({ chains }),
-      talismanWallet({ chains }),
-      tokenaryWallet({ chains }),
-      tokenPocketWallet({ chains, projectId }),
-      trustWallet({ chains, projectId }),
-      uniswapWallet({ chains, projectId }),
-      xdefiWallet({ chains }),
-      zealWallet({ chains }),
-      zerionWallet({ chains, projectId }),
-    ],
-  },
-]);
-
-const wagmiConfig = createConfig({
-  autoConnect: true,
-  connectors,
-  publicClient,
-  webSocketPublicClient,
+const wagmiConfig = getDefaultConfig({
+  appName: 'RainbowKit Demo',
+  projectId,
+  chains,
+  wallets: [
+    ...wallets,
+    {
+      groupName: 'Other',
+      wallets: [
+        argentWallet({ projectId, chains }),
+        bifrostWallet({ projectId, chains }),
+        bitgetWallet({ projectId, chains }),
+        bitskiWallet({ chains }),
+        clvWallet({ projectId, chains }),
+        coin98Wallet({ projectId, chains }),
+        coreWallet({ projectId, chains }),
+        dawnWallet({ chains }),
+        desigWallet({ chains }),
+        enkryptWallet({ chains }),
+        foxWallet({ projectId, chains }),
+        frameWallet({ chains }),
+        frontierWallet({ projectId, chains }),
+        imTokenWallet({ projectId, chains }),
+        ledgerWallet({ projectId, chains }),
+        mewWallet({ chains }),
+        oktoWallet({ projectId, chains }),
+        okxWallet({ projectId, chains }),
+        omniWallet({ projectId, chains }),
+        oneKeyWallet({ chains }),
+        phantomWallet({ chains }),
+        rabbyWallet({ chains }),
+        safeheronWallet({ chains }),
+        safepalWallet({ projectId, chains }),
+        subWallet({ projectId, chains }),
+        tahoWallet({ chains }),
+        talismanWallet({ chains }),
+        tokenPocketWallet({ projectId, chains }),
+        tokenaryWallet({ chains }),
+        trustWallet({ projectId, chains }),
+        uniswapWallet({ projectId, chains }),
+        xdefiWallet({ chains }),
+        zealWallet({ chains }),
+        zerionWallet({ projectId, chains }),
+      ],
+    },
+  ],
 });
 
 const demoAppInfo = {

--- a/packages/rainbowkit/src/config/getDefaultConfig.ts
+++ b/packages/rainbowkit/src/config/getDefaultConfig.ts
@@ -1,0 +1,50 @@
+import { type Chain, configureChains, createConfig } from 'wagmi';
+import { publicProvider } from 'wagmi/providers/public';
+import type { WalletList } from '../wallets/Wallet';
+import { connectorsForWallets } from '../wallets/connectorsForWallets';
+import {
+  coinbaseWallet,
+  metaMaskWallet,
+  rainbowWallet,
+  walletConnectWallet,
+} from '../wallets/walletConnectors';
+
+export const getDefaultConfig = ({
+  appName,
+  chains,
+  wallets,
+  projectId,
+}: {
+  appName: string;
+  appDescription?: string;
+  appUrl?: string;
+  appIcon?: string;
+  chains: Chain[];
+  wallets?: WalletList;
+  projectId: string;
+}) => {
+  const { publicClient, webSocketPublicClient } = configureChains(chains, [
+    publicProvider(),
+  ]);
+
+  const connectors = connectorsForWallets(
+    wallets || [
+      {
+        groupName: 'Popular',
+        wallets: [
+          rainbowWallet({ chains, projectId }),
+          coinbaseWallet({ appName, chains }),
+          metaMaskWallet({ chains, projectId }),
+          walletConnectWallet({ chains, projectId }),
+        ],
+      },
+    ],
+  );
+
+  return createConfig({
+    autoConnect: true,
+    connectors,
+    publicClient,
+    webSocketPublicClient,
+  });
+};

--- a/packages/rainbowkit/src/config/getDefaultConfig.ts
+++ b/packages/rainbowkit/src/config/getDefaultConfig.ts
@@ -11,6 +11,7 @@ import {
 
 export const getDefaultConfig = ({
   appName,
+  appIcon,
   chains,
   wallets,
   projectId,
@@ -33,7 +34,7 @@ export const getDefaultConfig = ({
         groupName: 'Popular',
         wallets: [
           rainbowWallet({ chains, projectId }),
-          coinbaseWallet({ appName, chains }),
+          coinbaseWallet({ appName, appIcon, chains }),
           metaMaskWallet({ chains, projectId }),
           walletConnectWallet({ chains, projectId }),
         ],

--- a/packages/rainbowkit/src/config/getDefaultConfig.ts
+++ b/packages/rainbowkit/src/config/getDefaultConfig.ts
@@ -2,6 +2,7 @@ import { type Chain, configureChains, createConfig } from 'wagmi';
 import { publicProvider } from 'wagmi/providers/public';
 import type { WalletList } from '../wallets/Wallet';
 import { connectorsForWallets } from '../wallets/connectorsForWallets';
+import type { WalletConnectConnectorMetadata } from '../wallets/getWalletConnectConnector';
 import {
   coinbaseWallet,
   metaMaskWallet,
@@ -11,6 +12,8 @@ import {
 
 export const getDefaultConfig = ({
   appName,
+  appDescription,
+  appUrl,
   appIcon,
   chains,
   wallets,
@@ -28,15 +31,21 @@ export const getDefaultConfig = ({
     publicProvider(),
   ]);
 
+  const metadata: WalletConnectConnectorMetadata = {
+    name: appName,
+    description: appDescription,
+    url: appUrl,
+  };
+
   const connectors = connectorsForWallets(
     wallets || [
       {
         groupName: 'Popular',
         wallets: [
-          rainbowWallet({ chains, projectId }),
+          rainbowWallet({ chains, projectId, options: { metadata } }),
           coinbaseWallet({ appName, appIcon, chains }),
-          metaMaskWallet({ chains, projectId }),
-          walletConnectWallet({ chains, projectId }),
+          metaMaskWallet({ chains, projectId, options: { metadata } }),
+          walletConnectWallet({ chains, projectId, options: { metadata } }),
         ],
       },
     ],

--- a/packages/rainbowkit/src/index.ts
+++ b/packages/rainbowkit/src/index.ts
@@ -1,6 +1,7 @@
 export { ConnectButton } from './components/ConnectButton/ConnectButton';
 export { WalletButton } from './components/WalletButton/WalletButton';
 export { RainbowKitProvider } from './components/RainbowKitProvider/RainbowKitProvider';
+export { getDefaultConfig } from './config/getDefaultConfig';
 export { getDefaultWallets } from './wallets/getDefaultWallets';
 export { getWalletConnectConnector } from './wallets/getWalletConnectConnector';
 export { connectorsForWallets } from './wallets/connectorsForWallets';

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -7,9 +7,13 @@ const sharedConnectors = new Map<SerializedOptions, WalletConnectConnector>();
 type WalletConnectConnectorConfig = ConstructorParameters<
   typeof WalletConnectConnector
 >[0];
+
 export type WalletConnectConnectorOptions =
   // @ts-ignore
   WalletConnectConnectorConfig['options'];
+
+export type WalletConnectConnectorMetadata =
+  WalletConnectConnectorOptions['metadata'];
 
 function createConnector(
   config: WalletConnectConnectorConfig,

--- a/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
@@ -6,11 +6,13 @@ import { hasInjectedProvider } from '../../getInjectedConnector';
 
 export interface CoinbaseWalletOptions {
   appName: string;
+  appIcon?: string;
   chains: Chain[];
 }
 
 export const coinbaseWallet = ({
   appName,
+  appIcon,
   chains,
   ...options
 }: CoinbaseWalletOptions): Wallet => {
@@ -43,6 +45,7 @@ export const coinbaseWallet = ({
         chains,
         options: {
           appName,
+          appLogoUrl: appIcon,
           headlessMode: true,
           ...options,
         },

--- a/site/components/Provider/Provider.tsx
+++ b/site/components/Provider/Provider.tsx
@@ -1,7 +1,4 @@
-import {
-  connectorsForWallets,
-  getDefaultWallets,
-} from '@rainbow-me/rainbowkit';
+import { getDefaultConfig, getDefaultWallets } from '@rainbow-me/rainbowkit';
 import {
   argentWallet,
   imTokenWallet,
@@ -10,7 +7,7 @@ import {
   trustWallet,
 } from '@rainbow-me/rainbowkit/wallets';
 import React from 'react';
-import { WagmiConfig, configureChains, createConfig } from 'wagmi';
+import { WagmiConfig } from 'wagmi';
 import {
   arbitrum,
   base,
@@ -20,44 +17,35 @@ import {
   polygon,
   zora,
 } from 'wagmi/chains';
-import { alchemyProvider } from 'wagmi/providers/alchemy';
-import { publicProvider } from 'wagmi/providers/public';
 
-export const { chains, publicClient } = configureChains(
-  [mainnet, polygon, optimism, arbitrum, base, zora, bsc],
-  [
-    alchemyProvider({ apiKey: process.env.NEXT_PUBLIC_ALCHEMY_ID ?? '' }),
-    publicProvider(),
-  ],
-);
+export const chains = [mainnet, polygon, optimism, arbitrum, base, zora, bsc];
 
 const projectId =
   process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID ?? 'YOUR_PROJECT_ID';
 
 const { wallets } = getDefaultWallets({
   appName: 'rainbowkit.com',
-  chains,
   projectId,
+  chains,
 });
 
-const connectors = connectorsForWallets([
-  ...wallets,
-  {
-    groupName: 'More',
-    wallets: [
-      argentWallet({ chains, projectId }),
-      trustWallet({ chains, projectId }),
-      omniWallet({ chains, projectId }),
-      imTokenWallet({ chains, projectId }),
-      ledgerWallet({ chains, projectId }),
-    ],
-  },
-]);
-
-const wagmiConfig = createConfig({
-  autoConnect: true,
-  connectors,
-  publicClient,
+const wagmiConfig = getDefaultConfig({
+  appName: 'rainbowkit.com',
+  projectId,
+  chains,
+  wallets: [
+    ...wallets,
+    {
+      groupName: 'More',
+      wallets: [
+        argentWallet({ chains, projectId }),
+        trustWallet({ chains, projectId }),
+        omniWallet({ chains, projectId }),
+        imTokenWallet({ chains, projectId }),
+        ledgerWallet({ chains, projectId }),
+      ],
+    },
+  ],
 });
 
 export function Provider({ children }) {


### PR DESCRIPTION
## Changes
- `getDefaultConfig` take a wallet list and props and wraps `configureChains` and `createConfig`
- `getDefaultWallets` is now default behavior in `getDefaultConfig`
- temporarily removed use of `alchemyProvider` instances