### PR TITLE
chore: refactor change modal and test file

### DIFF
--- a/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
+++ b/packages/rainbowkit/src/components/ChainModal/ChainModal.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { useChainId, useDisconnect, useSwitchChain } from 'wagmi';
+import { useAccount, useDisconnect, useSwitchChain } from 'wagmi';
 import { useConfig } from 'wagmi';
 import { isMobile } from '../../utils/isMobile';
 import { Box } from '../Box/Box';
@@ -23,7 +23,7 @@ export interface ChainModalProps {
 }
 
 export function ChainModal({ onClose, open }: ChainModalProps) {
-  const chainId = useChainId();
+  const { chainId } = useAccount();
   const { chains } = useConfig();
   const [pendingChainId, setPendingChainId] = useState<number | null>(null);
   const { switchChain } = useSwitchChain({


### PR DESCRIPTION
## Changes
- Instead of using chain id from wagmi's state use the current chain id from the connected connector. The chain id can be fetched from `useAccount` hook.
- Refactor test file `ChainModal.test.tsx`
 
 