### PR TITLE
fix: use relative links

### DIFF
--- a/packages/create-rainbowkit/generated-test-app/README.md
+++ b/packages/create-rainbowkit/generated-test-app/README.md
@@ -1,4 +1,4 @@
-This is a [RainbowKit](https://rainbowkit.com) + [wagmi](https://wagmi.sh) + [Next.js](https://nextjs.org/) project bootstrapped with [`create-rainbowkit`](https://github.com/rainbow-me/rainbowkit/tree/main/packages/create-rainbowkit).
+This is a [RainbowKit](https://rainbowkit.com) + [wagmi](https://wagmi.sh) + [Next.js](https://nextjs.org/) project bootstrapped with [`create-rainbowkit`](/packages/create-rainbowkit).
 
 ## Getting Started
 

--- a/packages/create-rainbowkit/templates/next-app/README.md
+++ b/packages/create-rainbowkit/templates/next-app/README.md
@@ -1,4 +1,4 @@
-This is a [RainbowKit](https://rainbowkit.com) + [wagmi](https://wagmi.sh) + [Next.js](https://nextjs.org/) project bootstrapped with [`create-rainbowkit`](https://github.com/rainbow-me/rainbowkit/tree/main/packages/create-rainbowkit).
+This is a [RainbowKit](https://rainbowkit.com) + [wagmi](https://wagmi.sh) + [Next.js](https://nextjs.org/) project bootstrapped with [`create-rainbowkit`](/packages/create-rainbowkit).
 
 ## Getting Started
 

--- a/packages/rainbowkit-siwe-next-auth/CHANGELOG.md
+++ b/packages/rainbowkit-siwe-next-auth/CHANGELOG.md
@@ -50,7 +50,7 @@
 
   1. Upgrade `next-auth` to `~4.22.0`
 
-  2. In your `next-auth` providers `async authorize(credentials)` implementation, alter the parameters passed to `getCsrfToken` like so. Reference our example implementation [here](https://github.com/rainbow-me/rainbowkit/tree/main/examples/with-next-siwe-next-auth).
+  2. In your `next-auth` providers `async authorize(credentials)` implementation, alter the parameters passed to `getCsrfToken` like so. Reference our example implementation [here](/examples/with-next-siwe-next-auth).
 
   ```ts
   - const nonce = await getCsrfToken({ req });

--- a/packages/rainbowkit/CHANGELOG.md
+++ b/packages/rainbowkit/CHANGELOG.md
@@ -833,7 +833,7 @@
 
 ### Patch Changes
 
-- 9432a2f: The `ConnectButton` component is now tagged with `use client;` to support the Next 13 App Router and server-side rendered dApps. You can reference a full `app/` directory implementation example [here](https://github.com/rainbow-me/rainbowkit/tree/main/examples/with-next-app).
+- 9432a2f: The `ConnectButton` component is now tagged with `use client;` to support the Next 13 App Router and server-side rendered dApps. You can reference a full `app/` directory implementation example [here](/examples/with-next-app).
 - b2c66ff: Modified acceptable peer dependency versions to ensure proper peer warnings for future versions of wagmi and viem. `wagmi` now requires `~1.0.1` and `viem` now requires `~0.3.19`.
 - bcb3d18: Modal Hooks including `useConnectModal`, `useAccountModal`, and `useChainModal` now each return a boolean with the status of the modal.
 


### PR DESCRIPTION
Using relative links as per [this wiki](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#relative-links)

I believe it's cleaner just in case there's a change to the org/repo name, etc.