### PR TITLE
fix: update manual setup to only show `1.x.x` version of wagmi and viem

### DIFF
--- a/.changeset/popular-penguins-smile.md
+++ b/.changeset/popular-penguins-smile.md
@@ -1,0 +1,5 @@
+---
+"site": patch
+---
+
+In the "Manual setup" section of the "Installation" page now shows to install `wagmi@1` and `viem@1`. This is because the latest `wagmi` and `viem` version is not compatible with the latest version `1.3.3` of rainbowkit.

--- a/site/data/ar/docs/installation.mdx
+++ b/site/data/ar/docs/installation.mdx
@@ -28,7 +28,7 @@ yarn create @rainbow-me/rainbowkit
 ثبت RainbowKit وإعتمادياته المشتركة، [wagmi](https://wagmi.sh/) و [viem](https://viem.sh).
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > ملاحظة: تعتبر RainbowKit مكتبة لـ [React](https://reactjs.org/).

--- a/site/data/en-US/docs/installation.mdx
+++ b/site/data/en-US/docs/installation.mdx
@@ -28,7 +28,7 @@ Alternatively, you can manually integrate RainbowKit into your existing project.
 Install RainbowKit and its peer dependencies, [wagmi](https://wagmi.sh/) and [viem](https://viem.sh).
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > Note: RainbowKit is a [React](https://reactjs.org/) library.

--- a/site/data/es-419/docs/installation.mdx
+++ b/site/data/es-419/docs/installation.mdx
@@ -28,7 +28,7 @@ Alternativamente, puedes integrar manualmente RainbowKit en tu proyecto existent
 Instala RainbowKit y sus dependencias de igual nivel, [wagmi](https://wagmi.sh/) y [viem](https://viem.sh).
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > Nota: RainbowKit es una biblioteca de [React](https://reactjs.org/).

--- a/site/data/fr/docs/installation.mdx
+++ b/site/data/fr/docs/installation.mdx
@@ -28,7 +28,7 @@ Alternativement, vous pouvez intégrer manuellement RainbowKit dans votre projet
 Installez RainbowKit et ses dépendances associées, [wagmi](https://wagmi.sh/) et [viem](https://viem.sh).
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > Remarque : RainbowKit est une bibliothèque [React](https://reactjs.org/).

--- a/site/data/hi/docs/installation.mdx
+++ b/site/data/hi/docs/installation.mdx
@@ -28,7 +28,7 @@ yarn create @rainbow-me/rainbowkit
 RainbowKit और उसके साथी निर्भरताओं, [wagmi](https://wagmi.sh/) और [viem](https://viem.sh) की स्थापना करें।
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > नोट: RainbowKit एक [React](https://reactjs.org/) पुस्तकालय है।

--- a/site/data/id/docs/installation.mdx
+++ b/site/data/id/docs/installation.mdx
@@ -28,7 +28,7 @@ Alternatifnya, Anda dapat mengintegrasikan RainbowKit secara manual ke dalam pro
 Instal RainbowKit dan peer dependenciesnya, [wagmi](https://wagmi.sh/) and [viem](https://viem.sh).
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > Catatan: RainbowKit adalah pustaka [React](https://reactjs.org/).

--- a/site/data/ja/docs/installation.mdx
+++ b/site/data/ja/docs/installation.mdx
@@ -28,7 +28,7 @@ yarn create @rainbow-me/rainbowkit
 RainbowKitおよびそのピア依存関係、 [wagmi](https://wagmi.sh/) と [viem](https://viem.sh)をインストールします。
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > 注: RainbowKitは [React](https://reactjs.org/) ライブラリです。

--- a/site/data/ko/docs/installation.mdx
+++ b/site/data/ko/docs/installation.mdx
@@ -28,7 +28,7 @@ yarn create @rainbow-me/rainbowkit
 RainbowKit와 그 피어 종속성인 [wagmi](https://wagmi.sh/)와 [viem](https://viem.sh)을 설치하세요.
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > 참고: RainbowKit는 [React](https://reactjs.org/) 라이브러리입니다.

--- a/site/data/pt-BR/docs/installation.mdx
+++ b/site/data/pt-BR/docs/installation.mdx
@@ -28,7 +28,7 @@ Alternativamente, você pode integrar manualmente o RainbowKit ao seu projeto ex
 Instale o RainbowKit e suas dependências, [wagmi](https://wagmi.sh/) e [viem](https://viem.sh).
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > Nota: RainbowKit é uma biblioteca [React](https://reactjs.org/).

--- a/site/data/ru/docs/installation.mdx
+++ b/site/data/ru/docs/installation.mdx
@@ -28,7 +28,7 @@ yarn create @rainbow-me/rainbowkit
 Установите RainbowKit и его зависимости [wagmi](https://wagmi.sh/) и [viem](https://viem.sh).
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > Примечание: RainbowKit - это библиотека [React](https://reactjs.org/).

--- a/site/data/th/docs/installation.mdx
+++ b/site/data/th/docs/installation.mdx
@@ -28,7 +28,7 @@ yarn create @rainbow-me/rainbowkit
 ติดตั้ง RainbowKit และ peer dependencies ที่ต้องการ [wagmi](https://wagmi.sh/) and [viem](https://viem.sh).
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > หมายเหตุ: RainbowKit เป็นคลังภาพ [React](https://reactjs.org/)

--- a/site/data/tr/docs/installation.mdx
+++ b/site/data/tr/docs/installation.mdx
@@ -28,7 +28,7 @@ Alternatif olarak, RainbowKit'i mevcut projenize manuel olarak entegre edebilirs
 RainbowKit ve peer bağımlılıklarını kurun, [wagmi](https://wagmi.sh/) ve [viem](https://viem.sh).
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > Not: RainbowKit, bir [React](https://reactjs.org/) kütüphanesidir.

--- a/site/data/ua/docs/installation.mdx
+++ b/site/data/ua/docs/installation.mdx
@@ -28,7 +28,7 @@ yarn create @rainbow-me/rainbowkit
 Встановіть RainbowKit та його супутні залежності, [wagmi](https://wagmi.sh/) та [viem](https://viem.sh).
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > Примітка: RainbowKit - це бібліотека [React](https://reactjs.org/).

--- a/site/data/zh-CN/docs/installation.mdx
+++ b/site/data/zh-CN/docs/installation.mdx
@@ -28,7 +28,7 @@ yarn create @rainbow-me/rainbowkit
 安装RainbowKit及其对等依赖项， [wagmi](https://wagmi.sh/) 和 [viem](https://viem.sh).
 
 ```bash
-npm install @rainbow-me/rainbowkit wagmi viem
+npm install @rainbow-me/rainbowkit wagmi@1 viem@1
 ```
 
 > 注意：RainbowKit 是一个 [React](https://reactjs.org/) 库。


### PR DESCRIPTION
## Changes
- "Manual setup" section of the "Installation" page now shows to install `wagmi@1` and `viem@1`. This is because the latest `wagmi` and `viem` version is not compatible with the latest version `1.3.3` of rainbowkit.

## What to test
1. Make sure it shows `npm install @rainbow-me/rainbowkit wagmi@1 viem@1`