### PR TITLE
chore: update coin98 wallet provider and support EIP-6963

### DIFF
--- a/.changeset/wild-suns-vanish.md
+++ b/.changeset/wild-suns-vanish.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Updated `coin98Wallet` window provider and added `rdns` for EIP-6963 support.
+Added EIP-6963 support for `coin98Wallet` wallet connector

--- a/.changeset/wild-suns-vanish.md
+++ b/.changeset/wild-suns-vanish.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Updated `coin98Wallet` window provider and added `rdns` for EIP-6963 support.

--- a/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
@@ -12,9 +12,10 @@ export const coin98Wallet = ({
   walletConnectParameters,
 }: Coin98WalletOptions): Wallet => {
   const isCoin98WalletInjected = hasInjectedProvider({
-    namespace: 'coin98Wallet',
+    namespace: 'coin98.provider',
     flag: 'isCoin98',
   });
+
   const shouldUseWalletConnect = !isCoin98WalletInjected;
   return {
     id: 'coin98',
@@ -23,6 +24,7 @@ export const coin98Wallet = ({
     installed: isCoin98WalletInjected,
     iconAccent: '#CDA349',
     iconBackground: '#fff',
+    rdns: 'coin98.com',
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=coin98.crypto.finance.media',


### PR DESCRIPTION
## Changes
- Updated coin98 wallet to use another `window.ethereum` provider
- Added `rdns` for EIP-6963 support

## What to test
1. Install Coin98 wallet [here](https://chromewebstore.google.com/detail/coin98-wallet/aeachknmefphepccionboohckonoeemg)
2. Once installed visit [rainbowkit.com](https://www.rainbowkit.com/)
3. Go to inspect element -> console -> type in `window.coin98.provider` and see if you get the provider. At the moment we use `window.coin98Wallet` which is `undefined`