### PR TITLE
fix: `showBalance` boolean support with `eth_getBalance` RPC logic

### DIFF
--- a/.changeset/thin-jokes-enjoy.md
+++ b/.changeset/thin-jokes-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fixed a bug where `showBalance` prop on the `<ConnectButton />` didn't work right if you used a boolean instead of responsive object values. `createNormalizeValueFn` from `@vanilla-extract/sprinkles` doesn't return `largeScreen` responsive value if a boolean was specified.

--- a/.changeset/thin-jokes-enjoy.md
+++ b/.changeset/thin-jokes-enjoy.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Fixed a bug where `showBalance` prop on the `<ConnectButton />` didn't work right if you used a boolean instead of responsive object values. `createNormalizeValueFn` from `@vanilla-extract/sprinkles` doesn't return `largeScreen` responsive value if a boolean was specified.
+Fixed a bug where the `showBalance` prop on `<ConnectButton />` didn't accept a boolean, and had only accepted responsive modal values.

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
@@ -86,11 +86,23 @@ export function ConnectButtonRenderer({
     showRecentTransactions;
 
   const { showBalance } = useShowBalance();
-  const shouldShowBalance = showBalance
-    ? normalizeResponsiveValue(showBalance)[
+
+  const computeShouldShowBalance = () => {
+    if (typeof showBalance === 'boolean') {
+      return showBalance;
+    }
+
+    if (showBalance) {
+      return normalizeResponsiveValue(showBalance)[
         isMobile() ? 'smallScreen' : 'largeScreen'
-      ]
-    : true;
+      ];
+    }
+
+    return true;
+  };
+
+  const shouldShowBalance = computeShouldShowBalance();
+
   const { data: balanceData } = useBalance({
     address: shouldShowBalance ? address : undefined,
   });


### PR DESCRIPTION
## Changes
- Fixed a bug where `showBalance` prop on the `<ConnectButton />` didn't work right if you used a boolean instead of responsive object values.

## What to test
1. Make sure to not have two `<ConnectButton />` component at the same time when testing.
2. Make sure the `showBalance` boolean behaviour works as expected and make sure it either calls `eth_getBalance` in the network tab or not based on `true` or `false` boolean:
```
<ConnectButton
  showBalance={true} // or false
/>
```
3. Also make sure the responsive object values work as expected without any breaks:
`<ConnectButton showBalance={{ largeScreen: true, smallScreen: false }} />`



_Note: `createNormalizeValueFn` from `@vanilla-extract/sprinkles` doesn't return `largeScreen` responsive value if a boolean is specified._
