### PR TITLE
fix: `connector.emitter.on` is not a function

### DIFF
--- a/packages/rainbowkit/src/components/RainbowKitProvider/AuthenticationContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/AuthenticationContext.tsx
@@ -86,17 +86,23 @@ export function RainbowKitAuthenticationProvider<Message = unknown>({
   // Wait for user authentication before listening to "change" event.
   // Avoid listening immediately after wallet connection due to potential SIWE authentication delay.
   // Ensure to turn off the "change" event listener for cleanup.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
-    if (connector && status === 'authenticated') {
+    // Wagmi renders emitter's partially on page load. We wanna make sure
+    // the event emitters gets updated before proceeding
+    if (
+      typeof connector?.emitter?.on === 'function' &&
+      status === 'authenticated'
+    ) {
       // Attach the event listener when status is 'authenticated'
-      connector.emitter?.on?.('change', handleChangedAccount);
+      connector.emitter.on('change', handleChangedAccount);
 
       // Cleanup function to remove the event listener
       return () => {
-        connector.emitter?.off?.('change', handleChangedAccount);
+        connector.emitter.off('change', handleChangedAccount);
       };
     }
-  }, [connector, status, handleChangedAccount]);
+  }, [connector?.emitter, status]);
 
   return (
     <AuthenticationContext.Provider


### PR DESCRIPTION
## Changes
- `connector.emitter` renders partially during page load. Made sure to check if the `emitter` has an `on` event before proceeding.

## Screen recordings / screenshots
Example from wagmi's boilerplate app.

https://github.com/rainbow-me/rainbowkit/assets/53529533/12577182-b8dd-4a81-bab2-ee61c01bd0ae

## What to test
- Open your brave browser
- Lock your "brave wallet" if you have one
- Have metamask installed and rabby wallet installed, but make sure rabby wallet is disabled in the "extensions"
- Connect your wallet with the "injected" connector instead of eip6963 one and refresh the page
- If it doesn't crash you're good 👍