### PR TITLE
fix: wallet icons selectable on connect modal (iOS)

### DIFF
--- a/.changeset/yellow-moons-move.md
+++ b/.changeset/yellow-moons-move.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fixed a bug that allowed users to hold and select wallet icons on the connect modal in iOS.

--- a/.changeset/yellow-moons-move.md
+++ b/.changeset/yellow-moons-move.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Fixed a bug that allowed users to hold and select wallet icons on the connect modal in iOS.
+Fixed a bug that allowed users to hold-press or cursor select wallet icons on iOS, which interrupted the connection experiencce.

--- a/packages/rainbowkit/src/components/AsyncImage/AsyncImage.tsx
+++ b/packages/rainbowkit/src/components/AsyncImage/AsyncImage.tsx
@@ -66,6 +66,7 @@ export function AsyncImage({
             })}
         height="full"
         position="absolute"
+        WebkitUserSelect="none"
         style={{
           touchCallout: 'none',
           transition: 'opacity .15s linear',

--- a/packages/rainbowkit/src/components/AsyncImage/AsyncImage.tsx
+++ b/packages/rainbowkit/src/components/AsyncImage/AsyncImage.tsx
@@ -1,4 +1,5 @@
 import React, { useReducer } from 'react';
+import { isIOS } from '../../utils/isMobile';
 import { Box, BoxProps } from '../Box/Box';
 import { AsyncImageSrc, useAsyncImage } from './useAsyncImage';
 
@@ -28,6 +29,7 @@ export function AsyncImage({
   width,
   testId,
 }: AsyncImageProps) {
+  const ios = isIOS();
   const src = useAsyncImage(srcProp);
   const isRemoteImage = src && /^http/.test(src);
   const [isRemoteImageLoaded, setRemoteImageLoaded] = useReducer(
@@ -66,7 +68,7 @@ export function AsyncImage({
             })}
         height="full"
         position="absolute"
-        WebkitUserSelect="none"
+        {...(ios ? { WebkitUserSelect: 'none' } : {})}
         style={{
           touchCallout: 'none',
           transition: 'opacity .15s linear',

--- a/packages/rainbowkit/src/css/sprinkles.css.ts
+++ b/packages/rainbowkit/src/css/sprinkles.css.ts
@@ -211,6 +211,7 @@ const unresponsiveProperties = defineProperties({
     paddingRight: spacing,
     paddingTop: spacing,
     position: ['absolute', 'fixed', 'relative'],
+    WebkitUserSelect: ['none'],
     right: {
       '0': '0',
     },


### PR DESCRIPTION
## Changes
- The wallet icons on the connect modal were selectable in iOS, but is fixed in this PR.

## What to test
1. Open the current [PR preview link](https://rainbowkit-example-3a7dnkanr-rainbowdotme.vercel.app/) on iOS
2. Make sure the wallet icons are not selectable on connect modal