### PR TITLE
feat: chain modal v2

### DIFF
--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -243,6 +243,8 @@ function RainbowKitApp({
   const [coolModeEnabled, setCoolModeEnabled] = useState(false);
   const [modalSize, setModalSize] = useState<ModalSize>('wide');
   const [showDisclaimer, setShowDisclaimer] = useState(false);
+  const [ignoreChainModalOnConnect, setIgnoreChainModalOnConnect] =
+    useState(false);
   const [customAvatar, setCustomAvatar] = useState(false);
 
   const routerLocale = router.locale as Locale;
@@ -287,6 +289,7 @@ function RainbowKitApp({
           ...demoAppInfo,
           ...(showDisclaimer && { disclaimer: DisclaimerDemo }),
         }}
+        ignoreChainModalOnConnect={ignoreChainModalOnConnect}
         avatar={customAvatar ? CustomAvatar : undefined}
         locale={locale}
         coolMode={coolModeEnabled}
@@ -424,6 +427,27 @@ function RainbowKitApp({
                           id="customAvatar"
                           name="customAvatar"
                           onChange={(e) => setCustomAvatar(e.target.checked)}
+                          type="checkbox"
+                        />
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <label
+                          htmlFor="ignoreModalChainOnConnect"
+                          style={{ userSelect: 'none' }}
+                        >
+                          ignoreModalChainOnConnect
+                        </label>
+                      </td>
+                      <td>
+                        <input
+                          checked={ignoreChainModalOnConnect}
+                          id="ignoreModalChainOnConnect"
+                          name="ignoreModalChainOnConnect"
+                          onChange={(e) =>
+                            setIgnoreChainModalOnConnect(e.target.checked)
+                          }
                           type="checkbox"
                         />
                       </td>

--- a/packages/rainbowkit/src/components/ChainModal/Chain.tsx
+++ b/packages/rainbowkit/src/components/ChainModal/Chain.tsx
@@ -19,6 +19,7 @@ interface ChainProps {
   iconBackground: string | undefined;
   src: string | AsyncImageSrc | undefined | null;
   idx: number;
+  isConnected?: boolean;
 }
 
 const Chain = ({
@@ -30,6 +31,7 @@ const Chain = ({
   src,
   name,
   iconBackground,
+  isConnected,
   idx,
 }: ChainProps) => {
   const mobile = isMobile();
@@ -74,7 +76,7 @@ const Chain = ({
               )}
               <div>{name ?? name}</div>
             </Box>
-            {isCurrentChain && (
+            {isCurrentChain && isConnected && (
               <Box
                 alignItems="center"
                 display="flex"

--- a/packages/rainbowkit/src/components/ChainModal/ChainModal.test.tsx
+++ b/packages/rainbowkit/src/components/ChainModal/ChainModal.test.tsx
@@ -6,7 +6,7 @@ import { renderWithProviders } from '../../../test/';
 import { ChainModal } from './ChainModal';
 
 describe('<ChainModal />', () => {
-  it('Show current connected chain indicator', async () => {
+  it('Show current chain selected status', async () => {
     const modal = renderWithProviders(<ChainModal onClose={() => {}} open />, {
       mock: true,
     });
@@ -14,7 +14,7 @@ describe('<ChainModal />', () => {
       `rk-chain-option-${mainnet.id}`,
     );
 
-    expect(mainnetOption).toHaveTextContent('Connected');
+    expect(mainnetOption).toHaveTextContent('Ethereum');
     expect(mainnetOption).toBeDisabled();
   });
 
@@ -55,13 +55,13 @@ describe('<ChainModal />', () => {
       `rk-chain-option-${arbitrum.id}`,
     );
 
-    expect(mainnetOption).toHaveTextContent('Connected');
-    expect(arbitrumOption).not.toHaveTextContent('Connected');
+    expect(mainnetOption).toHaveTextContent('Ethereum');
+    expect(mainnetOption).toBeDisabled();
 
     await user.click(arbitrumOption);
 
-    expect(mainnetOption).not.toHaveTextContent('Connected');
-    expect(arbitrumOption).toHaveTextContent('Connected');
+    expect(arbitrumOption).toHaveTextContent('Arbitrum');
+    expect(arbitrumOption).toBeDisabled();
 
     expect(onCloseGotCalled).toBe(true);
   });

--- a/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
+++ b/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { useChainId, useDisconnect, useSwitchChain } from 'wagmi';
+import { useAccount, useChainId, useDisconnect, useSwitchChain } from 'wagmi';
 import { useConfig } from 'wagmi';
 import { isMobile } from '../../utils/isMobile';
 import { Box } from '../Box/Box';
@@ -23,7 +23,9 @@ export interface ChainModalProps {
 }
 
 export function ChainModal({ onClose, open }: ChainModalProps) {
-  const chainId = useChainId();
+  const { chainId: connectedChainId, isConnected } = useAccount();
+  const currentChainId = useChainId();
+  const chainId = isConnected ? connectedChainId : currentChainId;
   const { chains } = useConfig();
   const [pendingChainId, setPendingChainId] = useState<number | null>(null);
   const { switchChain } = useSwitchChain({
@@ -101,6 +103,7 @@ export function ChainModal({ onClose, open }: ChainModalProps) {
                     key={id}
                     chainId={id}
                     currentChainId={chainId}
+                    isConnected={isConnected}
                     switchChain={switchChain}
                     chainIconSize={chainIconSize}
                     isLoading={pendingChainId === id}

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -13,6 +13,7 @@ import { Box } from '../Box/Box';
 import { DropdownIcon } from '../Icons/Dropdown';
 import { I18nContext } from '../RainbowKitProvider/I18nContext';
 import {
+  useIgnoreChainModalOnConnect,
   useInitialChainId,
   useRainbowKitChains,
 } from '../RainbowKitProvider/RainbowKitChainContext';
@@ -44,6 +45,7 @@ export function ConnectButton({
 }: ConnectButtonProps) {
   const chains = useRainbowKitChains();
   const connectionStatus = useConnectionStatus();
+  const ignoreChainModalOnConnect = useIgnoreChainModalOnConnect();
   const { setShowBalance } = useShowBalance();
   const initialChainId = useInitialChainId();
   const { i18n } = useContext(I18nContext);
@@ -67,7 +69,8 @@ export function ConnectButton({
         // chain that they want to switch to. We also hide the chain button if user is using
         // our authentication provider and is not yet signed in.
         const shouldHideChainButton =
-          (initialChainId && connectionStatus !== 'connected') ||
+          ((initialChainId || ignoreChainModalOnConnect) &&
+            connectionStatus !== 'connected') ||
           connectionStatus === 'unauthenticated';
         const ready = mounted && connectionStatus !== 'loading';
         const unsupportedChain = !!chain?.unsupported;

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.tsx
@@ -12,7 +12,10 @@ import { Avatar } from '../Avatar/Avatar';
 import { Box } from '../Box/Box';
 import { DropdownIcon } from '../Icons/Dropdown';
 import { I18nContext } from '../RainbowKitProvider/I18nContext';
-import { useRainbowKitChains } from '../RainbowKitProvider/RainbowKitChainContext';
+import {
+  useInitialChainId,
+  useRainbowKitChains,
+} from '../RainbowKitProvider/RainbowKitChainContext';
 import { useShowBalance } from '../RainbowKitProvider/ShowBalanceContext';
 import { ConnectButtonRenderer } from './ConnectButtonRenderer';
 
@@ -42,7 +45,7 @@ export function ConnectButton({
   const chains = useRainbowKitChains();
   const connectionStatus = useConnectionStatus();
   const { setShowBalance } = useShowBalance();
-
+  const initialChainId = useInitialChainId();
   const { i18n } = useContext(I18nContext);
 
   useEffect(() => {
@@ -59,8 +62,15 @@ export function ConnectButton({
         openChainModal,
         openConnectModal,
       }) => {
+        // Hide the chain button if the user has specified a custom "initialChainId".
+        // This prevents users from switching to a different chain when they have a desired
+        // chain that they want to switch to. We also hide the chain button if user is using
+        // our authentication provider and is not yet signed in.
+        const shouldHideChainButton =
+          (initialChainId && connectionStatus !== 'connected') ||
+          connectionStatus === 'unauthenticated';
         const ready = mounted && connectionStatus !== 'loading';
-        const unsupportedChain = chain?.unsupported ?? false;
+        const unsupportedChain = !!chain?.unsupported;
 
         return (
           <Box
@@ -75,98 +85,98 @@ export function ConnectButton({
               },
             })}
           >
-            {ready && account && connectionStatus === 'connected' ? (
-              <>
-                {chain && (chains.length > 1 || unsupportedChain) && (
+            {ready && !shouldHideChainButton && chain && chains.length > 1 && (
+              <Box
+                alignItems="center"
+                aria-label="Chain Selector"
+                as="button"
+                background={
+                  unsupportedChain
+                    ? 'connectButtonBackgroundError'
+                    : 'connectButtonBackground'
+                }
+                borderRadius="connectButton"
+                boxShadow="connectButton"
+                className={touchableStyles({
+                  active: 'shrink',
+                  hover: 'grow',
+                })}
+                color={
+                  unsupportedChain
+                    ? 'connectButtonTextError'
+                    : 'connectButtonText'
+                }
+                display={mapResponsiveValue(chainStatus, (value) =>
+                  value === 'none' ? 'none' : 'flex',
+                )}
+                fontFamily="body"
+                fontWeight="bold"
+                gap="6"
+                key={
+                  // Force re-mount to prevent CSS transition
+                  unsupportedChain ? 'unsupported' : 'supported'
+                }
+                onClick={openChainModal}
+                paddingX="10"
+                paddingY="8"
+                testId={
+                  unsupportedChain ? 'wrong-network-button' : 'chain-button'
+                }
+                transition="default"
+                type="button"
+              >
+                {unsupportedChain ? (
                   <Box
                     alignItems="center"
-                    aria-label="Chain Selector"
-                    as="button"
-                    background={
-                      unsupportedChain
-                        ? 'connectButtonBackgroundError'
-                        : 'connectButtonBackground'
-                    }
-                    borderRadius="connectButton"
-                    boxShadow="connectButton"
-                    className={touchableStyles({
-                      active: 'shrink',
-                      hover: 'grow',
-                    })}
-                    color={
-                      unsupportedChain
-                        ? 'connectButtonTextError'
-                        : 'connectButtonText'
-                    }
-                    display={mapResponsiveValue(chainStatus, (value) =>
-                      value === 'none' ? 'none' : 'flex',
-                    )}
-                    fontFamily="body"
-                    fontWeight="bold"
-                    gap="6"
-                    key={
-                      // Force re-mount to prevent CSS transition
-                      unsupportedChain ? 'unsupported' : 'supported'
-                    }
-                    onClick={openChainModal}
-                    paddingX="10"
-                    paddingY="8"
-                    testId={
-                      unsupportedChain ? 'wrong-network-button' : 'chain-button'
-                    }
-                    transition="default"
-                    type="button"
+                    display="flex"
+                    height="24"
+                    paddingX="4"
                   >
-                    {unsupportedChain ? (
+                    Wrong network
+                  </Box>
+                ) : (
+                  <Box alignItems="center" display="flex" gap="6">
+                    {chain.hasIcon ? (
                       <Box
-                        alignItems="center"
-                        display="flex"
+                        display={mapResponsiveValue(chainStatus, (value) =>
+                          value === 'full' || value === 'icon'
+                            ? 'block'
+                            : 'none',
+                        )}
                         height="24"
-                        paddingX="4"
+                        width="24"
                       >
-                        Wrong network
+                        <AsyncImage
+                          alt={chain.name ?? 'Chain icon'}
+                          background={chain.iconBackground}
+                          borderRadius="full"
+                          height="24"
+                          src={chain.iconUrl}
+                          width="24"
+                        />
                       </Box>
-                    ) : (
-                      <Box alignItems="center" display="flex" gap="6">
-                        {chain.hasIcon ? (
-                          <Box
-                            display={mapResponsiveValue(chainStatus, (value) =>
-                              value === 'full' || value === 'icon'
-                                ? 'block'
-                                : 'none',
-                            )}
-                            height="24"
-                            width="24"
-                          >
-                            <AsyncImage
-                              alt={chain.name ?? 'Chain icon'}
-                              background={chain.iconBackground}
-                              borderRadius="full"
-                              height="24"
-                              src={chain.iconUrl}
-                              width="24"
-                            />
-                          </Box>
-                        ) : null}
-                        <Box
-                          display={mapResponsiveValue(chainStatus, (value) => {
-                            if (value === 'icon' && !chain.iconUrl) {
-                              return 'block'; // Show the chain name if there is no iconUrl
-                            }
+                    ) : null}
+                    <Box
+                      display={mapResponsiveValue(chainStatus, (value) => {
+                        if (value === 'icon' && !chain.iconUrl) {
+                          return 'block'; // Show the chain name if there is no iconUrl
+                        }
 
-                            return value === 'full' || value === 'name'
-                              ? 'block'
-                              : 'none';
-                          })}
-                        >
-                          {chain.name ?? chain.id}
-                        </Box>
-                      </Box>
-                    )}
-                    <DropdownIcon />
+                        return value === 'full' || value === 'name'
+                          ? 'block'
+                          : 'none';
+                      })}
+                    >
+                      {chain.name ?? chain.id}
+                    </Box>
                   </Box>
                 )}
+                <DropdownIcon />
+              </Box>
+            )}
 
+            {ready && account && connectionStatus === 'connected' ? (
+              <>
                 {!unsupportedChain && (
                   <Box
                     alignItems="center"

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useContext } from 'react';
-import { useAccount, useBalance, useConfig } from 'wagmi';
+import { useAccount, useBalance, useChainId, useConfig } from 'wagmi';
 import { normalizeResponsiveValue } from '../../css/sprinkles.css';
 import { useIsMounted } from '../../hooks/useIsMounted';
 import { useMainnetEnsAvatar } from '../../hooks/useMainnetEnsAvatar';
@@ -65,9 +65,12 @@ export function ConnectButtonRenderer({
   const { address } = useAccount();
   const ensName = useMainnetEnsName(address);
   const ensAvatar = useMainnetEnsAvatar(ensName);
+  const { isConnected } = useAccount();
 
-  const { chainId } = useAccount();
+  const currentChainId = useChainId();
+  const { chainId: connectedChainId } = useAccount();
   const { chains: wagmiChains } = useConfig();
+  const chainId = isConnected ? connectedChainId : currentChainId;
   const isCurrentChainSupported = wagmiChains.some(
     (chain) => chain.id === chainId,
   );
@@ -133,7 +136,7 @@ export function ConnectButtonRenderer({
               iconUrl: resolvedChainIconUrl,
               id: chainId,
               name: chainName,
-              unsupported: !isCurrentChainSupported,
+              unsupported: isConnected && !isCurrentChainSupported,
             }
           : undefined,
         chainModalOpen,

--- a/packages/rainbowkit/src/components/RainbowKitProvider/AuthenticationContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/AuthenticationContext.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
   useRef,
 } from 'react';
-import { useAccount, useAccountEffect } from 'wagmi';
+import { Config, useAccount, useAccountEffect } from 'wagmi';
 
 export type AuthenticationStatus =
   | 'loading'
@@ -79,8 +79,10 @@ export function RainbowKitAuthenticationProvider<Message = unknown>({
     }
   }, [status, adapter, isDisconnected]);
 
-  const handleChangedAccount = () => {
-    adapter.signOut();
+  const handleChangedAccount = (
+    data: Parameters<Config['_internal']['events']['change']>[0],
+  ) => {
+    if (data.accounts) adapter.signOut();
   };
 
   // Wait for user authentication before listening to "change" event.

--- a/packages/rainbowkit/src/components/RainbowKitProvider/ModalContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/ModalContext.tsx
@@ -101,7 +101,10 @@ export function ModalProvider({ children }: ModalProviderProps) {
               ? openAccountModal
               : undefined,
           openChainModal:
-            connectionStatus === 'connected' ? openChainModal : undefined,
+            connectionStatus === 'connected' ||
+            connectionStatus === 'disconnected'
+              ? openChainModal
+              : undefined,
           openConnectModal:
             connectionStatus === 'disconnected' ||
             connectionStatus === 'unauthenticated'

--- a/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitChainContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitChainContext.tsx
@@ -11,20 +11,24 @@ export interface RainbowKitChain extends Chain {
 interface RainbowKitChainContextValue {
   chains: RainbowKitChain[];
   initialChainId?: number;
+  ignoreChainModalOnConnect: boolean;
 }
 
 const RainbowKitChainContext = createContext<RainbowKitChainContextValue>({
   chains: [],
+  ignoreChainModalOnConnect: false,
 });
 
 interface RainbowKitChainProviderProps {
   initialChain?: Chain | number;
+  ignoreChainModalOnConnect: boolean;
   children: ReactNode;
 }
 
 export function RainbowKitChainProvider({
   children,
   initialChain,
+  ignoreChainModalOnConnect,
 }: RainbowKitChainProviderProps) {
   const { chains } = useConfig();
 
@@ -35,8 +39,9 @@ export function RainbowKitChainProvider({
           chains: provideRainbowKitChains(chains),
           initialChainId:
             typeof initialChain === 'number' ? initialChain : initialChain?.id,
+          ignoreChainModalOnConnect,
         }),
-        [chains, initialChain],
+        [chains, initialChain, ignoreChainModalOnConnect],
       )}
     >
       {children}
@@ -49,6 +54,9 @@ export const useRainbowKitChains = () =>
 
 export const useInitialChainId = () =>
   useContext(RainbowKitChainContext).initialChainId;
+
+export const useIgnoreChainModalOnConnect = () =>
+  useContext(RainbowKitChainContext).ignoreChainModalOnConnect;
 
 export const useRainbowKitChainsById = () => {
   const rainbowkitChains = useRainbowKitChains();

--- a/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
@@ -65,6 +65,7 @@ export interface RainbowKitProviderProps {
   avatar?: AvatarComponent;
   modalSize?: ModalSizes;
   locale?: Locale;
+  ignoreChainModalOnConnect?: boolean;
 }
 
 const defaultTheme = lightTheme();
@@ -80,6 +81,7 @@ export function RainbowKitProvider({
   modalSize = ModalSizeOptions.WIDE,
   showRecentTransactions = false,
   theme = defaultTheme,
+  ignoreChainModalOnConnect = false,
 }: RainbowKitProviderProps) {
   usePreloadImages();
   useFingerprint();
@@ -102,7 +104,10 @@ export function RainbowKitProvider({
   const avatarContext = avatar ?? defaultAvatar;
 
   return (
-    <RainbowKitChainProvider initialChain={initialChain}>
+    <RainbowKitChainProvider
+      initialChain={initialChain}
+      ignoreChainModalOnConnect={ignoreChainModalOnConnect}
+    >
       <WalletButtonProvider>
         <I18nProvider locale={locale}>
           <CoolModeContext.Provider value={coolMode}>


### PR DESCRIPTION
## Changes
- Now you can choose any chains even if your wallet is not connected.
- Works with `siwe`.
- During connection process, it automatically selects the chain you picked earlier. Or the one you set as your default `initialChain` instead.
- If you've set `initialChain`, the option to change networks will be hidden to prevent accidental switches.

## Screen recordings / screenshots

https://github.com/rainbow-me/rainbowkit/assets/53529533/cb5c5ccf-72eb-4e19-887f-b0ebb91f1707

## What to test
1. Try switching chains without connecting your wallet to see if it works.
2. While connecting your wallet, confirm it connects to the chain you chose.
3. Set `initialChain` and check if the chain button is no longer visible.
4. Make sure everything works well with `siwe`. Test this connecting to your wallet first and then you should see chain button dissapear. This prevents users from switching chains with their connected wallet when they are not signed in yet.