### PR TITLE
docs: v2 beta migration guide

### DIFF
--- a/site/data/en-US/guides/rainbowkit-wagmi-v2.mdx
+++ b/site/data/en-US/guides/rainbowkit-wagmi-v2.mdx
@@ -1,0 +1,41 @@
+---
+title: Upgrading your dApp for RainbowKit v2
+description: RainbowKit and Wagmi have been promoted to v2
+image: guide-walletconnect-v2.png
+---
+
+**Breaking:**
+
+The [Wagmi](https://wagmi.sh) peer dependency is migrated over to [Wagmi v2](https://wagmi.sh/) which has been updated to `^2.0.0`.
+
+Follow the steps below to migrate.
+
+**1. Upgrade RainbowKit to beta version and `wagmi` to v2 version**
+
+```bash
+npm i @rainbow-me/rainbowkit@beta wagmi
+```
+
+**2. Install `viem` peer dependency**
+
+Wagmi v2 requires the `viem` peer dependency. Install it with the following command:
+
+```bash
+npm i viem@2
+```
+
+**3. Check for breaking changes in `wagmi`**
+
+If you use `wagmi` hooks in your application, you will need to follow `wagmi`'s migration guide to v2.
+
+
+[You can see their migration guide from v1 to v2 here](https://wagmi.sh/react/guides/migrate-from-v1-to-v2).
+
+
+**4. Check for breaking changes in `@rainbow-me/rainbowkit`**
+
+If you use `@rainbow-me/rainbowkit` wallets in your application, you will need to follow `@rainbow-me/rainbowkit`'s migration guide.
+
+**TODO INSERT GUIDE HERE**
+
+[You can see the migration guide here](https://wagmi.sh/react/guides/migrate-from-v1-to-v2).


### PR DESCRIPTION
## Changes
- added a migration guide for RainbowKit v2 beta with support for Wagmi v2