### PR TITLE
chore: specify wagmi parameters in getDefaultConfig

### DIFF
--- a/packages/rainbowkit/src/config/getDefaultConfig.ts
+++ b/packages/rainbowkit/src/config/getDefaultConfig.ts
@@ -1,5 +1,5 @@
 import { Transport } from 'viem';
-import { http } from 'wagmi';
+import { http, CreateConfigParameters } from 'wagmi';
 import { WagmiProviderProps, createConfig } from 'wagmi';
 import { type Chain } from 'wagmi/chains';
 import type { WalletList } from '../wallets/Wallet';
@@ -18,16 +18,21 @@ export type _chains = readonly [Chain, ...Chain[]];
 // It maps each 'Chain' id to a 'Transport'
 export type _transports = Record<_chains[number]['id'], Transport>;
 
-interface GetDefaultConfigParameters {
+type WagmiConfigParameters = Omit<
+  CreateConfigParameters<_chains, _transports>,
+  // If you use 'client' you can't use 'transports' (we force to use 'transports')
+  // More info here https://wagmi.sh/core/api/createConfig#client
+  // We will also use our own 'connectors' instead of letting user specifying it
+  'client' | 'connectors'
+>;
+
+interface GetDefaultConfigParameters extends WagmiConfigParameters {
   appName: string;
   appDescription?: string;
   appUrl?: string;
   appIcon?: string;
   wallets?: WalletList;
   projectId: string;
-  chains: _chains;
-  transports?: _transports;
-  multiInjectedProviderDiscovery?: boolean;
 }
 
 const createDefaultTransports = (chains: _chains): _transports => {
@@ -47,10 +52,10 @@ export const getDefaultConfig = ({
   appIcon,
   wallets,
   projectId,
-  chains,
-  multiInjectedProviderDiscovery = true,
-  transports,
+  ...wagmiParameters
 }: GetDefaultConfigParameters): WagmiProviderProps['config'] => {
+  let { transports, chains, ...restWagmiParameters } = wagmiParameters;
+
   const metadata = computeWalletConnectMetaData({
     appName,
     appDescription,
@@ -88,6 +93,6 @@ export const getDefaultConfig = ({
     connectors,
     chains,
     transports,
-    multiInjectedProviderDiscovery,
+    ...restWagmiParameters,
   });
 };


### PR DESCRIPTION
## Changes
- `getDefaultConfig` now supports all wagmi parameters apart from `connectors` and `client` params

## What to test
Test with `getDefaultConfig`:
```
import { getDefaultConfig } from "@rainbow-me/rainbowkit";
import { mainnet } from "wagmi/chains";

const config = getDefaultConfig({
  appName: "RainbowKit App",
  projectId: "YOUR_PROJECT_ID",
  chains: [mainnet],
  ...wagmiParameters, // Specify your own wagmi config parameters
});
```

_We won't expose `connectors` as part of the parameter since we will append that into `createConfig` ourselves and `client` is also not exposed since we then can't use `transports`. More info [here](https://wagmi.sh/core/api/createConfig#client)_