### PR TITLE
refactor: `useWindowSize` hook to re-render only after resize completion

### DIFF
--- a/.changeset/curly-spoons-look.md
+++ b/.changeset/curly-spoons-look.md
@@ -3,3 +3,5 @@
 ---
 
 Refactored `useWindowSize` hook, which previously caused components to re-render on every resize event, to now make components re-render only once the user has finished resizing the window.
+
+Forced `min-width` for wide connect modal to avoid weird ui resizing.

--- a/.changeset/curly-spoons-look.md
+++ b/.changeset/curly-spoons-look.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Refactored `useWindowSize` hook, which previously caused components to re-render on every resize event, to now make components re-render only once the user has finished resizing the window.

--- a/.changeset/curly-spoons-look.md
+++ b/.changeset/curly-spoons-look.md
@@ -2,6 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Refactored `useWindowSize` hook, which previously caused components to re-render on every resize event, to now make components re-render only once the user has finished resizing the window.
-
-Forced `min-width` for wide connect modal to avoid weird ui resizing.
+Fixed an issue that caused components to re-render on every window resize event. Now components will only re-render once the user has finished resizing their window.

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.css.ts
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css';
-import { largeScreenMinWidth, sprinkles } from '../../css/sprinkles.css';
+import { sprinkles } from '../../css/sprinkles.css';
 export const QRCodeBackgroundClassName = style([
   {
     background: 'white',
@@ -18,12 +18,7 @@ export const ScrollClassName = style([
 
 // biome-ignore format: design system keys
 export const sidebar = style({
-  '@media': {
-    [`screen and (min-width: ${largeScreenMinWidth}px)`]: {
-      minWidth: '287px',
-    },
-  },
-  'minWidth': '246px',
+  minWidth: '287px',
 });
 
 export const sidebarCompactMode = style({

--- a/packages/rainbowkit/src/components/Dialog/DialogContent.css.ts
+++ b/packages/rainbowkit/src/components/Dialog/DialogContent.css.ts
@@ -42,14 +42,8 @@ export const dialogContentWideMobile = style([
 export const dialogContentWideDesktop = style([
   dialogContent,
   {
-    width: largeScreenMinWidth,
-  },
-  {
-    '@media': {
-      [`screen and (min-width: ${largeScreenMinWidth}px)`]: {
-        width: '720px',
-      },
-    },
+    minWidth: '720px',
+    width: '720px',
   },
 ]);
 

--- a/packages/rainbowkit/src/hooks/useWindowSize.ts
+++ b/packages/rainbowkit/src/hooks/useWindowSize.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { debounce } from '../utils/debounce';
 
 export const useWindowSize = () => {
   const [windowSize, setWindowSize] = useState<{
@@ -8,13 +9,14 @@ export const useWindowSize = () => {
     height: undefined,
     width: undefined,
   });
+
   useEffect(() => {
-    function handleResize() {
+    const handleResize = debounce(() => {
       setWindowSize({
         height: window.innerHeight,
         width: window.innerWidth,
       });
-    }
+    }, 500); // 500ms debounce by default
     window.addEventListener('resize', handleResize);
     handleResize();
     return () => window.removeEventListener('resize', handleResize);

--- a/packages/rainbowkit/src/utils/debounce.ts
+++ b/packages/rainbowkit/src/utils/debounce.ts
@@ -1,0 +1,14 @@
+export function debounce(fn: () => void, ms: number) {
+  let timer: NodeJS.Timeout | null;
+
+  return () => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+
+    timer = setTimeout(() => {
+      timer = null;
+      fn();
+    }, ms);
+  };
+}


### PR DESCRIPTION
## Changes
- Updated `useWindowSize` hook to prevent component re-renders on every resize event.
- Implemented a `debounce` function for managing the debounce effect.
- Configured the `debounce` duration to 500 milliseconds for `useWindowSize` hook.
- Forced `min-width` to be `720px` for wide connect modal to avoid ui resizing issues when doing window resize event.