### PR TITLE
fix: enable ens fetching only if `mainnet` is configured

### DIFF
--- a/.changeset/popular-ducks-travel.md
+++ b/.changeset/popular-ducks-travel.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fixed a bug where wagmi would throw `ChainNotConfiguredError` if `mainnet` is not configured as a chain. This is happening when fetching ens name and ens avatar.

--- a/packages/rainbowkit/src/hooks/useIsMainnetConfigured.ts
+++ b/packages/rainbowkit/src/hooks/useIsMainnetConfigured.ts
@@ -1,0 +1,14 @@
+import { mainnet } from 'wagmi/chains';
+import { useRainbowKitChains } from '../components/RainbowKitProvider/RainbowKitChainContext';
+
+export function useIsMainnetConfigured() {
+  const rainbowKitChains = useRainbowKitChains();
+
+  const chainId = mainnet.id;
+
+  const configured = rainbowKitChains.some(
+    (rainbowKitChain) => rainbowKitChain.id === chainId,
+  );
+
+  return configured;
+}

--- a/packages/rainbowkit/src/hooks/useMainnetEnsAvatar.ts
+++ b/packages/rainbowkit/src/hooks/useMainnetEnsAvatar.ts
@@ -1,11 +1,17 @@
 import { GetEnsNameReturnType, normalize } from 'viem/ens';
 import { useEnsAvatar } from 'wagmi';
 import { mainnet } from 'wagmi/chains';
+import { useIsMainnetConfigured } from './useIsMainnetConfigured';
 
 export function useMainnetEnsAvatar(name: GetEnsNameReturnType | undefined) {
+  const mainnetConfigured = useIsMainnetConfigured();
+
   const { data: ensAvatar } = useEnsAvatar({
     chainId: mainnet.id,
     name: name ? normalize(name) : undefined,
+    query: {
+      enabled: mainnetConfigured,
+    },
   });
 
   return ensAvatar;

--- a/packages/rainbowkit/src/hooks/useMainnetEnsName.ts
+++ b/packages/rainbowkit/src/hooks/useMainnetEnsName.ts
@@ -1,11 +1,17 @@
 import { Address } from 'viem';
 import { useEnsName } from 'wagmi';
 import { mainnet } from 'wagmi/chains';
+import { useIsMainnetConfigured } from './useIsMainnetConfigured';
 
 export function useMainnetEnsName(address: Address | undefined) {
+  const mainnetConfigured = useIsMainnetConfigured();
+
   const { data: ensName } = useEnsName({
     chainId: mainnet.id,
     address,
+    query: {
+      enabled: mainnetConfigured,
+    },
   });
 
   return ensName;


### PR DESCRIPTION
## Changes
- If `mainnet` is not configured and cache is cleared you might get thrown with `ChainNotConfiguredError`
 