### PR TITLE
fix: add missing `projectId` to `bifrostWallet` in the docs

### DIFF
--- a/.changeset/seven-humans-push.md
+++ b/.changeset/seven-humans-push.md
@@ -1,0 +1,5 @@
+---
+"site": patch
+---
+
+Add projectId to bifrostWallet in the docs for custom wallet list

--- a/.changeset/seven-humans-push.md
+++ b/.changeset/seven-humans-push.md
@@ -2,4 +2,4 @@
 "site": patch
 ---
 
-Add projectId to bifrostWallet in the docs for custom wallet list
+Add `projectId` to `bifrostWallet` in the docs for custom wallet list

--- a/site/data/en-US/docs/custom-wallet-list.mdx
+++ b/site/data/en-US/docs/custom-wallet-list.mdx
@@ -142,6 +142,7 @@ bitKeepWallet(options: {
 ```tsx
 import { bifrostWallet } from '@rainbow-me/rainbowkit/wallets';
 bifrostWallet(options: {
+  projectId: string;
   chains: Chain[];
 });
 ```


### PR DESCRIPTION
## Changes
- Add missing `projectId` to `bifrostWallet`