### PR TITLE
feat: `getChains` for custom rainbowkit chains (wagmi v2)

### DIFF
--- a/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
@@ -153,13 +153,27 @@ const chainMetadataById = Object.fromEntries(
     .map(({ chainId, ...metadata }) => [chainId, metadata]),
 );
 
-export const provideRainbowKitChains = (chains: readonly [Chain, ...Chain[]]) =>
-  chains.map((chain) => {
-    const defaultMetadata = chainMetadataById[chain.id] ?? {};
-    return {
-      ...chain,
-      name: defaultMetadata.name ?? chain.name, // Favor colloquial names
-      iconUrl: defaultMetadata.iconUrl,
-      iconBackground: defaultMetadata.iconBackground,
-    } as RainbowKitChain;
-  });
+const transformChainMetaData = (chain: RainbowKitChain) => {
+  const defaultMetadata = chainMetadataById[chain.id] ?? {};
+  return {
+    ...chain,
+    name: defaultMetadata.name ?? chain.name, // favor colloquial names
+    iconUrl: chain.iconUrl ?? defaultMetadata.iconUrl,
+    iconBackground: chain.iconBackground ?? defaultMetadata.iconBackground,
+  } as RainbowKitChain;
+};
+
+export const provideRainbowKitChains = (
+  chains: readonly [Chain, ...Chain[]],
+) => {
+  return chains.map(transformChainMetaData);
+};
+
+export const getChains = (
+  chains: readonly [RainbowKitChain, ...RainbowKitChain[]],
+): readonly [Chain, ...Chain[]] => {
+  const rainbowKitChains = provideRainbowKitChains(chains);
+
+  // Construct a tuple from the array as required by wagmi = readonly [Chain, ...Chain[]]
+  return [rainbowKitChains[0], ...rainbowKitChains.slice(1)];
+};

--- a/packages/rainbowkit/src/index.ts
+++ b/packages/rainbowkit/src/index.ts
@@ -15,6 +15,8 @@ export {
   RainbowKitAuthenticationProvider,
   createAuthenticationAdapter,
 } from './components/RainbowKitProvider/AuthenticationContext';
+export { getChains } from './components/RainbowKitProvider/provideRainbowKitChains';
+export type { RainbowKitChain as Chain } from './components/RainbowKitProvider/RainbowKitChainContext';
 export type {
   Wallet,
   WalletList,


### PR DESCRIPTION
## Changes
- Created `getChains` to create custom chains with `iconUrl` and `iconBackground` option
- Used `getChains` to have similar name as `getDefaultWallets` and `getDefaultConfig`

## Screen recordings / screenshots

https://github.com/rainbow-me/rainbowkit/assets/53529533/6608f4f5-1257-4520-a3c5-793b0f986863

## What to test
- Test with `getDefaultConfig`:
```
const chains = getChains([
  { ...mainnet, iconUrl: "<icon_url>", iconBackground: "<icon_background>" },
  { ...polygon, iconUrl: "<icon_url>", iconBackground: "<icon_background>" },
]);

const config = getDefaultConfig({
  appName: "RainbowKit Demo",
  projectId,
  chains
});
```
- Test with `createConfig`:

```
const chains = getChains([
  { ...mainnet, iconUrl: "<icon_url>", iconBackground: "<icon_background>" },
  { ...polygon, iconUrl: "<icon_url>", iconBackground: "<icon_background>" },
]);

const config = createConfig({
  chains,
  transports: {
    [mainnet.id]: http(),
    [polygon.id]: http(),
  },
});
```