### PR TITLE
fix: set `connectModalOpen` state to `false` after a successful `siwe` login

### DIFF
--- a/.changeset/eighty-poets-clap.md
+++ b/.changeset/eighty-poets-clap.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fixed a bug where the `connectModalOpen` state incorrectly remained `true` after a successful `siwe` authentication. This fix ensures that `connectModalOpen` shows the correct state.

--- a/packages/rainbowkit/src/components/ConnectModal/ConnectModal.tsx
+++ b/packages/rainbowkit/src/components/ConnectModal/ConnectModal.tsx
@@ -46,7 +46,7 @@ export function ConnectModal({ onClose, open }: ConnectModalProps) {
     return (
       <Dialog onClose={onAuthCancel} open={open} titleId={titleId}>
         <DialogContent bottomSheetOnMobile padding="0">
-          <SignIn onClose={onAuthCancel} />
+          <SignIn onClose={onAuthCancel} onCloseModal={onClose} />
         </DialogContent>
       </Dialog>
     );

--- a/packages/rainbowkit/src/components/SignIn/SignIn.tsx
+++ b/packages/rainbowkit/src/components/SignIn/SignIn.tsx
@@ -96,7 +96,13 @@ export function SignIn({ onClose }: { onClose: () => void }) {
       try {
         const verified = await authAdapter.verify({ message, signature });
 
-        if (verified) return;
+        if (verified) {
+          // This will ensure that 'connectModalOpen' state doesn't
+          // stay to true after a successful authentication
+          onClose();
+          return;
+        }
+
         throw new Error();
       } catch {
         return setState((x) => ({

--- a/packages/rainbowkit/src/components/SignIn/SignIn.tsx
+++ b/packages/rainbowkit/src/components/SignIn/SignIn.tsx
@@ -13,7 +13,13 @@ import { Text } from '../Text/Text';
 
 export const signInIcon = async () => (await import('./sign.png')).default;
 
-export function SignIn({ onClose }: { onClose: () => void }) {
+export function SignIn({
+  onClose,
+  onCloseModal,
+}: {
+  onClose: () => void;
+  onCloseModal: () => void;
+}) {
   const { i18n } = useContext(I18nContext);
   const [{ status, ...state }, setState] = React.useState<{
     status: 'idle' | 'signing' | 'verifying';
@@ -99,7 +105,7 @@ export function SignIn({ onClose }: { onClose: () => void }) {
         if (verified) {
           // This will ensure that 'connectModalOpen' state doesn't
           // stay to true after a successful authentication
-          onClose();
+          onCloseModal();
           return;
         }
 


### PR DESCRIPTION
## Changes
- Setting `connectModalOpen` to `false` after a successful `siwe` login 
 
## Screen recordings / screenshots

https://github.com/rainbow-me/rainbowkit/assets/53529533/51c6891d-579b-4176-b2eb-d52166e960b9

## What to test
1. Go to the [rainbowkit preview example app](https://rainbowkit-example-p1d6ncuf4-rainbowdotme.vercel.app/)
2. Make sure to checkbox the `authentication` box
3. Connect your wallet and sign in
4. After a successful login make sure it says `Open connect modal` with a disabled button in the `Modal hooks` section