### PR TITLE
refactor: wallet connectors provider checks, deprecate @wagmi/core types

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@types/react-dom": "^18.2.17",
     "@vanilla-extract/esbuild-plugin": "^2.3.1",
     "@vanilla-extract/vite-plugin": "^3.9.3",
-    "@wagmi/core": "~1.4.13",
     "autoprefixer": "^10.4.16",
     "esbuild": "^0.14.39",
     "esbuild-plugin-replace": "^1.4.0",

--- a/packages/rainbow-button/package.json
+++ b/packages/rainbow-button/package.json
@@ -42,9 +42,6 @@
     "viem": "~0.3.19 || ^1.0.0",
     "wagmi": "~1.0.1 || ~1.1.0 || ~1.2.0 || ~1.3.0 || ~1.4.0"
   },
-  "devDependencies": {
-    "@wagmi/core": "^1.4.3"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rainbow-me/rainbowkit.git",

--- a/packages/rainbow-button/src/connectors/rainbow.ts
+++ b/packages/rainbow-button/src/connectors/rainbow.ts
@@ -1,6 +1,6 @@
 import { connectorsForWallets } from '@rainbow-me/rainbowkit';
 import { rainbowWallet } from '@rainbow-me/rainbowkit/wallets';
-import { Connector } from '@wagmi/core';
+import { Connector } from 'wagmi';
 
 export type RainbowConnectorOptions = Parameters<typeof rainbowWallet>[0];
 

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -62,7 +62,6 @@
     "viem": "~1.21.4",
     "vitest": "^0.33.0",
     "wagmi": "~1.4.13",
-    "@wagmi/core": "~1.4.13",
     "@types/i18n-js": "^3.8.9",
     "@types/ua-parser-js": "^0.7.39"
   },

