### PR TITLE
chore: `injectedWallet` on mobile detection & cleanup connectors code

### DIFF
--- a/.changeset/weak-bears-brush.md
+++ b/.changeset/weak-bears-brush.md
@@ -1,0 +1,60 @@
+---
+"@rainbow-me/rainbowkit": patch
+"site": patch
+---
+
+`injectedWallet` gets added on its own if `window.ethereum` is found on mobile and it's not already on the custom wallet list. This way, you don't have to use WalletConnect if you don't need to and can stick with the built-in provider `window.ethereum` instead.
+
+You can also set `injectedWalletOnMobile` to `false` if you prefer not to use this feature. This can be done in `getDefaultConfig` as the first parameter or in `connectorsForWallets` as the second parameter.
+
+Example with `getDefaultConfig`
+
+```tsx
+import { getDefaultConfig } from "@rainbow-me/rainbowkit";
+import { argentWallet } from "@rainbow-me/rainbowkit/wallets";
+import { mainnet } from "wagmi/chains";
+
+const config = getDefaultConfig({
+  appName: "RainbowKit demo",
+  projectId: "YOUR_PROJECT_ID",
+  wallets: [
+    {
+      groupName: "Other",
+      wallets: [argentWallet],
+    },
+  ],
+  chains: [mainnet],
+  injectedWalletOnMobile: false, // <- add 'false' here
+});
+```
+
+Example with `connectorsForWallets`
+
+```tsx
+import { connectorsForWallets, getDefaultConfig } from "@rainbow-me/rainbowkit";
+import { argentWallet } from "@rainbow-me/rainbowkit/wallets";
+import { createConfig, http } from "wagmi";
+import { mainnet } from "wagmi/chains";
+
+const connectors = connectorsForWallets(
+  [
+    {
+      groupName: "Other",
+      wallets: [argentWallet],
+    },
+  ],
+  {
+    appName: "RainbowKit demo",
+    projectId: "YOUR_PROJECT_ID",
+    injectedWalletOnMobile: false, // <- add 'false' here
+  }
+);
+
+const config = createConfig({
+  connectors,
+  chains: [mainnet],
+  transports: {
+    [mainnet.id]: http(),
+  },
+});
+```

--- a/packages/rainbowkit/src/config/getDefaultConfig.ts
+++ b/packages/rainbowkit/src/config/getDefaultConfig.ts
@@ -33,6 +33,7 @@ interface GetDefaultConfigParameters extends WagmiConfigParameters {
   appIcon?: string;
   wallets?: WalletList;
   projectId: string;
+  injectedWalletOnMobile?: boolean;
 }
 
 const createDefaultTransports = (chains: _chains): _transports => {
@@ -52,6 +53,7 @@ export const getDefaultConfig = ({
   appIcon,
   wallets,
   projectId,
+  injectedWalletOnMobile,
   ...wagmiParameters
 }: GetDefaultConfigParameters): WagmiProviderProps['config'] => {
   let { transports, chains, ...restWagmiParameters } = wagmiParameters;
@@ -82,6 +84,7 @@ export const getDefaultConfig = ({
       appUrl,
       appIcon,
       walletConnectParameters: { metadata },
+      injectedWalletOnMobile,
     },
   );
 

--- a/packages/rainbowkit/src/wallets/Wallet.ts
+++ b/packages/rainbowkit/src/wallets/Wallet.ts
@@ -104,7 +104,6 @@ export type RainbowKitWalletConnectParameters = Omit<
 >;
 
 export type RainbowKitDetails = Omit<Wallet, 'createConnector' | 'hidden'> & {
-  index: number;
   groupIndex: number;
   groupName: string;
   isWalletConnectModalConnector?: boolean;

--- a/packages/rainbowkit/src/wallets/connectorsForWallets.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.ts
@@ -23,17 +23,19 @@ export interface ConnectorsForWalletsParameters {
   appUrl?: string;
   appIcon?: string;
   walletConnectParameters?: RainbowKitWalletConnectParameters;
+  injectedWalletOnMobile?: boolean;
 }
 
 export const connectorsForWallets = (
   walletList: WalletList,
   {
     projectId,
-    walletConnectParameters,
+    walletConnectParameters = {},
     appName,
     appDescription,
     appUrl,
     appIcon,
+    injectedWalletOnMobile = true,
   }: ConnectorsForWalletsParameters,
 ): CreateConnectorFn[] => {
   const connectors: CreateConnectorFn[] = [];
@@ -101,7 +103,12 @@ export const connectorsForWallets = (
   // If you use a browser wallet, we add the injectedWallet to the wallet list
   // if you haven't added one yet. This would avoid using WalletConnect when
   // not needed and only use built in injected provider (window.ethereum)
-  if (mobile && typeof window !== 'undefined' && window.ethereum) {
+  if (
+    mobile &&
+    typeof window !== 'undefined' &&
+    window.ethereum &&
+    injectedWalletOnMobile
+  ) {
     const isInjectedWalletIncluded = walletListItems.some(
       (walletItem) => walletItem.id === 'injected',
     );

--- a/packages/rainbowkit/src/wallets/connectorsForWallets.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.ts
@@ -181,5 +181,5 @@ export const connectorsForWallets = (
     connectors.push(connector);
   }
 
-  return [...connectors];
+  return connectors;
 };

--- a/site/data/en-US/docs/custom-wallet-list.mdx
+++ b/site/data/en-US/docs/custom-wallet-list.mdx
@@ -78,7 +78,11 @@ import { walletConnectWallet } from '@rainbow-me/rainbowkit/wallets';
 
 ##### Injected Wallet
 
-This is a fallback wallet option designed for scenarios where `window.ethereum` exists but hasn’t been provided by another wallet in the list. This wallet will automatically hide itself from the list when the fallback is not necessary or if there is no injected wallet available.
+This is a fallback wallet option designed for scenarios where `window.ethereum` exists.
+
+If you're on mobile and `window.ethereum` exist, but the wallet isn't in your wallet list yet, this wallet gets added automatically. This usually occurs if you're using a browser wallet on mobile.
+
+You can stop the `injectedWallet` from automatically being added on mobile when detected by setting `injectedWalletOnMobile` to `false`. Do this by setting it as the first parameter in `getDefaultConfig`, or as the second parameter in `connectorsForWallets` if you're using Wagmi's `createConfig`.
 
 **It's recommended that you always include this wallet in the list to ensure all injected wallets are supported.**
 


### PR DESCRIPTION
## Changes
- `connectorsForWallets` now appends `injectedWallet` automatically on mobile if `window.ethereum` is detected

## What to test
1. Open up metamask on mobile (or any other mobile wallets you use that supports browser wallet)
2. Paste in [this](https://rainbowkit-example-790kz443k-rainbowdotme.vercel.app/) preview link into the mobile wallet's browser
3. Make sure you get the browser wallet in the connect modal
4. Click on the browser wallet and make sure you're connected
5. Make sure `Sign Message`, `Sign Typed Data` and `Send Transaction` works as expected in the demo app.

_[Here](https://github.com/rainbow-me/rainbowkit/discussions/1732) is a related discussion that someone wanted to extend EIP-6963 to support mobile, but in this case many mobile wallet don't expose `rdns` which will result into a duplication issue. This also happens in the official WalletConnect modal_ 

_In this case Browser wallet should work fine since there will be only one `window.ethereum` provider and can't be overidden on mobile_
