### PR TITLE
fix: back button not showing in compact modal size (download option)

### DIFF
--- a/.changeset/odd-adults-complain.md
+++ b/.changeset/odd-adults-complain.md
@@ -1,0 +1,7 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fixed a bug where the back button wasn't showing on compact size modal when selecting `DownloadOptions` wallet step. 
+
+Removed back button for wide size modal entirely when selecting `DownloadOptions` wallet step to prevent incorrect wallet step switching.

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -306,8 +306,8 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
       headerBackButtonLink = connector
         ? WalletStep.Connect
         : compactModeEnabled
-        ? WalletStep.None
-        : null;
+          ? WalletStep.None
+          : null;
       break;
     case WalletStep.Download:
       walletContent = selectedWallet && (

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -305,9 +305,9 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
         i18n.t('get_options.short_title', { wallet: selectedWallet.name });
       headerBackButtonLink = connector
         ? WalletStep.Connect
-        : hasExtensionAndMobile && WalletStep.Connect
-          ? initialWalletStep
-          : null;
+        : compactModeEnabled
+        ? WalletStep.None
+        : null;
       break;
     case WalletStep.Download:
       walletContent = selectedWallet && (


### PR DESCRIPTION
## Changes
- When selecting `DownloadOptions` wallet step in compact size modal the back button won't show. This means users would have to refresh the page and open the modal again to get back the list of wallets they want to connect with.
- Made sure to not include back button for wide size modal when selecting `DownloadOptions` wallet step. This will prevent users from switching to the wrong wallet step.

## Screen recordings / screenshots

https://github.com/rainbow-me/rainbowkit/assets/53529533/0e1992e6-e609-4f93-957b-50f6d8b87dc6

## What to test
- Select compact modal size and try selecting wallets like rabby wallet and talisman wallet. Make sure they have a "back button" included to get back all wallets.
- Visit our [example](https://rainbowkit-example.vercel.app/) page and try selecting argent wallet and then desig wallet right after. You will get a "back button" which will lead you to a unnecessary wallet step saying "Desig Wallet is not installed`. For wide modals we will make sure to not include back button.