--- a/packages/rainbowkit/src/config/getDefaultConfig.ts
+++ b/packages/rainbowkit/src/config/getDefaultConfig.ts
@@ -42,9 +42,17 @@ export const getDefaultConfig = ({
       {
         groupName: 'Popular',
         wallets: [
-          rainbowWallet({ chains, projectId, options: { metadata } }),
+          rainbowWallet({
+            chains,
+            projectId,
+            walletConnectOptions: { metadata },
+          }),
           coinbaseWallet({ appName, appIcon, chains }),
-          metaMaskWallet({ chains, projectId, options: { metadata } }),
+          metaMaskWallet({
+            chains,
+            projectId,
+            walletConnectOptions: { metadata },
+          }),
           walletConnectWallet({ chains, projectId, options: { metadata } }),
         ],
       },

--- a/packages/rainbowkit/src/hooks/useMainnet.ts
+++ b/packages/rainbowkit/src/hooks/useMainnet.ts
@@ -11,7 +11,6 @@ export function useMainnet() {
   // than necessary in case the manual typing is ever incorrect.
   // If we're unable to resolve a list of chains, or the chains are
   // an invalid type, we'll silently bail out.
-  // @ts-expect-error
   const provider = usePublicClient<{ chains?: Chain[] }>();
   const chains = Array.isArray(provider.chains) ? provider.chains : [];
   const enabled = chains?.some((chain) => chain?.id === chainId);

--- a/packages/rainbowkit/src/wallets/getInjectedConnector.test.ts
+++ b/packages/rainbowkit/src/wallets/getInjectedConnector.test.ts
@@ -77,25 +77,63 @@ describe('getInjectedConnector', () => {
 });
 
 describe('hasInjectedProvider', () => {
-  it('only rainbow provider', () => {
+  it('only rainbow flag', () => {
     window.ethereum = { isMetaMask: true, isRainbow: true } as WindowProvider;
     const hasRainbow = hasInjectedProvider({ flag: 'isRainbow' });
     expect(hasRainbow).toEqual(true);
   });
 
-  it('only metamask provider', () => {
+  it('only metamask flag', () => {
     window.ethereum = { isMetaMask: true } as WindowProvider;
     const hasRainbow = hasInjectedProvider({ flag: 'isRainbow' });
     expect(hasRainbow).toEqual(false);
   });
 
-  it('only coinbase provider', () => {
+  it('only coinbase flag', () => {
     window.ethereum = {
       isMetaMask: true,
       isCoinbaseWallet: true,
     } as WindowProvider;
     const hasCoinbase = hasInjectedProvider({ flag: 'isCoinbaseWallet' });
     expect(hasCoinbase).toEqual(true);
+  });
+
+  it('only enkrypt namespace', () => {
+    // @ts-expect-error - window namespace for enkrypt
+    window.enkrypt = {
+      providers: {
+        ethereum: { isMetaMask: true },
+      },
+    } as WindowProvider;
+    const hasEnkrypt = hasInjectedProvider({
+      namespace: 'enkrypt.providers.ethereum',
+    });
+    expect(hasEnkrypt).toEqual(true);
+  });
+
+  it('core namespace and flag', () => {
+    // @ts-expect-error - window namespace for avalanche, core
+    window.avalanche = {
+      isMetaMask: true,
+      isAvalanche: true,
+    } as WindowProvider;
+    const hasCore = hasInjectedProvider({
+      namespace: 'avalanche',
+      flag: 'isAvalanche',
+    });
+    expect(hasCore).toEqual(true);
+  });
+
+  it('core namespace and flag, fallback', () => {
+    window.ethereum = {
+      isMetaMask: true,
+      isAvalanche: true,
+    } as WindowProvider;
+    const hasCore = hasInjectedProvider({
+      namespace: 'avalanche',
+      flag: 'isAvalanche',
+    });
+    expect(hasCore).toEqual(true);
   });
 
   it('has rainbow and coinbase wallet', () => {

--- a/packages/rainbowkit/src/wallets/getInjectedConnector.test.ts
+++ b/packages/rainbowkit/src/wallets/getInjectedConnector.test.ts
@@ -21,7 +21,7 @@ describe('getInjectedConnector', () => {
   it('only metamask provider', () => {
     window.ethereum = { isMetaMask: true } as WindowProvider;
     const connector = getInjectedConnector({
-      flag: 'isRainbow',
+      flag: 'isMetaMask',
       chains,
     });
     expect(connector.name).toEqual('MetaMask');
@@ -79,13 +79,13 @@ describe('getInjectedConnector', () => {
 describe('hasInjectedProvider', () => {
   it('only rainbow provider', () => {
     window.ethereum = { isMetaMask: true, isRainbow: true } as WindowProvider;
-    const hasRainbow = hasInjectedProvider('isRainbow');
+    const hasRainbow = hasInjectedProvider({ flag: 'isRainbow' });
     expect(hasRainbow).toEqual(true);
   });
 
   it('only metamask provider', () => {
     window.ethereum = { isMetaMask: true } as WindowProvider;
-    const hasRainbow = hasInjectedProvider('isRainbow');
+    const hasRainbow = hasInjectedProvider({ flag: 'isRainbow' });
     expect(hasRainbow).toEqual(false);
   });
 
@@ -94,7 +94,7 @@ describe('hasInjectedProvider', () => {
       isMetaMask: true,
       isCoinbaseWallet: true,
     } as WindowProvider;
-    const hasCoinbase = hasInjectedProvider('isCoinbaseWallet');
+    const hasCoinbase = hasInjectedProvider({ flag: 'isCoinbaseWallet' });
     expect(hasCoinbase).toEqual(true);
   });
 
@@ -108,10 +108,10 @@ describe('hasInjectedProvider', () => {
       ],
     } as WindowProvider;
 
-    const hasCoinbase = hasInjectedProvider('isCoinbaseWallet');
+    const hasCoinbase = hasInjectedProvider({ flag: 'isCoinbaseWallet' });
     expect(hasCoinbase).toEqual(true);
 
-    const hasRainbow = hasInjectedProvider('isRainbow');
+    const hasRainbow = hasInjectedProvider({ flag: 'isRainbow' });
     expect(hasRainbow).toEqual(true);
   });
 
@@ -126,13 +126,13 @@ describe('hasInjectedProvider', () => {
       ],
     } as WindowProvider;
 
-    const hasCoinbase = hasInjectedProvider('isCoinbaseWallet');
+    const hasCoinbase = hasInjectedProvider({ flag: 'isCoinbaseWallet' });
     expect(hasCoinbase).toEqual(true);
 
-    const hasRainbow = hasInjectedProvider('isRainbow');
+    const hasRainbow = hasInjectedProvider({ flag: 'isRainbow' });
     expect(hasRainbow).toEqual(true);
 
-    const hasMetaMask = hasInjectedProvider('isMetaMask');
+    const hasMetaMask = hasInjectedProvider({ flag: 'isMetaMask' });
     expect(hasMetaMask).toEqual(true);
   });
 });

--- a/packages/rainbowkit/src/wallets/getInjectedConnector.ts
+++ b/packages/rainbowkit/src/wallets/getInjectedConnector.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import type { InjectedProviderFlags, WindowProvider } from 'wagmi/window';
 import type { Chain } from '../components/RainbowKitProvider/RainbowKitChainContext';
@@ -44,17 +43,14 @@ function getInjectedProvider(
 export function getInjectedConnector({
   chains,
   flag,
-  options,
 }: {
   flag: keyof InjectedProviderFlags;
   chains: Chain[];
-  options?: InjectedConnectorOptions;
 }): InjectedConnector {
   return new InjectedConnector({
     chains,
     options: {
       getProvider: () => getInjectedProvider(flag),
-      ...options,
     },
   });
 }

--- a/packages/rainbowkit/src/wallets/getInjectedConnector.ts
+++ b/packages/rainbowkit/src/wallets/getInjectedConnector.ts
@@ -26,8 +26,18 @@ function getExplicitInjectedProvider(
 function getWindowProviderNamespace(
   namespace: string,
 ): WindowProvider | undefined {
-  // @ts-expect-error - only `window.ethereum` is available in wagmi's global namespace
-  return window[namespace];
+  const providerSearch = (
+    provider: any,
+    namespace: string,
+  ): WindowProvider | undefined => {
+    const [property, ...path] = namespace.split('.');
+    const _provider = provider[property];
+    if (_provider) {
+      if (path.length === 0) return _provider;
+      return providerSearch(_provider, path.join('.'));
+    }
+  };
+  return providerSearch(window, namespace);
 }
 
 /*

--- a/packages/rainbowkit/src/wallets/getInjectedConnector.ts
+++ b/packages/rainbowkit/src/wallets/getInjectedConnector.ts
@@ -6,32 +6,61 @@ import type { Chain } from '../components/RainbowKitProvider/RainbowKitChainCont
  * Returns the explicit window provider that matches the flag and the flag is true
  */
 function getExplicitInjectedProvider(
-  flag: keyof InjectedProviderFlags,
+  flag: keyof InjectedProviderFlags | string,
 ): WindowProvider | undefined {
   if (typeof window === 'undefined' || typeof window.ethereum === 'undefined')
     return;
   const providers = window.ethereum.providers;
   return providers
-    ? providers.find((provider) => provider[flag])
-    : window.ethereum[flag]
+    ? // @ts-expect-error - some provider flags are not typed in `InjectedProviderFlags`
+      providers.find((provider) => provider[flag])
+    : // @ts-expect-error - some provider flags are not typed in `InjectedProviderFlags`
+      window.ethereum[flag]
       ? window.ethereum
       : undefined;
 }
 
-export function hasInjectedProvider(
-  flag: keyof InjectedProviderFlags,
-): boolean {
-  return Boolean(getExplicitInjectedProvider(flag));
+/*
+ * Gets the `window.namespace` window provider if it exists
+ */
+function getWindowProviderNamespace(
+  namespace: string,
+): WindowProvider | undefined {
+  // @ts-expect-error - only `window.ethereum` is available in wagmi's global namespace
+  return window[namespace];
+}
+
+/*
+ * Checks if the explict provider or window ethereum exists
+ */
+export function hasInjectedProvider({
+  flag,
+  namespace,
+}: {
+  flag?: keyof InjectedProviderFlags | string;
+  namespace?: string;
+}): boolean {
+  if (namespace && typeof getWindowProviderNamespace(namespace) !== 'undefined')
+    return true;
+  if (flag && typeof getExplicitInjectedProvider(flag) !== 'undefined')
+    return true;
+  return false;
 }
 
 /*
  * Returns an injected provider that favors the flag match, but falls back to window.ethereum
  */
 function getInjectedProvider(
-  flag: keyof InjectedProviderFlags,
+  flag: keyof InjectedProviderFlags | string,
+  namespace?: string,
 ): WindowProvider | undefined {
   if (typeof window === 'undefined' || typeof window.ethereum === 'undefined')
     return;
+  if (namespace) {
+    // prefer custom eip1193 namespaces
+    const windowProvider = getWindowProviderNamespace(namespace);
+    if (windowProvider) return windowProvider;
+  }
   const providers = window.ethereum.providers;
   const provider = getExplicitInjectedProvider(flag);
   if (provider) return provider;
@@ -43,14 +72,16 @@ function getInjectedProvider(
 export function getInjectedConnector({
   chains,
   flag,
+  namespace,
 }: {
-  flag?: keyof InjectedProviderFlags;
+  flag?: keyof InjectedProviderFlags | string;
+  namespace?: string;
   chains: Chain[];
 }): InjectedConnector {
   return new InjectedConnector({
     chains,
     options: flag
-      ? { getProvider: () => getInjectedProvider(flag) }
+      ? { getProvider: () => getInjectedProvider(flag, namespace) }
       : undefined,
   });
 }

--- a/packages/rainbowkit/src/wallets/getInjectedConnector.ts
+++ b/packages/rainbowkit/src/wallets/getInjectedConnector.ts
@@ -44,13 +44,13 @@ export function getInjectedConnector({
   chains,
   flag,
 }: {
-  flag: keyof InjectedProviderFlags;
+  flag?: keyof InjectedProviderFlags;
   chains: Chain[];
 }): InjectedConnector {
   return new InjectedConnector({
     chains,
-    options: {
-      getProvider: () => getInjectedProvider(flag),
-    },
+    options: flag
+      ? { getProvider: () => getInjectedProvider(flag) }
+      : undefined,
   });
 }

--- a/packages/rainbowkit/src/wallets/getInjectedConnector.ts
+++ b/packages/rainbowkit/src/wallets/getInjectedConnector.ts
@@ -37,7 +37,7 @@ function getWindowProviderNamespace(
       return providerSearch(_provider, path.join('.'));
     }
   };
-  return providerSearch(window, namespace);
+  if (typeof window !== 'undefined') return providerSearch(window, namespace);
 }
 
 /*
@@ -67,14 +67,13 @@ function getInjectedProvider({
   flag?: keyof InjectedProviderFlags | string;
   namespace?: string;
 }): WindowProvider | undefined {
-  if (typeof window === 'undefined' || typeof window.ethereum === 'undefined')
-    return;
+  if (typeof window === 'undefined') return;
   if (namespace) {
     // prefer custom eip1193 namespaces
     const windowProvider = getWindowProviderNamespace(namespace);
     if (windowProvider) return windowProvider;
   }
-  const providers = window.ethereum.providers;
+  const providers = window.ethereum?.providers;
   if (flag) {
     const provider = getExplicitInjectedProvider(flag);
     if (provider) return provider;

--- a/packages/rainbowkit/src/wallets/walletConnectors/bifrostWallet/bifrostWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bifrostWallet/bifrostWallet.ts
@@ -22,7 +22,7 @@ export const bifrostWallet = ({
   projectId,
   walletConnectOptions,
 }: BifrostWalletOptions): Wallet => {
-  const isBifrostInjected = hasInjectedProvider('isBifrost');
+  const isBifrostInjected = hasInjectedProvider({ flag: 'isBifrost' });
   const shouldUseWalletConnect = !isBifrostInjected;
 
   return {

--- a/packages/rainbowkit/src/wallets/walletConnectors/bifrostWallet/bifrostWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bifrostWallet/bifrostWallet.ts
@@ -1,9 +1,11 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isAndroid } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 import {
   WalletConnectConnectorOptions,
   getWalletConnectConnector,
@@ -19,13 +21,8 @@ export const bifrostWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  ...options
-}: BifrostWalletOptions & InjectedConnectorOptions): Wallet => {
-  const isBifrostInjected =
-    typeof window !== 'undefined' &&
-    typeof window.ethereum !== 'undefined' &&
-    window.ethereum.isBifrost;
-
+}: BifrostWalletOptions): Wallet => {
+  const isBifrostInjected = hasInjectedProvider('isBifrost');
   const shouldUseWalletConnect = !isBifrostInjected;
 
   return {
@@ -47,9 +44,9 @@ export const bifrostWallet = ({
             projectId,
             options: walletConnectOptions,
           })
-        : new InjectedConnector({
+        : getInjectedConnector({
+            flag: 'isBifrost',
             chains,
-            options,
           });
 
       const getUri = async () => {

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitgetWallet/bitgetWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitgetWallet/bitgetWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
@@ -17,8 +16,7 @@ export const bitgetWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  ...options
-}: BitgetWalletOptions & InjectedConnectorOptions): Wallet => {
+}: BitgetWalletOptions): Wallet => {
   const isBitKeepInjected =
     typeof window !== 'undefined' &&
     // @ts-expect-error
@@ -59,7 +57,6 @@ export const bitgetWallet = ({
             options: {
               // @ts-expect-error
               getProvider: () => window.bitkeep.ethereum,
-              ...options,
             },
           });
 

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitgetWallet/bitgetWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitgetWallet/bitgetWallet.ts
@@ -1,8 +1,11 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isAndroid } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
@@ -17,15 +20,10 @@ export const bitgetWallet = ({
   projectId,
   walletConnectOptions,
 }: BitgetWalletOptions): Wallet => {
-  const isBitKeepInjected =
-    typeof window !== 'undefined' &&
-    // @ts-expect-error
-    window.bitkeep !== undefined &&
-    // @ts-expect-error
-    window.bitkeep.ethereum !== undefined &&
-    // @ts-expect-error
-    window.bitkeep.ethereum.isBitKeep === true;
-
+  const isBitKeepInjected = hasInjectedProvider({
+    namespace: 'bitkeep.ethereum',
+    flag: 'isBitKeep',
+  });
   const shouldUseWalletConnect = !isBitKeepInjected;
 
   return {
@@ -52,12 +50,10 @@ export const bitgetWallet = ({
             options: walletConnectOptions,
             projectId,
           })
-        : new InjectedConnector({
+        : getInjectedConnector({
             chains,
-            options: {
-              // @ts-expect-error
-              getProvider: () => window.bitkeep.ethereum,
-            },
+            namespace: 'bitkeep.ethereum',
+            flag: 'isBitKeep',
           });
 
       const getUri = async () => {

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
@@ -1,6 +1,9 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface BitskiWalletOptions {
   chains: Chain[];
@@ -9,11 +12,7 @@ export interface BitskiWalletOptions {
 export const bitskiWallet = ({ chains }: BitskiWalletOptions): Wallet => ({
   id: 'bitski',
   name: 'Bitski',
-  installed:
-    typeof window !== 'undefined' &&
-    typeof window.ethereum !== 'undefined' &&
-    ((window.ethereum as any).isBitski === true ||
-      !!window.ethereum.providers?.find((p: any) => p.isBitski === true)),
+  installed: hasInjectedProvider('isBitski'),
   iconUrl: async () => (await import('./bitskiWallet.svg')).default,
   iconBackground: '#fff',
   downloadUrls: {
@@ -22,9 +21,7 @@ export const bitskiWallet = ({ chains }: BitskiWalletOptions): Wallet => ({
     browserExtension: 'https://bitski.com',
   },
   createConnector: () => ({
-    connector: new InjectedConnector({
-      chains,
-    }),
+    connector: getInjectedConnector({ chains, flag: 'isBitski' }),
     extension: {
       instructions: {
         learnMoreUrl:

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
@@ -12,7 +12,7 @@ export interface BitskiWalletOptions {
 export const bitskiWallet = ({ chains }: BitskiWalletOptions): Wallet => ({
   id: 'bitski',
   name: 'Bitski',
-  installed: hasInjectedProvider('isBitski'),
+  installed: hasInjectedProvider({ flag: 'isBitski' }),
   iconUrl: async () => (await import('./bitskiWallet.svg')).default,
   iconBackground: '#fff',
   downloadUrls: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -7,10 +6,7 @@ export interface BitskiWalletOptions {
   chains: Chain[];
 }
 
-export const bitskiWallet = ({
-  chains,
-  ...options
-}: BitskiWalletOptions & InjectedConnectorOptions): Wallet => ({
+export const bitskiWallet = ({ chains }: BitskiWalletOptions): Wallet => ({
   id: 'bitski',
   name: 'Bitski',
   installed:
@@ -28,7 +24,6 @@ export const bitskiWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options,
     }),
     extension: {
       instructions: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
@@ -20,7 +20,7 @@ export const braveWallet = ({ chains }: BraveWalletOptions): Wallet => ({
   name: 'Brave Wallet',
   iconUrl: async () => (await import('./braveWallet.svg')).default,
   iconBackground: '#fff',
-  installed: hasInjectedProvider('isBraveWallet'),
+  installed: hasInjectedProvider({ flag: 'isBraveWallet' }),
   downloadUrls: {
     // We're opting not to provide a download prompt if Brave isn't the current
     // browser since it's unlikely to be a desired behavior for users. It's

--- a/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
@@ -1,6 +1,9 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 /**
  * @protected `braveWallet` interface
@@ -17,8 +20,7 @@ export const braveWallet = ({ chains }: BraveWalletOptions): Wallet => ({
   name: 'Brave Wallet',
   iconUrl: async () => (await import('./braveWallet.svg')).default,
   iconBackground: '#fff',
-  installed:
-    typeof window !== 'undefined' && window.ethereum?.isBraveWallet === true,
+  installed: hasInjectedProvider('isBraveWallet'),
   downloadUrls: {
     // We're opting not to provide a download prompt if Brave isn't the current
     // browser since it's unlikely to be a desired behavior for users. It's
@@ -26,8 +28,6 @@ export const braveWallet = ({ chains }: BraveWalletOptions): Wallet => ({
     // an explicit wallet choice for users coming from other browsers.
   },
   createConnector: () => ({
-    connector: new InjectedConnector({
-      chains,
-    }),
+    connector: getInjectedConnector({ chains, flag: 'isBraveWallet' }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -13,10 +12,7 @@ export interface BraveWalletOptions {
 /**
  * @protected Brave Browser wallet connector
  */
-export const braveWallet = ({
-  chains,
-  ...options
-}: BraveWalletOptions & InjectedConnectorOptions): Wallet => ({
+export const braveWallet = ({ chains }: BraveWalletOptions): Wallet => ({
   id: 'brave',
   name: 'Brave Wallet',
   iconUrl: async () => (await import('./braveWallet.svg')).default,
@@ -32,7 +28,6 @@ export const braveWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options,
     }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/browserWallet/browserWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/browserWallet/browserWallet.ts
@@ -1,6 +1,7 @@
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
+import { getInjectedConnector } from '../../getInjectedConnector';
 
 /**
  * @protected `browserWallet` interface
@@ -26,8 +27,6 @@ export const browserWallet = ({ chains }: BrowserWalletOptions): Wallet => ({
           wallet.id === 'coinbase'),
     ),
   createConnector: () => ({
-    connector: new InjectedConnector({
-      chains,
-    }),
+    connector: getInjectedConnector({ chains }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/browserWallet/browserWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/browserWallet/browserWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -13,10 +12,7 @@ export interface BrowserWalletOptions {
 /**
  * @protected eip-1193 wallet connector
  */
-export const browserWallet = ({
-  chains,
-  ...options
-}: BrowserWalletOptions & InjectedConnectorOptions): Wallet => ({
+export const browserWallet = ({ chains }: BrowserWalletOptions): Wallet => ({
   id: 'browser',
   name: 'Browser Wallet',
   iconUrl: async () => (await import('./browserWallet.svg')).default,
@@ -32,7 +28,6 @@ export const browserWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options,
     }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/clvWallet/clvWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/clvWallet/clvWallet.ts
@@ -1,7 +1,10 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 import {
   WalletConnectConnectorOptions,
   getWalletConnectConnector,
@@ -13,20 +16,12 @@ export interface CLVWalletOptions {
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
-declare global {
-  interface Window {
-    clover: any;
-  }
-}
-
 export const clvWallet = ({
   chains,
   projectId,
   walletConnectOptions,
 }: CLVWalletOptions): Wallet => {
-  const provider = typeof window !== 'undefined' && window['clover'];
-  const isCLVInjected = Boolean(provider);
-
+  const isCLVInjected = hasInjectedProvider({ namespace: 'clover' });
   const shouldUseWalletConnect = !isCLVInjected;
 
   return {
@@ -35,7 +30,7 @@ export const clvWallet = ({
     iconUrl: async () => (await import('./clvWallet.svg')).default,
     iconBackground: '#fff',
     iconAccent: '#BDFDE2',
-    installed: !shouldUseWalletConnect ? isCLVInjected : undefined,
+    installed: isCLVInjected,
     downloadUrls: {
       chrome:
         'https://chrome.google.com/webstore/detail/clv-wallet/nhnkbkgjikgcigadomkphalanndcapjk',
@@ -50,12 +45,7 @@ export const clvWallet = ({
             options: walletConnectOptions,
             projectId,
           })
-        : new InjectedConnector({
-            chains,
-            options: {
-              getProvider: () => provider,
-            },
-          });
+        : getInjectedConnector({ chains, namespace: 'clover' });
 
       const getUri = async () => {
         const uri = await getWalletConnectUri(connector);

--- a/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
@@ -64,8 +63,7 @@ export const coin98Wallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  ...options
-}: Coin98WalletOptions & InjectedConnectorOptions): Wallet => {
+}: Coin98WalletOptions): Wallet => {
   const isCoin98WalletInjected = Boolean(getCoin98WalletInjectedProvider());
   const shouldUseWalletConnect = !isCoin98WalletInjected;
   return {
@@ -100,7 +98,6 @@ export const coin98Wallet = ({
             options: {
               name: 'Coin98 Wallet',
               getProvider: getCoin98WalletInjectedProvider,
-              ...options,
             },
           });
       const getUri = async () => {

--- a/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
@@ -1,17 +1,14 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { Wallet } from '../../Wallet';
 import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
+import {
   WalletConnectConnectorOptions,
   getWalletConnectConnector,
 } from '../../getWalletConnectConnector';
-
-declare global {
-  interface Window {
-    coin98Wallet: Window['ethereum'];
-  }
-}
 
 export interface Coin98WalletOptions {
   projectId: string;
@@ -19,61 +16,21 @@ export interface Coin98WalletOptions {
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
-function getCoin98WalletInjectedProvider(): Window['ethereum'] {
-  const isCoin98Wallet = (ethereum: NonNullable<Window['ethereum']>) => {
-    // Identify if Coin98 Wallet injected provider is present.
-    const coin98Wallet = !!ethereum.isCoin98;
-
-    return coin98Wallet;
-  };
-
-  const injectedProviderExist =
-    typeof window !== 'undefined' && typeof window.ethereum !== 'undefined';
-
-  // No injected providers exist.
-  if (!injectedProviderExist) {
-    return;
-  }
-
-  // Coin98 Wallet injected provider is available in the global scope.
-  // There are cases that some cases injected providers can replace window.ethereum
-  // without updating the ethereum.providers array. To prevent issues where
-  // the C98 connector does not recognize the provider when C98 extension is installed,
-  // we begin our checks by relying on C98's global object.
-  if (window['coin98Wallet']) {
-    return window['coin98Wallet'];
-  }
-
-  // Coin98 Wallet was injected into window.ethereum.
-  if (isCoin98Wallet(window.ethereum!)) {
-    return window.ethereum;
-  }
-
-  // Coin98 Wallet provider might be replaced by another
-  // injected provider, check the providers array.
-  if (window.ethereum?.providers) {
-    // ethereum.providers array is a non-standard way to
-    // preserve multiple injected providers. Eventually, EIP-5749
-    // will become a living standard and we will have to update this.
-    return window.ethereum.providers.find(isCoin98Wallet);
-  }
-}
-
 export const coin98Wallet = ({
   chains,
   projectId,
   walletConnectOptions,
 }: Coin98WalletOptions): Wallet => {
-  const isCoin98WalletInjected = Boolean(getCoin98WalletInjectedProvider());
+  const isCoin98WalletInjected = hasInjectedProvider({
+    namespace: 'coin98Wallet',
+    flag: 'isCoin98',
+  });
   const shouldUseWalletConnect = !isCoin98WalletInjected;
   return {
     id: 'coin98',
     name: 'Coin98 Wallet',
     iconUrl: async () => (await import('./coin98Wallet.svg')).default,
-    // Note that we never resolve `installed` to `false` because the
-    // Coin98 Wallet provider falls back to other connection methods if
-    // the injected connector isn't available
-    installed: !shouldUseWalletConnect ? isCoin98WalletInjected : undefined,
+    installed: isCoin98WalletInjected,
     iconAccent: '#CDA349',
     iconBackground: '#fff',
     downloadUrls: {
@@ -93,12 +50,10 @@ export const coin98Wallet = ({
             chains,
             options: walletConnectOptions,
           })
-        : new InjectedConnector({
+        : getInjectedConnector({
             chains,
-            options: {
-              name: 'Coin98 Wallet',
-              getProvider: getCoin98WalletInjectedProvider,
-            },
+            namespace: 'coin98Wallet',
+            flag: 'isCoin98',
           });
       const getUri = async () => {
         const uri = await getWalletConnectUri(connector);

--- a/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
@@ -15,7 +15,9 @@ export const coinbaseWallet = ({
   appIcon,
   chains,
 }: CoinbaseWalletOptions): Wallet => {
-  const isCoinbaseWalletInjected = hasInjectedProvider('isCoinbaseWallet');
+  const isCoinbaseWalletInjected = hasInjectedProvider({
+    flag: 'isCoinbaseWallet',
+  });
 
   return {
     id: 'coinbase',

--- a/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
@@ -14,7 +14,6 @@ export const coinbaseWallet = ({
   appName,
   appIcon,
   chains,
-  ...options
 }: CoinbaseWalletOptions): Wallet => {
   const isCoinbaseWalletInjected = hasInjectedProvider('isCoinbaseWallet');
 
@@ -47,7 +46,6 @@ export const coinbaseWallet = ({
           appName,
           appLogoUrl: appIcon,
           headlessMode: true,
-          ...options,
         },
       });
 

--- a/packages/rainbowkit/src/wallets/walletConnectors/coreWallet/coreWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coreWallet/coreWallet.ts
@@ -1,19 +1,14 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
-import { WindowProvider } from 'wagmi/dist/window';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { Wallet } from '../../Wallet';
 import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
+import {
   WalletConnectConnectorOptions,
   getWalletConnectConnector,
 } from '../../getWalletConnectConnector';
-
-declare global {
-  interface Window {
-    evmproviders?: Record<string, WindowProvider>;
-    avalanche?: WindowProvider;
-  }
-}
 
 export interface CoreWalletOptions {
   projectId: string;
@@ -21,42 +16,15 @@ export interface CoreWalletOptions {
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
-function getCoreWalletInjectedProvider(): WindowProvider | undefined {
-  const injectedProviderExist =
-    typeof window !== 'undefined' && typeof window.ethereum !== 'undefined';
-
-  // No injected providers exist.
-  if (!injectedProviderExist) {
-    return;
-  }
-
-  // Core implements EIP-5749 and creates the window.evmproviders
-  if (window['evmproviders']?.['core']) {
-    return window['evmproviders']?.['core'];
-  }
-
-  // Core was injected into window.avalanche.
-  if (window.avalanche) {
-    return window.avalanche;
-  }
-
-  // Core was injected into window.ethereum.
-  if (
-    typeof window !== 'undefined' &&
-    typeof window.ethereum !== 'undefined' &&
-    window.ethereum.isAvalanche === true
-  ) {
-    return window.ethereum;
-  }
-}
-
 export const coreWallet = ({
   chains,
   projectId,
   walletConnectOptions,
 }: CoreWalletOptions): Wallet => {
-  const isCoreInjected = Boolean(getCoreWalletInjectedProvider());
-
+  const isCoreInjected = hasInjectedProvider({
+    namespace: 'avalanche',
+    flag: 'isAvalanche',
+  });
   const shouldUseWalletConnect = !isCoreInjected;
   return {
     id: 'core',
@@ -80,11 +48,10 @@ export const coreWallet = ({
             chains,
             options: walletConnectOptions,
           })
-        : new InjectedConnector({
+        : getInjectedConnector({
             chains,
-            options: {
-              getProvider: getCoreWalletInjectedProvider,
-            },
+            namespace: 'avalanche',
+            flag: 'isAvalanche',
           });
       const getUri = async () => {
         const uri = await getWalletConnectUri(connector);

--- a/packages/rainbowkit/src/wallets/walletConnectors/coreWallet/coreWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coreWallet/coreWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { WindowProvider } from 'wagmi/dist/window';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
@@ -55,8 +54,7 @@ export const coreWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  ...options
-}: CoreWalletOptions & InjectedConnectorOptions): Wallet => {
+}: CoreWalletOptions): Wallet => {
   const isCoreInjected = Boolean(getCoreWalletInjectedProvider());
 
   const shouldUseWalletConnect = !isCoreInjected;
@@ -86,7 +84,6 @@ export const coreWallet = ({
             chains,
             options: {
               getProvider: getCoreWalletInjectedProvider,
-              ...options,
             },
           });
       const getUri = async () => {

--- a/packages/rainbowkit/src/wallets/walletConnectors/dawnWallet/dawnWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/dawnWallet/dawnWallet.ts
@@ -1,7 +1,10 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { isIOS } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface DawnWalletOptions {
   chains: Chain[];
@@ -12,18 +15,13 @@ export const dawnWallet = ({ chains }: DawnWalletOptions): Wallet => ({
   name: 'Dawn',
   iconUrl: async () => (await import('./dawnWallet.svg')).default,
   iconBackground: '#000000',
-  installed:
-    typeof window !== 'undefined' &&
-    typeof window.ethereum !== 'undefined' &&
-    window.ethereum.isDawn,
+  installed: hasInjectedProvider('isDawn'),
   hidden: () => !isIOS(),
   downloadUrls: {
     ios: 'https://apps.apple.com/us/app/dawn-ethereum-wallet/id1673143782',
     mobile: 'https://dawnwallet.xyz',
   },
   createConnector: () => ({
-    connector: new InjectedConnector({
-      chains,
-    }),
+    connector: getInjectedConnector({ chains, flag: 'isDawn' }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/dawnWallet/dawnWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/dawnWallet/dawnWallet.ts
@@ -15,7 +15,7 @@ export const dawnWallet = ({ chains }: DawnWalletOptions): Wallet => ({
   name: 'Dawn',
   iconUrl: async () => (await import('./dawnWallet.svg')).default,
   iconBackground: '#000000',
-  installed: hasInjectedProvider('isDawn'),
+  installed: hasInjectedProvider({ flag: 'isDawn' }),
   hidden: () => !isIOS(),
   downloadUrls: {
     ios: 'https://apps.apple.com/us/app/dawn-ethereum-wallet/id1673143782',

--- a/packages/rainbowkit/src/wallets/walletConnectors/dawnWallet/dawnWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/dawnWallet/dawnWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { isIOS } from '../../../utils/isMobile';
@@ -8,10 +7,7 @@ export interface DawnWalletOptions {
   chains: Chain[];
 }
 
-export const dawnWallet = ({
-  chains,
-  ...options
-}: DawnWalletOptions & InjectedConnectorOptions): Wallet => ({
+export const dawnWallet = ({ chains }: DawnWalletOptions): Wallet => ({
   id: 'dawn',
   name: 'Dawn',
   iconUrl: async () => (await import('./dawnWallet.svg')).default,
@@ -28,7 +24,6 @@ export const dawnWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options,
     }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/desigWallet/desigWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/desigWallet/desigWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -7,10 +6,7 @@ export interface DesigWalletOptions {
   chains: Chain[];
 }
 
-export const desigWallet = ({
-  chains,
-  ...options
-}: DesigWalletOptions & InjectedConnectorOptions): Wallet => {
+export const desigWallet = ({ chains }: DesigWalletOptions): Wallet => {
   return {
     id: 'desig',
     name: 'Desig Wallet',
@@ -36,7 +32,7 @@ export const desigWallet = ({
 
       const connector = new InjectedConnector({
         chains,
-        options: { getProvider, ...options },
+        options: { getProvider },
       });
 
       return {

--- a/packages/rainbowkit/src/wallets/walletConnectors/desigWallet/desigWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/desigWallet/desigWallet.ts
@@ -1,68 +1,62 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface DesigWalletOptions {
   chains: Chain[];
 }
 
-export const desigWallet = ({ chains }: DesigWalletOptions): Wallet => {
-  return {
-    id: 'desig',
-    name: 'Desig Wallet',
-    iconUrl: async () => (await import('./desigWallet.svg')).default,
-    iconBackground: '#ffffff',
-    installed:
-      (typeof window !== 'undefined' && !!(window as any)?.desig?.ethereum) ||
-      undefined,
-    downloadUrls: {
-      android: 'https://play.google.com/store/apps/details?id=io.desig.app',
-      ios: 'https://apps.apple.com/app/desig-wallet/id6450106028',
-      qrCode: 'https://desig.io',
-      mobile: 'https://desig.io',
-      browserExtension:
-        'https://chrome.google.com/webstore/detail/desig-wallet/panpgppehdchfphcigocleabcmcgfoca',
-    },
+export const desigWallet = ({ chains }: DesigWalletOptions): Wallet => ({
+  id: 'desig',
+  name: 'Desig Wallet',
+  iconUrl: async () => (await import('./desigWallet.svg')).default,
+  iconBackground: '#ffffff',
+  installed: hasInjectedProvider({ namespace: 'desig.ethereum' }),
+  downloadUrls: {
+    android: 'https://play.google.com/store/apps/details?id=io.desig.app',
+    ios: 'https://apps.apple.com/app/desig-wallet/id6450106028',
+    qrCode: 'https://desig.io',
+    mobile: 'https://desig.io',
+    browserExtension:
+      'https://chrome.google.com/webstore/detail/desig-wallet/panpgppehdchfphcigocleabcmcgfoca',
+  },
 
-    createConnector: () => {
-      const getProvider = () =>
-        typeof window !== 'undefined'
-          ? (window as any).desig?.ethereum
-          : undefined;
+  createConnector: () => {
+    const connector = getInjectedConnector({
+      chains,
+      namespace: 'desig.ethereum',
+    });
 
-      const connector = new InjectedConnector({
-        chains,
-        options: { getProvider },
-      });
-
-      return {
-        connector,
-        extension: {
-          instructions: {
-            steps: [
-              {
-                description:
-                  'wallet_connectors.desig.extension.step1.description',
-                step: 'install',
-                title: 'wallet_connectors.desig.extension.step1.title',
-              },
-              {
-                description:
-                  'wallet_connectors.desig.extension.step2.description',
-                step: 'create',
-                title: 'wallet_connectors.desig.extension.step2.title',
-              },
-              {
-                description:
-                  'wallet_connectors.desig.extension.step3.description',
-                step: 'refresh',
-                title: 'wallet_connectors.desig.extension.step3.title',
-              },
-            ],
-            learnMoreUrl: 'https://desig.io',
-          },
+    return {
+      connector,
+      extension: {
+        instructions: {
+          steps: [
+            {
+              description:
+                'wallet_connectors.desig.extension.step1.description',
+              step: 'install',
+              title: 'wallet_connectors.desig.extension.step1.title',
+            },
+            {
+              description:
+                'wallet_connectors.desig.extension.step2.description',
+              step: 'create',
+              title: 'wallet_connectors.desig.extension.step2.title',
+            },
+            {
+              description:
+                'wallet_connectors.desig.extension.step3.description',
+              step: 'refresh',
+              title: 'wallet_connectors.desig.extension.step3.title',
+            },
+          ],
+          learnMoreUrl: 'https://desig.io',
         },
-      };
-    },
-  };
-};
+      },
+    };
+  },
+});

--- a/packages/rainbowkit/src/wallets/walletConnectors/enkryptWallet/enkryptWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/enkryptWallet/enkryptWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import type { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import type { Wallet } from '../../Wallet';
@@ -17,10 +16,7 @@ export interface EnkryptWalletOptions {
   chains: Chain[];
 }
 
-export const enkryptWallet = ({
-  chains,
-  ...options
-}: EnkryptWalletOptions & InjectedConnectorOptions): Wallet => {
+export const enkryptWallet = ({ chains }: EnkryptWalletOptions): Wallet => {
   const isEnkryptInjected =
     typeof window !== 'undefined' &&
     typeof window.enkrypt !== 'undefined' &&
@@ -50,7 +46,6 @@ export const enkryptWallet = ({
               isEnkryptInjected
                 ? window?.enkrypt?.providers?.ethereum
                 : undefined,
-            ...options,
           },
         }),
         extension: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/enkryptWallet/enkryptWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/enkryptWallet/enkryptWallet.ts
@@ -1,79 +1,61 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import type { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import type { Wallet } from '../../Wallet';
-
-declare global {
-  interface Window {
-    enkrypt: {
-      providers: {
-        ethereum: any;
-      };
-    };
-  }
-}
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface EnkryptWalletOptions {
   chains: Chain[];
 }
 
-export const enkryptWallet = ({ chains }: EnkryptWalletOptions): Wallet => {
-  const isEnkryptInjected =
-    typeof window !== 'undefined' &&
-    typeof window.enkrypt !== 'undefined' &&
-    window?.enkrypt?.providers?.ethereum;
-  return {
-    id: 'enkrypt',
-    name: 'Enkrypt Wallet',
-    installed: isEnkryptInjected ? true : undefined,
-    iconUrl: async () => (await import('./enkryptWallet.svg')).default,
-    iconBackground: '#FFFFFF',
-    downloadUrls: {
-      qrCode: 'https://www.enkrypt.com',
-      chrome:
-        'https://chrome.google.com/webstore/detail/enkrypt-ethereum-polkadot/kkpllkodjeloidieedojogacfhpaihoh',
-      browserExtension: 'https://www.enkrypt.com/',
-      edge: 'https://microsoftedge.microsoft.com/addons/detail/enkrypt-ethereum-polkad/gfenajajnjjmmdojhdjmnngomkhlnfjl',
-      firefox: 'https://addons.mozilla.org/en-US/firefox/addon/enkrypt/',
-      opera: 'https://addons.opera.com/en/extensions/details/enkrypt/',
-      safari: 'https://apps.apple.com/app/enkrypt-web3-wallet/id1640164309',
-    },
-    createConnector: () => {
-      return {
-        connector: new InjectedConnector({
-          chains,
-          options: {
-            getProvider: () =>
-              isEnkryptInjected
-                ? window?.enkrypt?.providers?.ethereum
-                : undefined,
-          },
-        }),
-        extension: {
-          instructions: {
-            learnMoreUrl: 'https://blog.enkrypt.com/what-is-a-web3-wallet/',
-            steps: [
-              {
-                description:
-                  'wallet_connectors.enkrypt.extension.step1.description',
-                step: 'install',
-                title: 'wallet_connectors.enkrypt.extension.step1.title',
-              },
-              {
-                description:
-                  'wallet_connectors.enkrypt.extension.step2.description',
-                step: 'create',
-                title: 'wallet_connectors.enkrypt.extension.step2.title',
-              },
-              {
-                description:
-                  'wallet_connectors.enkrypt.extension.step3.description',
-                step: 'refresh',
-                title: 'wallet_connectors.enkrypt.extension.step3.title',
-              },
-            ],
-          },
+export const enkryptWallet = ({ chains }: EnkryptWalletOptions): Wallet => ({
+  id: 'enkrypt',
+  name: 'Enkrypt Wallet',
+  installed: hasInjectedProvider({ namespace: 'enkrypt.providers.ethereum' }),
+  iconUrl: async () => (await import('./enkryptWallet.svg')).default,
+  iconBackground: '#FFFFFF',
+  downloadUrls: {
+    qrCode: 'https://www.enkrypt.com',
+    chrome:
+      'https://chrome.google.com/webstore/detail/enkrypt-ethereum-polkadot/kkpllkodjeloidieedojogacfhpaihoh',
+    browserExtension: 'https://www.enkrypt.com/',
+    edge: 'https://microsoftedge.microsoft.com/addons/detail/enkrypt-ethereum-polkad/gfenajajnjjmmdojhdjmnngomkhlnfjl',
+    firefox: 'https://addons.mozilla.org/en-US/firefox/addon/enkrypt/',
+    opera: 'https://addons.opera.com/en/extensions/details/enkrypt/',
+    safari: 'https://apps.apple.com/app/enkrypt-web3-wallet/id1640164309',
+  },
+  createConnector: () => {
+    return {
+      connector: getInjectedConnector({
+        chains,
+        namespace: 'enkrypt.providers.ethereum',
+      }),
+      extension: {
+        instructions: {
+          learnMoreUrl: 'https://blog.enkrypt.com/what-is-a-web3-wallet/',
+          steps: [
+            {
+              description:
+                'wallet_connectors.enkrypt.extension.step1.description',
+              step: 'install',
+              title: 'wallet_connectors.enkrypt.extension.step1.title',
+            },
+            {
+              description:
+                'wallet_connectors.enkrypt.extension.step2.description',
+              step: 'create',
+              title: 'wallet_connectors.enkrypt.extension.step2.title',
+            },
+            {
+              description:
+                'wallet_connectors.enkrypt.extension.step3.description',
+              step: 'refresh',
+              title: 'wallet_connectors.enkrypt.extension.step3.title',
+            },
+          ],
         },
-      };
-    },
-  };
-};
+      },
+    };
+  },
+});

--- a/packages/rainbowkit/src/wallets/walletConnectors/foxWallet/foxWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/foxWallet/foxWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
@@ -16,8 +15,7 @@ export const foxWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  ...options
-}: FoxWalletOptions & InjectedConnectorOptions): Wallet => {
+}: FoxWalletOptions): Wallet => {
   const isFoxInjected =
     typeof window !== 'undefined' &&
     // @ts-expect-error
@@ -48,7 +46,6 @@ export const foxWallet = ({
             options: {
               // @ts-expect-error
               getProvider: () => window.foxwallet.ethereum,
-              ...options,
             },
           });
 

--- a/packages/rainbowkit/src/wallets/walletConnectors/foxWallet/foxWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/foxWallet/foxWallet.ts
@@ -1,7 +1,10 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
@@ -16,11 +19,9 @@ export const foxWallet = ({
   projectId,
   walletConnectOptions,
 }: FoxWalletOptions): Wallet => {
-  const isFoxInjected =
-    typeof window !== 'undefined' &&
-    // @ts-expect-error
-    typeof window.foxwallet !== 'undefined';
-
+  const isFoxInjected = hasInjectedProvider({
+    namespace: 'foxwallet.ethereum',
+  });
   const shouldUseWalletConnect = !isFoxInjected;
 
   return {
@@ -41,13 +42,7 @@ export const foxWallet = ({
             chains,
             options: walletConnectOptions,
           })
-        : new InjectedConnector({
-            chains,
-            options: {
-              // @ts-expect-error
-              getProvider: () => window.foxwallet.ethereum,
-            },
-          });
+        : getInjectedConnector({ chains, namespace: 'foxwallet.ethereum' });
 
       return {
         connector,

--- a/packages/rainbowkit/src/wallets/walletConnectors/frameWallet/frameWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/frameWallet/frameWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -7,10 +6,7 @@ export interface FrameWalletOptions {
   chains: Chain[];
 }
 
-export const frameWallet = ({
-  chains,
-  ...options
-}: FrameWalletOptions & InjectedConnectorOptions): Wallet => ({
+export const frameWallet = ({ chains }: FrameWalletOptions): Wallet => ({
   id: 'frame',
   name: 'Frame',
   installed:
@@ -26,7 +22,6 @@ export const frameWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options,
     }),
     extension: {
       instructions: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/frameWallet/frameWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/frameWallet/frameWallet.ts
@@ -1,6 +1,9 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface FrameWalletOptions {
   chains: Chain[];
@@ -9,20 +12,14 @@ export interface FrameWalletOptions {
 export const frameWallet = ({ chains }: FrameWalletOptions): Wallet => ({
   id: 'frame',
   name: 'Frame',
-  installed:
-    typeof window !== 'undefined' &&
-    typeof window.ethereum !== 'undefined' &&
-    ((window.ethereum as any).isFrame === true ||
-      !!window.ethereum.providers?.find((p: any) => p.isFrame === true)),
+  installed: hasInjectedProvider('isFrame'),
   iconUrl: async () => (await import('./frameWallet.svg')).default,
   iconBackground: '#121C20',
   downloadUrls: {
     browserExtension: 'https://frame.sh/',
   },
   createConnector: () => ({
-    connector: new InjectedConnector({
-      chains,
-    }),
+    connector: getInjectedConnector({ chains, flag: 'isFrame' }),
     extension: {
       instructions: {
         learnMoreUrl:

--- a/packages/rainbowkit/src/wallets/walletConnectors/frameWallet/frameWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/frameWallet/frameWallet.ts
@@ -12,7 +12,7 @@ export interface FrameWalletOptions {
 export const frameWallet = ({ chains }: FrameWalletOptions): Wallet => ({
   id: 'frame',
   name: 'Frame',
-  installed: hasInjectedProvider('isFrame'),
+  installed: hasInjectedProvider({ flag: 'isFrame' }),
   iconUrl: async () => (await import('./frameWallet.svg')).default,
   iconBackground: '#121C20',
   downloadUrls: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/frontierWallet/frontierWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/frontierWallet/frontierWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import type { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
@@ -23,8 +22,7 @@ export const frontierWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  ...options
-}: FrontierWalletOptions & InjectedConnectorOptions): Wallet => {
+}: FrontierWalletOptions): Wallet => {
   const isFrontierInjected =
     typeof window !== 'undefined' &&
     typeof window.frontier !== 'undefined' &&
@@ -74,7 +72,6 @@ export const frontierWallet = ({
               if (typeof window === 'undefined') return;
               return getFront(window.frontier);
             },
-            ...options,
           },
         }),
         mobile: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/frontierWallet/frontierWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/frontierWallet/frontierWallet.ts
@@ -55,7 +55,7 @@ export const frontierWallet = ({
             projectId,
             options: walletConnectOptions,
           })
-        : new InjectedConnector({ chains });
+        : undefined;
       const getUri = async () => {
         const uri = await getWalletConnectUri(connector);
         return isAndroid()

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -1,5 +1,4 @@
-import type { MetaMaskConnectorOptions } from '@wagmi/core/connectors/metaMask';
-import { MetaMaskConnector } from 'wagmi/connectors/metaMask';
+import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isAndroid, isIOS } from '../../../utils/isMobile';
@@ -63,8 +62,7 @@ export const metaMaskWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  ...options
-}: MetaMaskWalletOptions & MetaMaskConnectorOptions): Wallet => {
+}: MetaMaskWalletOptions): Wallet => {
   const providers = typeof window !== 'undefined' && window.ethereum?.providers;
 
   // Not using the explicit isMetaMask fn to check for MetaMask
@@ -104,7 +102,7 @@ export const metaMaskWallet = ({
             chains,
             options: walletConnectOptions,
           })
-        : new MetaMaskConnector({
+        : new InjectedConnector({
             chains,
             options: {
               getProvider: () =>
@@ -113,7 +111,6 @@ export const metaMaskWallet = ({
                   : typeof window !== 'undefined'
                     ? window.ethereum
                     : undefined,
-              ...options,
             },
           });
 

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -104,11 +104,10 @@ export const metaMaskWallet = ({
             chains,
             // custom handling for metamask button fallback for third party wallets
             getProvider: () =>
-              typeof window !== 'undefined' && window.ethereum?.providers
-                ? window.ethereum.providers.find(isMetaMask)
-                : typeof window !== 'undefined'
-                  ? window.ethereum
-                  : undefined,
+              typeof window !== 'undefined'
+                ? window.ethereum?.providers?.find(isMetaMask) ??
+                  window.ethereum
+                : undefined,
           });
 
       const getUri = async () => {

--- a/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -6,10 +5,7 @@ export interface MewWalletOptions {
   chains: Chain[];
 }
 
-export const mewWallet = ({
-  chains,
-  ...options
-}: MewWalletOptions & InjectedConnectorOptions): Wallet => {
+export const mewWallet = ({ chains }: MewWalletOptions): Wallet => {
   const isMewWalletInjected =
     typeof window !== 'undefined' &&
     Boolean(
@@ -35,7 +31,6 @@ export const mewWallet = ({
       return {
         connector: new InjectedConnector({
           chains,
-          options,
         }),
       };
     },

--- a/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
@@ -1,25 +1,22 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
+
 export interface MewWalletOptions {
   chains: Chain[];
 }
 
 export const mewWallet = ({ chains }: MewWalletOptions): Wallet => {
-  const isMewWalletInjected =
-    typeof window !== 'undefined' &&
-    Boolean(
-      (
-        window.ethereum as typeof window.ethereum &
-          (undefined | { isMEWwallet?: boolean })
-      )?.isMEWwallet,
-    );
   return {
     id: 'mew',
     name: 'MEW wallet',
     iconUrl: async () => (await import('./mewWallet.svg')).default,
     iconBackground: '#fff',
-    installed: isMewWalletInjected,
+    // @ts-ignore - `isMEWwallet` needs to be added to Wagmi
+    installed: hasInjectedProvider('isMEWwallet'),
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.myetherwallet.mewwallet&referrer=utm_source%3Drainbow',
@@ -29,9 +26,8 @@ export const mewWallet = ({ chains }: MewWalletOptions): Wallet => {
     },
     createConnector: () => {
       return {
-        connector: new InjectedConnector({
-          chains,
-        }),
+        // @ts-ignore - `isMEWwallet` needs to be added to Wagmi
+        connector: getInjectedConnector({ chains, flag: 'isMEWwallet' }),
       };
     },
   };

--- a/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
@@ -15,8 +15,7 @@ export const mewWallet = ({ chains }: MewWalletOptions): Wallet => {
     name: 'MEW wallet',
     iconUrl: async () => (await import('./mewWallet.svg')).default,
     iconBackground: '#fff',
-    // @ts-ignore - `isMEWwallet` needs to be added to Wagmi
-    installed: hasInjectedProvider('isMEWwallet'),
+    installed: hasInjectedProvider({ flag: 'isMEWwallet' }),
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.myetherwallet.mewwallet&referrer=utm_source%3Drainbow',
@@ -26,7 +25,6 @@ export const mewWallet = ({ chains }: MewWalletOptions): Wallet => {
     },
     createConnector: () => {
       return {
-        // @ts-ignore - `isMEWwallet` needs to be added to Wagmi
         connector: getInjectedConnector({ chains, flag: 'isMEWwallet' }),
       };
     },

--- a/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
@@ -1,8 +1,11 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isAndroid } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
@@ -17,12 +20,7 @@ export const okxWallet = ({
   projectId,
   walletConnectOptions,
 }: OKXWalletOptions): Wallet => {
-  // `isOkxWallet` or `isOKExWallet` needs to be added to the wagmi `Ethereum` object
-  const isOKXInjected =
-    typeof window !== 'undefined' &&
-    // @ts-expect-error
-    typeof window.okxwallet !== 'undefined';
-
+  const isOKXInjected = hasInjectedProvider({ namespace: 'okxwallet' });
   const shouldUseWalletConnect = !isOKXInjected;
 
   return {
@@ -50,13 +48,7 @@ export const okxWallet = ({
             chains,
             options: walletConnectOptions,
           })
-        : new InjectedConnector({
-            chains,
-            options: {
-              // @ts-expect-error
-              getProvider: () => window.okxwallet,
-            },
-          });
+        : getInjectedConnector({ chains, namespace: 'okxwallet' });
 
       return {
         connector,

--- a/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
@@ -17,8 +16,7 @@ export const okxWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  ...options
-}: OKXWalletOptions & InjectedConnectorOptions): Wallet => {
+}: OKXWalletOptions): Wallet => {
   // `isOkxWallet` or `isOKExWallet` needs to be added to the wagmi `Ethereum` object
   const isOKXInjected =
     typeof window !== 'undefined' &&
@@ -57,7 +55,6 @@ export const okxWallet = ({
             options: {
               // @ts-expect-error
               getProvider: () => window.okxwallet,
-              ...options,
             },
           });
 

--- a/packages/rainbowkit/src/wallets/walletConnectors/oneKeyWallet/oneKeyWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/oneKeyWallet/oneKeyWallet.ts
@@ -1,76 +1,64 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface OnekeyWalletOptions {
   chains: Chain[];
 }
 
-declare global {
-  interface Window {
-    $onekey: any;
-  }
-}
-
-export const oneKeyWallet = ({ chains }: OnekeyWalletOptions): Wallet => {
-  const provider = typeof window !== 'undefined' && window['$onekey']?.ethereum;
-  const isOnekeyInjected = Boolean(provider);
-
-  return {
-    createConnector: () => {
-      const connector = new InjectedConnector({
+export const oneKeyWallet = ({ chains }: OnekeyWalletOptions): Wallet => ({
+  id: 'onekey',
+  name: 'OneKey',
+  iconUrl: async () => (await import('./oneKeyWallet.svg')).default,
+  iconAccent: '#00B812',
+  iconBackground: '#fff',
+  installed: hasInjectedProvider({ namespace: '$onekey.ethereum' }),
+  downloadUrls: {
+    android:
+      'https://play.google.com/store/apps/details?id=so.onekey.app.wallet',
+    browserExtension: 'https://www.onekey.so/download/',
+    chrome:
+      'https://chrome.google.com/webstore/detail/onekey/jnmbobjmhlngoefaiojfljckilhhlhcj',
+    edge: 'https://microsoftedge.microsoft.com/addons/detail/onekey/obffkkagpmohennipjokmpllocnlndac',
+    ios: 'https://apps.apple.com/us/app/onekey-open-source-wallet/id1609559473',
+    mobile: 'https://www.onekey.so/download/',
+    qrCode: 'https://www.onekey.so/download/',
+  },
+  createConnector: () => {
+    return {
+      connector: getInjectedConnector({
         chains,
-        options: {
-          getProvider: () => provider,
+        namespace: '$onekey.ethereum',
+      }),
+      extension: {
+        instructions: {
+          learnMoreUrl:
+            'https://help.onekey.so/hc/en-us/categories/360000170236',
+          steps: [
+            {
+              description:
+                'wallet_connectors.one_key.extension.step1.description',
+              step: 'install',
+              title: 'wallet_connectors.one_key.extension.step1.title',
+            },
+            {
+              description:
+                'wallet_connectors.one_key.extension.step2.description',
+              step: 'create',
+              title: 'wallet_connectors.one_key.extension.step2.title',
+            },
+            {
+              description:
+                'wallet_connectors.one_key.extension.step3.description',
+              step: 'refresh',
+              title: 'wallet_connectors.one_key.extension.step3.title',
+            },
+          ],
         },
-      });
-
-      return {
-        connector,
-        extension: {
-          instructions: {
-            learnMoreUrl:
-              'https://help.onekey.so/hc/en-us/categories/360000170236',
-            steps: [
-              {
-                description:
-                  'wallet_connectors.one_key.extension.step1.description',
-                step: 'install',
-                title: 'wallet_connectors.one_key.extension.step1.title',
-              },
-              {
-                description:
-                  'wallet_connectors.one_key.extension.step2.description',
-                step: 'create',
-                title: 'wallet_connectors.one_key.extension.step2.title',
-              },
-              {
-                description:
-                  'wallet_connectors.one_key.extension.step3.description',
-                step: 'refresh',
-                title: 'wallet_connectors.one_key.extension.step3.title',
-              },
-            ],
-          },
-        },
-      };
-    },
-    downloadUrls: {
-      android:
-        'https://play.google.com/store/apps/details?id=so.onekey.app.wallet',
-      browserExtension: 'https://www.onekey.so/download/',
-      chrome:
-        'https://chrome.google.com/webstore/detail/onekey/jnmbobjmhlngoefaiojfljckilhhlhcj',
-      edge: 'https://microsoftedge.microsoft.com/addons/detail/onekey/obffkkagpmohennipjokmpllocnlndac',
-      ios: 'https://apps.apple.com/us/app/onekey-open-source-wallet/id1609559473',
-      mobile: 'https://www.onekey.so/download/',
-      qrCode: 'https://www.onekey.so/download/',
-    },
-    iconAccent: '#00B812',
-    iconBackground: '#fff',
-    iconUrl: async () => (await import('./oneKeyWallet.svg')).default,
-    id: 'onekey',
-    installed: isOnekeyInjected,
-    name: 'OneKey',
-  };
-};
+      },
+    };
+  },
+});

--- a/packages/rainbowkit/src/wallets/walletConnectors/phantomWallet/phantomWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/phantomWallet/phantomWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -7,10 +6,7 @@ export interface PhantomWalletOptions {
   chains: Chain[];
 }
 
-export const phantomWallet = ({
-  chains,
-  ...options
-}: PhantomWalletOptions & InjectedConnectorOptions): Wallet => {
+export const phantomWallet = ({ chains }: PhantomWalletOptions): Wallet => {
   return {
     id: 'phantom',
     name: 'Phantom',
@@ -38,7 +34,7 @@ export const phantomWallet = ({
 
       const connector = new InjectedConnector({
         chains,
-        options: { getProvider, ...options },
+        options: { getProvider },
       });
 
       return {

--- a/packages/rainbowkit/src/wallets/walletConnectors/phantomWallet/phantomWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/phantomWallet/phantomWallet.ts
@@ -1,70 +1,63 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface PhantomWalletOptions {
   chains: Chain[];
 }
 
-export const phantomWallet = ({ chains }: PhantomWalletOptions): Wallet => {
-  return {
-    id: 'phantom',
-    name: 'Phantom',
-    iconUrl: async () => (await import('./phantomWallet.svg')).default,
-    iconBackground: '#9A8AEE',
-    installed:
-      (typeof window !== 'undefined' &&
-        !!((window as any).phantom as any)?.ethereum) ||
-      undefined,
-    downloadUrls: {
-      android: 'https://play.google.com/store/apps/details?id=app.phantom',
-      ios: 'https://apps.apple.com/app/phantom-solana-wallet/1598432977',
-      mobile: 'https://phantom.app/download',
-      qrCode: 'https://phantom.app/download',
-      chrome:
-        'https://chrome.google.com/webstore/detail/phantom/bfnaelmomeimhlpmgjnjophhpkkoljpa',
-      firefox: 'https://addons.mozilla.org/firefox/addon/phantom-app/',
-      browserExtension: 'https://phantom.app/download',
-    },
-    createConnector: () => {
-      const getProvider = () =>
-        typeof window !== 'undefined'
-          ? ((window as any).phantom as any)?.ethereum
-          : undefined;
+export const phantomWallet = ({ chains }: PhantomWalletOptions): Wallet => ({
+  id: 'phantom',
+  name: 'Phantom',
+  iconUrl: async () => (await import('./phantomWallet.svg')).default,
+  iconBackground: '#9A8AEE',
+  installed: hasInjectedProvider({ namespace: 'phantom.ethereum' }),
+  downloadUrls: {
+    android: 'https://play.google.com/store/apps/details?id=app.phantom',
+    ios: 'https://apps.apple.com/app/phantom-solana-wallet/1598432977',
+    mobile: 'https://phantom.app/download',
+    qrCode: 'https://phantom.app/download',
+    chrome:
+      'https://chrome.google.com/webstore/detail/phantom/bfnaelmomeimhlpmgjnjophhpkkoljpa',
+    firefox: 'https://addons.mozilla.org/firefox/addon/phantom-app/',
+    browserExtension: 'https://phantom.app/download',
+  },
+  createConnector: () => {
+    const connector = getInjectedConnector({
+      chains,
+      namespace: 'phantom.ethereum',
+    });
 
-      const connector = new InjectedConnector({
-        chains,
-        options: { getProvider },
-      });
-
-      return {
-        connector,
-        extension: {
-          instructions: {
-            steps: [
-              {
-                description:
-                  'wallet_connectors.phantom.extension.step1.description',
-                step: 'install',
-                title: 'wallet_connectors.phantom.extension.step1.title',
-              },
-              {
-                description:
-                  'wallet_connectors.phantom.extension.step2.description',
-                step: 'create',
-                title: 'wallet_connectors.phantom.extension.step2.title',
-              },
-              {
-                description:
-                  'wallet_connectors.phantom.extension.step3.description',
-                step: 'refresh',
-                title: 'wallet_connectors.phantom.extension.step3.title',
-              },
-            ],
-            learnMoreUrl: 'https://help.phantom.app',
-          },
+    return {
+      connector,
+      extension: {
+        instructions: {
+          steps: [
+            {
+              description:
+                'wallet_connectors.phantom.extension.step1.description',
+              step: 'install',
+              title: 'wallet_connectors.phantom.extension.step1.title',
+            },
+            {
+              description:
+                'wallet_connectors.phantom.extension.step2.description',
+              step: 'create',
+              title: 'wallet_connectors.phantom.extension.step2.title',
+            },
+            {
+              description:
+                'wallet_connectors.phantom.extension.step3.description',
+              step: 'refresh',
+              title: 'wallet_connectors.phantom.extension.step3.title',
+            },
+          ],
+          learnMoreUrl: 'https://help.phantom.app',
         },
-      };
-    },
-  };
-};
+      },
+    };
+  },
+});

--- a/packages/rainbowkit/src/wallets/walletConnectors/rabbyWallet/rabbyWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rabbyWallet/rabbyWallet.ts
@@ -14,7 +14,7 @@ export const rabbyWallet = ({ chains }: RabbyWalletOptions): Wallet => ({
   name: 'Rabby Wallet',
   iconUrl: async () => (await import('./rabbyWallet.svg')).default,
   iconBackground: '#8697FF',
-  installed: hasInjectedProvider('isRabby'),
+  installed: hasInjectedProvider({ flag: 'isRabby' }),
   downloadUrls: {
     chrome:
       'https://chrome.google.com/webstore/detail/rabby-wallet/acmacodkjbdgmoleebolmdjonilkdbch',

--- a/packages/rainbowkit/src/wallets/walletConnectors/rabbyWallet/rabbyWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rabbyWallet/rabbyWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -7,10 +6,7 @@ export interface RabbyWalletOptions {
   chains: Chain[];
 }
 
-export const rabbyWallet = ({
-  chains,
-  ...options
-}: RabbyWalletOptions & InjectedConnectorOptions): Wallet => ({
+export const rabbyWallet = ({ chains }: RabbyWalletOptions): Wallet => ({
   id: 'rabby',
   name: 'Rabby Wallet',
   iconUrl: async () => (await import('./rabbyWallet.svg')).default,
@@ -27,7 +23,6 @@ export const rabbyWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options,
     }),
     extension: {
       instructions: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/rabbyWallet/rabbyWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rabbyWallet/rabbyWallet.ts
@@ -1,6 +1,9 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface RabbyWalletOptions {
   chains: Chain[];
@@ -11,19 +14,14 @@ export const rabbyWallet = ({ chains }: RabbyWalletOptions): Wallet => ({
   name: 'Rabby Wallet',
   iconUrl: async () => (await import('./rabbyWallet.svg')).default,
   iconBackground: '#8697FF',
-  installed:
-    typeof window !== 'undefined' &&
-    typeof window.ethereum !== 'undefined' &&
-    window.ethereum.isRabby === true,
+  installed: hasInjectedProvider('isRabby'),
   downloadUrls: {
     chrome:
       'https://chrome.google.com/webstore/detail/rabby-wallet/acmacodkjbdgmoleebolmdjonilkdbch',
     browserExtension: 'https://rabby.io',
   },
   createConnector: () => ({
-    connector: new InjectedConnector({
-      chains,
-    }),
+    connector: getInjectedConnector({ chains, flag: 'isRabby' }),
     extension: {
       instructions: {
         learnMoreUrl: 'https://rabby.io/',

--- a/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
@@ -20,7 +20,7 @@ export const rainbowWallet = ({
   projectId,
   walletConnectOptions,
 }: RainbowWalletOptions): Wallet => {
-  const isRainbowInjected = hasInjectedProvider('isRainbow');
+  const isRainbowInjected = hasInjectedProvider({ flag: 'isRainbow' });
   const shouldUseWalletConnect = !isRainbowInjected;
   return {
     id: 'rainbow',

--- a/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isAndroid, isIOS } from '../../../utils/isMobile';
@@ -20,8 +19,7 @@ export const rainbowWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  ...options
-}: RainbowWalletOptions & InjectedConnectorOptions): Wallet => {
+}: RainbowWalletOptions): Wallet => {
   const isRainbowInjected = hasInjectedProvider('isRainbow');
   const shouldUseWalletConnect = !isRainbowInjected;
   return {
@@ -46,7 +44,7 @@ export const rainbowWallet = ({
             chains,
             options: walletConnectOptions,
           })
-        : getInjectedConnector({ flag: 'isRainbow', chains, options });
+        : getInjectedConnector({ flag: 'isRainbow', chains });
 
       const getUri = async () => {
         const uri = await getWalletConnectUri(connector);

--- a/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
@@ -15,7 +15,6 @@ export interface SafeWalletOptions {
  */
 export const safeWallet = ({
   chains,
-  ...options
 }: SafeWalletOptions & SafeConnectorOptions): Wallet => ({
   id: 'safe',
   name: 'Safe',
@@ -32,6 +31,6 @@ export const safeWallet = ({
     // since it's unlikely to be a desired behavior for users.
   },
   createConnector: () => ({
-    connector: new SafeConnector({ chains, options }),
+    connector: new SafeConnector({ chains }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/safeheronWallet/safeheronWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safeheronWallet/safeheronWallet.ts
@@ -1,15 +1,12 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface SafeheronWalletOptions {
   chains: Chain[];
-}
-
-declare global {
-  interface Window {
-    safeheron: any;
-  }
 }
 
 export const safeheronWallet = ({
@@ -17,11 +14,10 @@ export const safeheronWallet = ({
 }: SafeheronWalletOptions): Wallet => ({
   id: 'safeheron',
   name: 'Safeheron',
-  installed:
-    typeof window !== 'undefined' &&
-    typeof window.safeheron !== 'undefined' &&
-    // @ts-ignore
-    window.safeheron.isSafeheron === true,
+  installed: hasInjectedProvider({
+    namespace: 'safeheron',
+    flag: 'isSafeheron',
+  }),
   iconUrl: async () => (await import('./safeheronWallet.svg')).default,
   iconBackground: '#fff',
   downloadUrls: {
@@ -30,12 +26,10 @@ export const safeheronWallet = ({
     browserExtension: 'https://www.safeheron.com/',
   },
   createConnector: () => ({
-    connector: new InjectedConnector({
+    connector: getInjectedConnector({
       chains,
-      options: {
-        getProvider: () =>
-          typeof window !== 'undefined' ? window.safeheron : undefined,
-      },
+      namespace: 'safeheron',
+      flag: 'isSafeheron',
     }),
     extension: {
       instructions: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/safeheronWallet/safeheronWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safeheronWallet/safeheronWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -15,8 +14,7 @@ declare global {
 
 export const safeheronWallet = ({
   chains,
-  ...options
-}: SafeheronWalletOptions & InjectedConnectorOptions): Wallet => ({
+}: SafeheronWalletOptions): Wallet => ({
   id: 'safeheron',
   name: 'Safeheron',
   installed:
@@ -37,7 +35,6 @@ export const safeheronWallet = ({
       options: {
         getProvider: () =>
           typeof window !== 'undefined' ? window.safeheron : undefined,
-        ...options,
       },
     }),
     extension: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/safepalWallet/safepalWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safepalWallet/safepalWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
@@ -62,8 +61,7 @@ export const safepalWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  ...options
-}: SafepalWalletOptions & InjectedConnectorOptions): Wallet => {
+}: SafepalWalletOptions): Wallet => {
   const isSafePalWalletInjected = Boolean(getSafepalWalletInjectedProvider());
   const shouldUseWalletConnect = !isSafePalWalletInjected;
 
@@ -110,7 +108,6 @@ export const safepalWallet = ({
             chains,
             options: {
               getProvider: getSafepalWalletInjectedProvider,
-              ...options,
             },
           });
 

--- a/packages/rainbowkit/src/wallets/walletConnectors/safepalWallet/safepalWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safepalWallet/safepalWallet.ts
@@ -1,15 +1,12 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { InstructionStepName, Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
-
-declare global {
-  interface Window {
-    safepalProvider: Window['ethereum'];
-  }
-}
 
 export interface SafepalWalletOptions {
   projectId: string;
@@ -17,52 +14,15 @@ export interface SafepalWalletOptions {
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
-function getSafepalWalletInjectedProvider(): Window['ethereum'] {
-  const isSafePalWallet = (ethereum: NonNullable<Window['ethereum']> | any) => {
-    // Identify if SafePal Wallet injected provider is present.
-    const safepalWallet = !!ethereum.isSafePal;
-
-    return safepalWallet;
-  };
-
-  const injectedProviderExist =
-    typeof window !== 'undefined' && typeof window.ethereum !== 'undefined';
-
-  // No injected providers exist.
-  if (!injectedProviderExist) {
-    return;
-  }
-
-  // SafePal Wallet injected provider is available in the global scope.
-  // There are cases that some cases injected providers can replace window.ethereum
-  // without updating the ethereum.providers array. To prevent issues where
-  // the TW connector does not recognize the provider when TW extension is installed,
-  // we begin our checks by relying on TW's global object.
-  if (window['safepalProvider']) {
-    return window['safepalProvider'];
-  }
-
-  // SafePal Wallet was injected into window.ethereum.
-  if (isSafePalWallet(window.ethereum!)) {
-    return window.ethereum;
-  }
-
-  // SafePal Wallet provider might be replaced by another
-  // injected provider, check the providers array.
-  if (window.ethereum?.providers) {
-    // ethereum.providers array is a non-standard way to
-    // preserve multiple injected providers. Eventually, EIP-5749
-    // will become a living standard and we will have to update this.
-    return window.ethereum.providers.find(isSafePalWallet);
-  }
-}
-
 export const safepalWallet = ({
   chains,
   projectId,
   walletConnectOptions,
 }: SafepalWalletOptions): Wallet => {
-  const isSafePalWalletInjected = Boolean(getSafepalWalletInjectedProvider());
+  const isSafePalWalletInjected = hasInjectedProvider({
+    namespace: 'safepalProvider',
+    flag: 'isSafePal',
+  });
   const shouldUseWalletConnect = !isSafePalWalletInjected;
 
   return {
@@ -104,11 +64,10 @@ export const safepalWallet = ({
             chains,
             options: walletConnectOptions,
           })
-        : new InjectedConnector({
+        : getInjectedConnector({
             chains,
-            options: {
-              getProvider: getSafepalWalletInjectedProvider,
-            },
+            namespace: 'safepalProvider',
+            flag: 'isSafePal',
           });
 
       const mobileConnector = {

--- a/packages/rainbowkit/src/wallets/walletConnectors/subWallet/subWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/subWallet/subWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
@@ -29,8 +28,7 @@ export const subWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  ...options
-}: SubWalletOptions & InjectedConnectorOptions): Wallet => {
+}: SubWalletOptions): Wallet => {
   const isSubWalletInjected = Boolean(getSubWalletInjectedProvider());
   const shouldUseWalletConnect = !isSubWalletInjected;
 
@@ -63,7 +61,6 @@ export const subWallet = ({
             chains,
             options: {
               getProvider: getSubWalletInjectedProvider,
-              ...options,
             },
           });
 

--- a/packages/rainbowkit/src/wallets/walletConnectors/subWallet/subWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/subWallet/subWallet.ts
@@ -1,17 +1,14 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { InstructionStepName, Wallet } from '../../Wallet';
 import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
+import {
   WalletConnectConnectorOptions,
   getWalletConnectConnector,
 } from '../../getWalletConnectConnector';
-
-declare global {
-  interface Window {
-    SubWallet: Window['ethereum'];
-  }
-}
 
 export interface SubWalletOptions {
   projectId: string;
@@ -19,17 +16,12 @@ export interface SubWalletOptions {
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
-const getSubWalletInjectedProvider = (): Window['ethereum'] => {
-  if (typeof window === 'undefined') return;
-  return window.SubWallet;
-};
-
 export const subWallet = ({
   chains,
   projectId,
   walletConnectOptions,
 }: SubWalletOptions): Wallet => {
-  const isSubWalletInjected = Boolean(getSubWalletInjectedProvider());
+  const isSubWalletInjected = hasInjectedProvider({ namespace: 'SubWallet' });
   const shouldUseWalletConnect = !isSubWalletInjected;
 
   return {
@@ -57,12 +49,7 @@ export const subWallet = ({
             chains,
             options: walletConnectOptions,
           })
-        : new InjectedConnector({
-            chains,
-            options: {
-              getProvider: getSubWalletInjectedProvider,
-            },
-          });
+        : getInjectedConnector({ chains, namespace: 'SubWallet' });
 
       const getUriMobile = async () => {
         const uri = await getWalletConnectUri(connector);

--- a/packages/rainbowkit/src/wallets/walletConnectors/tahoWallet/tahoWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tahoWallet/tahoWallet.ts
@@ -1,15 +1,12 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface TahoWalletOptions {
   chains: Chain[];
-}
-
-declare global {
-  interface Window {
-    tally: any;
-  }
 }
 
 export const tahoWallet = ({ chains }: TahoWalletOptions): Wallet => ({
@@ -22,24 +19,13 @@ export const tahoWallet = ({ chains }: TahoWalletOptions): Wallet => ({
       'https://chrome.google.com/webstore/detail/taho/eajafomhmkipbjmfmhebemolkcicgfmd',
     browserExtension: 'https://taho.xyz',
   },
-  installed:
-    typeof window !== 'undefined' &&
-    typeof window.tally !== 'undefined' &&
-    window['tally']
-      ? true
-      : undefined,
+  installed: hasInjectedProvider({ namespace: 'tally', flag: 'isTally' }),
   createConnector: () => {
     return {
-      connector: new InjectedConnector({
+      connector: getInjectedConnector({
         chains,
-        options: {
-          getProvider: () => {
-            const getTaho = (tally?: any) =>
-              tally?.isTally ? tally : undefined;
-            if (typeof window === 'undefined') return;
-            return getTaho(window.tally);
-          },
-        },
+        namespace: 'tally',
+        flag: 'isTally',
       }),
       extension: {
         instructions: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/tahoWallet/tahoWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tahoWallet/tahoWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -13,10 +12,7 @@ declare global {
   }
 }
 
-export const tahoWallet = ({
-  chains,
-  ...options
-}: TahoWalletOptions & InjectedConnectorOptions): Wallet => ({
+export const tahoWallet = ({ chains }: TahoWalletOptions): Wallet => ({
   id: 'taho',
   name: 'Taho',
   iconBackground: '#d08d57',
@@ -43,7 +39,6 @@ export const tahoWallet = ({
             if (typeof window === 'undefined') return;
             return getTaho(window.tally);
           },
-          ...options,
         },
       }),
       extension: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/talismanWallet/talismanWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/talismanWallet/talismanWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -13,10 +12,7 @@ export interface TalismanWalletOptions {
   chains: Chain[];
 }
 
-export const talismanWallet = ({
-  chains,
-  ...options
-}: TalismanWalletOptions & InjectedConnectorOptions): Wallet => ({
+export const talismanWallet = ({ chains }: TalismanWalletOptions): Wallet => ({
   id: 'talisman',
   name: 'Talisman',
   iconUrl: async () => (await import('./talismanWallet.svg')).default,
@@ -40,7 +36,6 @@ export const talismanWallet = ({
           if (typeof window === 'undefined') return;
           return window.talismanEth;
         },
-        ...options,
       },
     }),
     extension: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/talismanWallet/talismanWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/talismanWallet/talismanWallet.ts
@@ -1,12 +1,9 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
-
-declare global {
-  interface Window {
-    talismanEth: Window['ethereum'];
-  }
-}
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface TalismanWalletOptions {
   chains: Chain[];
@@ -17,10 +14,10 @@ export const talismanWallet = ({ chains }: TalismanWalletOptions): Wallet => ({
   name: 'Talisman',
   iconUrl: async () => (await import('./talismanWallet.svg')).default,
   iconBackground: '#fff',
-  installed:
-    typeof window !== 'undefined' &&
-    typeof window.talismanEth !== 'undefined' &&
-    window.talismanEth.isTalisman === true,
+  installed: hasInjectedProvider({
+    namespace: 'talismanEth',
+    flag: 'isTalisman',
+  }),
   downloadUrls: {
     chrome:
       'https://chrome.google.com/webstore/detail/talisman-polkadot-wallet/fijngjgcjhjmmpcmkeiomlglpeiijkld',
@@ -29,14 +26,10 @@ export const talismanWallet = ({ chains }: TalismanWalletOptions): Wallet => ({
     browserExtension: 'https://talisman.xyz/download',
   },
   createConnector: () => ({
-    connector: new InjectedConnector({
+    connector: getInjectedConnector({
       chains,
-      options: {
-        getProvider: () => {
-          if (typeof window === 'undefined') return;
-          return window.talismanEth;
-        },
-      },
+      namespace: 'talismanEth',
+      flag: 'isTalisman',
     }),
     extension: {
       instructions: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/tokenPocketWallet/tokenPocketWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tokenPocketWallet/tokenPocketWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import type { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
@@ -17,7 +16,7 @@ export const tokenPocketWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-}: TokenPocketWalletOptions & InjectedConnectorOptions): Wallet => {
+}: TokenPocketWalletOptions): Wallet => {
   const isTokenPocketInjected =
     typeof window !== 'undefined' && window.ethereum?.isTokenPocket === true;
 

--- a/packages/rainbowkit/src/wallets/walletConnectors/tokenPocketWallet/tokenPocketWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tokenPocketWallet/tokenPocketWallet.ts
@@ -1,8 +1,11 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import type { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isMobile } from '../../../utils/isMobile';
 import type { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -17,9 +20,7 @@ export const tokenPocketWallet = ({
   projectId,
   walletConnectOptions,
 }: TokenPocketWalletOptions): Wallet => {
-  const isTokenPocketInjected =
-    typeof window !== 'undefined' && window.ethereum?.isTokenPocket === true;
-
+  const isTokenPocketInjected = hasInjectedProvider('isTokenPocket');
   const shouldUseWalletConnect = !isTokenPocketInjected;
 
   return {
@@ -45,7 +46,7 @@ export const tokenPocketWallet = ({
             projectId,
             options: walletConnectOptions,
           })
-        : new InjectedConnector({ chains });
+        : getInjectedConnector({ chains, flag: 'isTokenPocket' });
 
       const getUri = async () => {
         const uri = await getWalletConnectUri(connector);

--- a/packages/rainbowkit/src/wallets/walletConnectors/tokenPocketWallet/tokenPocketWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tokenPocketWallet/tokenPocketWallet.ts
@@ -20,7 +20,7 @@ export const tokenPocketWallet = ({
   projectId,
   walletConnectOptions,
 }: TokenPocketWalletOptions): Wallet => {
-  const isTokenPocketInjected = hasInjectedProvider('isTokenPocket');
+  const isTokenPocketInjected = hasInjectedProvider({ flag: 'isTokenPocket' });
   const shouldUseWalletConnect = !isTokenPocketInjected;
 
   return {

--- a/packages/rainbowkit/src/wallets/walletConnectors/tokenaryWallet/tokenaryWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tokenaryWallet/tokenaryWallet.ts
@@ -15,7 +15,7 @@ export const tokenaryWallet = ({ chains }: TokenaryWalletOptions): Wallet => ({
   name: 'Tokenary',
   iconUrl: async () => (await import('./tokenaryWallet.svg')).default,
   iconBackground: '#ffffff',
-  installed: hasInjectedProvider('isTokenary'),
+  installed: hasInjectedProvider({ flag: 'isTokenary' }),
   hidden: () => !isSafari(),
   downloadUrls: {
     ios: 'https://tokenary.io/get',

--- a/packages/rainbowkit/src/wallets/walletConnectors/tokenaryWallet/tokenaryWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tokenaryWallet/tokenaryWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { isSafari } from '../../../utils/browsers';
@@ -8,10 +7,7 @@ export interface TokenaryWalletOptions {
   chains: Chain[];
 }
 
-export const tokenaryWallet = ({
-  chains,
-  ...options
-}: TokenaryWalletOptions & InjectedConnectorOptions): Wallet => ({
+export const tokenaryWallet = ({ chains }: TokenaryWalletOptions): Wallet => ({
   id: 'tokenary',
   name: 'Tokenary',
   iconUrl: async () => (await import('./tokenaryWallet.svg')).default,
@@ -31,7 +27,6 @@ export const tokenaryWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options,
     }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/tokenaryWallet/tokenaryWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tokenaryWallet/tokenaryWallet.ts
@@ -1,7 +1,10 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { isSafari } from '../../../utils/browsers';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface TokenaryWalletOptions {
   chains: Chain[];
@@ -12,10 +15,7 @@ export const tokenaryWallet = ({ chains }: TokenaryWalletOptions): Wallet => ({
   name: 'Tokenary',
   iconUrl: async () => (await import('./tokenaryWallet.svg')).default,
   iconBackground: '#ffffff',
-  installed:
-    typeof window !== 'undefined' &&
-    typeof window.ethereum !== 'undefined' &&
-    window.ethereum.isTokenary,
+  installed: hasInjectedProvider('isTokenary'),
   hidden: () => !isSafari(),
   downloadUrls: {
     ios: 'https://tokenary.io/get',
@@ -25,8 +25,6 @@ export const tokenaryWallet = ({ chains }: TokenaryWalletOptions): Wallet => ({
     browserExtension: 'https://tokenary.io/get',
   },
   createConnector: () => ({
-    connector: new InjectedConnector({
-      chains,
-    }),
+    connector: getInjectedConnector({ chains, flag: 'isTokenary' }),
   }),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isMobile } from '../../../utils/isMobile';
@@ -17,8 +16,8 @@ declare global {
 }
 
 export interface TrustWalletOptions {
-  projectId: string;
   chains: Chain[];
+  projectId: string;
   walletConnectOptions?: WalletConnectConnectorOptions;
 }
 
@@ -26,8 +25,7 @@ export const trustWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  ...options
-}: TrustWalletOptions & InjectedConnectorOptions): Wallet => {
+}: TrustWalletOptions): Wallet => {
   const isTrustWalletInjected = isMobile()
     ? hasInjectedProvider('isTrust')
     : hasInjectedProvider('isTrustWallet');
@@ -73,8 +71,8 @@ export const trustWallet = ({
             options: walletConnectOptions,
           })
         : isMobile()
-          ? getInjectedConnector({ flag: 'isTrust', chains, options })
-          : getInjectedConnector({ flag: 'isTrustWallet', chains, options });
+          ? getInjectedConnector({ flag: 'isTrust', chains })
+          : getInjectedConnector({ flag: 'isTrustWallet', chains });
 
       const mobileConnector = {
         getUri: shouldUseWalletConnect ? getUriMobile : undefined,

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -9,12 +9,6 @@ import {
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
-declare global {
-  interface Window {
-    trustwallet: Window['ethereum'];
-  }
-}
-
 export interface TrustWalletOptions {
   chains: Chain[];
   projectId: string;
@@ -27,8 +21,8 @@ export const trustWallet = ({
   walletConnectOptions,
 }: TrustWalletOptions): Wallet => {
   const isTrustWalletInjected = isMobile()
-    ? hasInjectedProvider('isTrust')
-    : hasInjectedProvider('isTrustWallet');
+    ? hasInjectedProvider({ flag: 'isTrust' })
+    : hasInjectedProvider({ flag: 'isTrustWallet' });
   const shouldUseWalletConnect = !isTrustWalletInjected;
 
   return {

--- a/packages/rainbowkit/src/wallets/walletConnectors/xdefiWallet/xdefiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/xdefiWallet/xdefiWallet.ts
@@ -1,66 +1,48 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
-
-declare global {
-  interface Window {
-    xfi: any;
-  }
-}
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface XDEFIWalletOptions {
   chains: Chain[];
 }
 
-export const xdefiWallet = ({ chains }: XDEFIWalletOptions): Wallet => {
-  const isInstalled =
-    typeof window !== 'undefined' && typeof window?.xfi !== 'undefined';
-  return {
-    id: 'xdefi',
-    name: 'XDEFI Wallet',
-    installed: isInstalled,
-    iconUrl: async () => (await import('./xdefiWallet.svg')).default,
-    iconBackground: '#fff',
-    downloadUrls: {
-      chrome:
-        'https://chrome.google.com/webstore/detail/xdefi-wallet/hmeobnfnfcmdkdcmlblgagmfpfboieaf',
-      browserExtension: 'https://xdefi.io',
-    },
-    createConnector: () => ({
-      connector: new InjectedConnector({
-        chains,
-        options: {
-          //@ts-ignore
-          getProvider: () => {
-            return isInstalled ? (window.xfi?.ethereum as any) : undefined;
+export const xdefiWallet = ({ chains }: XDEFIWalletOptions): Wallet => ({
+  id: 'xdefi',
+  name: 'XDEFI Wallet',
+  installed: hasInjectedProvider({ namespace: 'xfi.ethereum' }),
+  iconUrl: async () => (await import('./xdefiWallet.svg')).default,
+  iconBackground: '#fff',
+  downloadUrls: {
+    chrome:
+      'https://chrome.google.com/webstore/detail/xdefi-wallet/hmeobnfnfcmdkdcmlblgagmfpfboieaf',
+    browserExtension: 'https://xdefi.io',
+  },
+  createConnector: () => ({
+    connector: getInjectedConnector({ namespace: 'xfi.ethereum', chains }),
+    extension: {
+      instructions: {
+        learnMoreUrl: 'https://xdefi.io/support-categories/xdefi-wallet/',
+        steps: [
+          {
+            description: 'wallet_connectors.xdefi.extension.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.xdefi.extension.step1.title',
           },
-        },
-      }),
-      extension: {
-        instructions: {
-          learnMoreUrl: 'https://xdefi.io/support-categories/xdefi-wallet/',
-          steps: [
-            {
-              description:
-                'wallet_connectors.xdefi.extension.step1.description',
-              step: 'install',
-              title: 'wallet_connectors.xdefi.extension.step1.title',
-            },
-            {
-              description:
-                'wallet_connectors.xdefi.extension.step2.description',
-              step: 'create',
-              title: 'wallet_connectors.xdefi.extension.step2.title',
-            },
-            {
-              description:
-                'wallet_connectors.xdefi.extension.step3.description',
-              step: 'refresh',
-              title: 'wallet_connectors.xdefi.extension.step3.title',
-            },
-          ],
-        },
+          {
+            description: 'wallet_connectors.xdefi.extension.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.xdefi.extension.step2.title',
+          },
+          {
+            description: 'wallet_connectors.xdefi.extension.step3.description',
+            step: 'refresh',
+            title: 'wallet_connectors.xdefi.extension.step3.title',
+          },
+        ],
       },
-    }),
-  };
-};
+    },
+  }),
+});

--- a/packages/rainbowkit/src/wallets/walletConnectors/xdefiWallet/xdefiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/xdefiWallet/xdefiWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/dist/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -13,10 +12,7 @@ export interface XDEFIWalletOptions {
   chains: Chain[];
 }
 
-export const xdefiWallet = ({
-  chains,
-  ...options
-}: XDEFIWalletOptions & InjectedConnectorOptions): Wallet => {
+export const xdefiWallet = ({ chains }: XDEFIWalletOptions): Wallet => {
   const isInstalled =
     typeof window !== 'undefined' && typeof window?.xfi !== 'undefined';
   return {
@@ -38,7 +34,6 @@ export const xdefiWallet = ({
           getProvider: () => {
             return isInstalled ? (window.xfi?.ethereum as any) : undefined;
           },
-          ...options,
         },
       }),
       extension: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/zealWallet/zealWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/zealWallet/zealWallet.ts
@@ -1,7 +1,9 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
-import { hasInjectedProvider } from '../../getInjectedConnector';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 
 export interface ZealWalletOptions {
   chains: Chain[];
@@ -17,9 +19,7 @@ export const zealWallet = ({ chains }: ZealWalletOptions): Wallet => ({
     browserExtension: 'https://zeal.app',
   },
   createConnector: () => ({
-    connector: new InjectedConnector({
-      chains,
-    }),
+    connector: getInjectedConnector({ chains, flag: 'isZeal' }),
     extension: {
       instructions: {
         learnMoreUrl: 'https://zeal.app/',

--- a/packages/rainbowkit/src/wallets/walletConnectors/zealWallet/zealWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/zealWallet/zealWallet.ts
@@ -14,7 +14,7 @@ export const zealWallet = ({ chains }: ZealWalletOptions): Wallet => ({
   name: 'Zeal',
   iconUrl: async () => (await import('./zealWallet.svg')).default,
   iconBackground: '#fff0',
-  installed: hasInjectedProvider('isZeal'),
+  installed: hasInjectedProvider({ flag: 'isZeal' }),
   downloadUrls: {
     browserExtension: 'https://zeal.app',
   },

--- a/packages/rainbowkit/src/wallets/walletConnectors/zealWallet/zealWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/zealWallet/zealWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { Wallet } from '../../Wallet';
@@ -8,10 +7,7 @@ export interface ZealWalletOptions {
   chains: Chain[];
 }
 
-export const zealWallet = ({
-  chains,
-  ...options
-}: ZealWalletOptions & InjectedConnectorOptions): Wallet => ({
+export const zealWallet = ({ chains }: ZealWalletOptions): Wallet => ({
   id: 'zeal',
   name: 'Zeal',
   iconUrl: async () => (await import('./zealWallet.svg')).default,
@@ -23,7 +19,6 @@ export const zealWallet = ({
   createConnector: () => ({
     connector: new InjectedConnector({
       chains,
-      options,
     }),
     extension: {
       instructions: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
@@ -1,8 +1,11 @@
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
 import { isIOS } from '../../../utils/isMobile';
 import { Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import type { WalletConnectConnectorOptions } from '../../getWalletConnectConnector';
 
@@ -17,12 +20,10 @@ export const zerionWallet = ({
   projectId,
   walletConnectOptions,
 }: ZerionWalletOptions): Wallet => {
-  const isZerionInjected =
-    typeof window !== 'undefined' &&
-    ((typeof window.ethereum !== 'undefined' && window.ethereum.isZerion) ||
-      // @ts-expect-error
-      typeof window.zerionWallet !== 'undefined');
-
+  const isZerionInjected = hasInjectedProvider({
+    namespace: 'zerionWallet',
+    flag: 'isZerion',
+  });
   const shouldUseWalletConnect = !isZerionInjected;
 
   return {
@@ -49,15 +50,10 @@ export const zerionWallet = ({
             chains,
             options: walletConnectOptions,
           })
-        : new InjectedConnector({
+        : getInjectedConnector({
             chains,
-            options: {
-              getProvider: () =>
-                typeof window !== 'undefined'
-                  ? // @ts-expect-error
-                    window.zerionWallet || window.ethereum
-                  : undefined,
-            },
+            namespace: 'zerionWallet',
+            flag: 'isZerion',
           });
 
       const getUri = async () => {

--- a/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
@@ -1,4 +1,3 @@
-import type { InjectedConnectorOptions } from '@wagmi/core/connectors/injected';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { Chain } from '../../../components/RainbowKitProvider/RainbowKitChainContext';
 import { getWalletConnectUri } from '../../../utils/getWalletConnectUri';
@@ -17,8 +16,7 @@ export const zerionWallet = ({
   chains,
   projectId,
   walletConnectOptions,
-  ...options
-}: ZerionWalletOptions & InjectedConnectorOptions): Wallet => {
+}: ZerionWalletOptions): Wallet => {
   const isZerionInjected =
     typeof window !== 'undefined' &&
     ((typeof window.ethereum !== 'undefined' && window.ethereum.isZerion) ||
@@ -59,7 +57,6 @@ export const zerionWallet = ({
                   ? // @ts-expect-error
                     window.zerionWallet || window.ethereum
                   : undefined,
-              ...options,
             },
           });
 

--- a/packages/rainbowkit/test/index.tsx
+++ b/packages/rainbowkit/test/index.tsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import type { MockProviderOptions } from '@wagmi/core/connectors/mock';
 import React, { ReactElement } from 'react';
 import { http, createWalletClient } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
@@ -15,12 +14,16 @@ import { getDefaultWallets } from '../src/wallets/getDefaultWallets';
 
 const defaultChains = [mainnet, polygon, optimism, arbitrum, base, zora];
 
+type MockConnectorOptions = ConstructorParameters<
+  typeof MockConnector
+>[0]['options'];
+
 export function renderWithProviders(
   component: ReactElement,
   options?: {
     chains?: Chain[];
     mock?: boolean;
-    mockOptions?: MockProviderOptions;
+    mockOptions?: MockConnectorOptions;
     props?: Omit<RainbowKitProviderProps, 'children'>;
   },
 ) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       '@vanilla-extract/vite-plugin':
         specifier: ^3.9.3
         version: 3.9.3(@types/node@18.19.4)(vite@5.0.7)
-      '@wagmi/core':
-        specifier: ~1.4.13
-        version: 1.4.13(@types/react@18.2.46)(react@18.2.0)(typescript@5.0.4)(viem@1.21.4)
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.32)
@@ -230,10 +227,6 @@ importers:
       wagmi:
         specifier: ~1.0.1 || ~1.1.0 || ~1.2.0 || ~1.3.0 || ~1.4.0
         version: 1.4.7(@types/react@18.2.46)(lokijs@1.5.12)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@1.19.4)
-    devDependencies:
-      '@wagmi/core':
-        specifier: ^1.4.3
-        version: 1.4.7(@types/react@18.2.46)(lokijs@1.5.12)(react@18.2.0)(typescript@5.0.4)(viem@1.19.4)
 
   packages/rainbowkit:
     dependencies:
@@ -289,9 +282,6 @@ importers:
       '@vanilla-extract/private':
         specifier: ^1.0.3
         version: 1.0.3
-      '@wagmi/core':
-        specifier: ~1.4.13
-        version: 1.4.13(@types/react@18.2.46)(react@18.2.0)(typescript@5.0.4)(viem@1.21.4)
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.32)
@@ -2752,6 +2742,7 @@ packages:
 
   /@ledgerhq/connect-kit-loader@1.1.0:
     resolution: {integrity: sha512-HUy12FEczoWY2FPubnsm1uOA8tkVWc0j90i47suThV3C9NL2xx69ZAIEU3Ytzs2bwLek9S1Q2S1VQJvA+3Ygkg==}
+    dev: false
 
   /@lit-labs/ssr-dom-shim@1.1.1:
     resolution: {integrity: sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ==}
@@ -3872,6 +3863,7 @@ packages:
       - typescript
       - utf-8-validate
       - zod
+    dev: false
 
   /@safe-global/safe-apps-provider@0.18.1(typescript@5.0.4):
     resolution: {integrity: sha512-V4a05A3EgJcriqtDoJklDz1BOinWhC6P0hjUSxshA4KOZM7rGPCTto/usXs09zr1vvL28evl/NldSTv97j2bmg==}
@@ -3896,6 +3888,7 @@ packages:
       - typescript
       - utf-8-validate
       - zod
+    dev: false
 
   /@safe-global/safe-apps-sdk@8.1.0(typescript@5.0.4):
     resolution: {integrity: sha512-XJbEPuaVc7b9n23MqlF6c+ToYIS3f7P2Sel8f3cSBQ9WORE4xrSuvhMpK9fDSFqJ7by/brc+rmJR/5HViRr0/w==}
@@ -4738,6 +4731,7 @@ packages:
       - supports-color
       - utf-8-validate
       - zod
+    dev: false
 
   /@wagmi/core@1.4.13(@types/react@18.2.46)(react@18.2.0)(typescript@5.0.4)(viem@1.21.4):
     resolution: {integrity: sha512-ytMCvXbBOgfDu9Qw67279wq/jNEe7EZLjLyekX7ROnvHRADqFr3lwZI6ih41UmtRZAmXAx8Ghyuqy154EjB5mQ==}
@@ -4802,6 +4796,7 @@ packages:
       - supports-color
       - utf-8-validate
       - zod
+    dev: false
 
   /@walletconnect/core@2.10.2(lokijs@1.5.12):
     resolution: {integrity: sha512-JQz/xp3SLEpTeRQctdck2ugSBVEpMxoSE+lFi2voJkZop1hv6P+uqr6E4PzjFluAjeAnKlT1xvra0aFWjPWVcw==}
@@ -4827,6 +4822,7 @@ packages:
       - bufferutil
       - lokijs
       - utf-8-validate
+    dev: false
 
   /@walletconnect/core@2.11.0:
     resolution: {integrity: sha512-2Tjp5BCevI7dbmqo/OrCjX4tqgMqwJNQLlQAlphqPfvwlF9+tIu6pGcVbSN3U9zyXzWIZCeleqEaWUeSeET4Ew==}
@@ -4912,6 +4908,7 @@ packages:
       - encoding
       - lokijs
       - utf-8-validate
+    dev: false
 
   /@walletconnect/ethereum-provider@2.11.0(@types/react@18.2.46)(react@18.2.0):
     resolution: {integrity: sha512-YrTeHVjuSuhlUw7SQ6xBJXDuJ6iAC+RwINm9nVhoKYJSHAy3EVSJZOofMKrnecL0iRMtD29nj57mxAInIBRuZA==}
@@ -5000,6 +4997,7 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: false
 
   /@walletconnect/jsonrpc-ws-connection@1.0.14:
     resolution: {integrity: sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==}
@@ -5026,6 +5024,7 @@ packages:
       lokijs: 1.5.12
       safe-json-utils: 1.1.1
       tslib: 1.14.1
+    dev: false
 
   /@walletconnect/keyvaluestorage@1.1.1:
     resolution: {integrity: sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==}
@@ -5184,6 +5183,7 @@ packages:
       - bufferutil
       - lokijs
       - utf-8-validate
+    dev: false
 
   /@walletconnect/sign-client@2.11.0:
     resolution: {integrity: sha512-H2ukscibBS+6WrzQWh+WyVBqO5z4F5et12JcwobdwgHnJSlqIoZxqnUYYWNCI5rUR5UKsKWaUyto4AE9N5dw4Q==}
@@ -5232,6 +5232,7 @@ packages:
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - lokijs
+    dev: false
 
   /@walletconnect/types@2.11.0:
     resolution: {integrity: sha512-AB5b1lrEbCGHxqS2vqfCkIoODieH+ZAUp9rA1O2ftrhnqDJiJK983Df87JhYhECsQUBHHfALphA8ydER0q+9sw==}
@@ -5275,6 +5276,7 @@ packages:
       - encoding
       - lokijs
       - utf-8-validate
+    dev: false
 
   /@walletconnect/universal-provider@2.11.0:
     resolution: {integrity: sha512-zgJv8jDvIMP4Qse/D9oIRXGdfoNqonsrjPZanQ/CHNe7oXGOBiQND2IIeX+tS0H7uNA0TPvctljCLiIN9nw4eA==}
@@ -5326,6 +5328,7 @@ packages:
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - lokijs
+    dev: false
 
   /@walletconnect/utils@2.11.0:
     resolution: {integrity: sha512-hxkHPlTlDQILHfIKXlmzgNJau/YcSBC3XHUSuZuKZbNEw3duFT6h6pm3HT/1+j1a22IG05WDsNBuTCRkwss+BQ==}
@@ -11340,6 +11343,7 @@ packages:
 
   /safe-json-utils@1.1.1:
     resolution: {integrity: sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ==}
+    dev: false
 
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -12569,6 +12573,7 @@ packages:
       - bufferutil
       - utf-8-validate
       - zod
+    dev: false
 
   /viem@1.21.4(typescript@5.0.4):
     resolution: {integrity: sha512-BNVYdSaUjeS2zKQgPs+49e5JKocfo60Ib2yiXOWBT6LuVxY1I/6fFX3waEtpXvL1Xn4qu+BVitVtMh9lyThyhQ==}


### PR DESCRIPTION
## Changes
- removed `@wagmi/core` dev dependency and usage
- added `namespace` to `hasInjectedProvider` to `getInjectedProvider` for custom ethereum namespaces (i.e. not `window.ethereum`)
- cleaned up wallet connectors:
  - removed `MetaMaskConnector` usage; this has different behavior in Wagmi v2
  - adopted `getInjectedConnector` everywhere and removed custom logic
  - added `getProvider` option to `getInjectedConnector` for explicit metamask checks and custom logic
  - removed use of `InjectedConnectorOptions` for overflow options
  - explicit usage of `walletConnectOptions`
  - removed `declare global` usage for custom window providers