### PR TITLE
fix: transaction pending forever if not found

### DIFF
--- a/.changeset/wise-rivers-hammer.md
+++ b/.changeset/wise-rivers-hammer.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Fixed a bug in the account modal transactions section, where transactions that were 'not found' were incorrectly shown as 'pending' instead of 'failed'.
+Fixed a bug in the account modal transactions section where transactions that were not found or cancelled were incorrectly shown as 'pending' instead of 'failed'.

--- a/.changeset/wise-rivers-hammer.md
+++ b/.changeset/wise-rivers-hammer.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fixed a bug in the account modal transactions section, where transactions that were 'not found' were incorrectly shown as 'pending' instead of 'failed'.

--- a/packages/rainbowkit/src/transactions/transactionStore.ts
+++ b/packages/rainbowkit/src/transactions/transactionStore.ts
@@ -127,7 +127,6 @@ export function createTransactionStore({
         .filter((transaction) => transaction.status === 'pending')
         .map(async (transaction) => {
           const { confirmations, hash } = transaction;
-
           const existingRequest = transactionRequestCache.get(hash);
 
           if (existingRequest) {
@@ -135,7 +134,11 @@ export function createTransactionStore({
           }
 
           const requestPromise = provider
-            .waitForTransactionReceipt({ confirmations, hash: hash as Address })
+            .waitForTransactionReceipt({
+              confirmations,
+              hash: hash as Address,
+              timeout: 300_000, // 5 minutes
+            })
             .then(({ status }) => {
               transactionRequestCache.delete(hash);
 

--- a/packages/rainbowkit/src/transactions/transactionStore.ts
+++ b/packages/rainbowkit/src/transactions/transactionStore.ts
@@ -150,6 +150,12 @@ export function createTransactionStore({
                 // @ts-ignore - types changed with viem@1.1.0
                 status === 0 || status === 'reverted' ? 'failed' : 'confirmed',
               );
+            })
+            .catch(() => {
+              // If a transaction is not found or cancelled
+              // viem will throw a 'TransactionNotFoundError'.
+              // In this case it should mark the transaction as 'failed'
+              setTransactionStatus(account, chainId, hash, 'failed');
             });
 
           transactionRequestCache.set(hash, requestPromise);


### PR DESCRIPTION
## Changes
- Cancelled transactions or transactions that don't exist will now be shown as `failed` in our rainbowkit account modal. Currently it shows as `pending` forever.

- Implemented a maximum timeout of 5 minutes. This means if a transaction verification takes longer than 5 minutes, we will cancel it and mark it as `failed`. Most transactions (about 95%) complete in under 5 minutes. This change is made due to the fact that some RPC providers like alchemy may attempt to verify indefinitely while public provider errors after a few seconds. This depends fully on the provider. 

## Screen recordings / screenshots

https://github.com/rainbow-me/rainbowkit/assets/53529533/b4b81e0b-8f24-4f87-98e8-4472e6cd5212

## What to test
- Get a cancelled or non existing transaction. [Here is cancelled sepolia transaction](https://sepolia.etherscan.io/tx/0x2fb26af26c8e825fffc99c3067138ec66216e85cd5a8dda56223d98bf76f6465) and [non existing mainnet transaction](https://etherscan.io/tx/0x3e7afee93ac5a71451ee682ca9db8334c79b2e2c08c3870b2e5cec1b59d81351)
- Paste it in the [rainbowkit example](https://rainbowkit-example.vercel.app/) and wait for 5 minutes and see if it fails. Easier way is to test locally and only use `publicProvider` instead of `alchemyProvider` [here](https://github.com/rainbow-me/rainbowkit/blob/main/packages/example/pages/_app.tsx#L117). While you're using the `publicProvider` follow the same step. Paste in transaction hash and watch transaction fail after a few seconds.