### PR TITLE
fix: empty state in connect modal with `<WalletButton>`

### DIFF
--- a/.changeset/shaggy-flowers-sort.md
+++ b/.changeset/shaggy-flowers-sort.md
@@ -3,4 +3,4 @@
 "site": patch
 ---
 
-The `WalletButton` component made the connect modal appear empty when trying to connect. This happened because of a mix up between EIP-6963 and RainbowKit connectors. The problem was finding the correct `wallet.id`. `WalletButton` uses RainbowKit's id, but EIP-6963 uses `rdns` for its id. We now don't merge EIP-6963 and RainbowKit connectors if user interacts with `WalletButton` component.
+Resolved an issue where the Connect Modal wallet list would appear empty for EIP-6963 connectors when using the `WalletButton` component

--- a/.changeset/shaggy-flowers-sort.md
+++ b/.changeset/shaggy-flowers-sort.md
@@ -1,0 +1,6 @@
+---
+"@rainbow-me/rainbowkit": patch
+"site": patch
+---
+
+The `WalletButton` component made the connect modal appear empty when trying to connect. This happened because of a mix up between EIP-6963 and RainbowKit connectors. The problem was finding the correct `wallet.id`. `WalletButton` uses RainbowKit's id, but EIP-6963 uses `rdns` for its id. We now don't merge EIP-6963 and RainbowKit connectors if user interacts with `WalletButton` component.

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -76,7 +76,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
 
   const { connector } = useContext(WalletButtonContext);
 
-  const mergeEIP6963WithRkConnectors = true;
+  const mergeEIP6963WithRkConnectors = !connector;
 
   const wallets = useWalletConnectors(mergeEIP6963WithRkConnectors)
     .filter((wallet) => wallet.ready || !!wallet.extensionDownloadUrl)
@@ -127,7 +127,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
     const sWallet = wallets.find((w) => wallet.id === w.id);
 
     const uri = await sWallet?.getQrCodeUri?.();
-
+    console.log({ uri });
     setQrCodeUri(uri);
 
     // This timeout prevents the UI from flickering if connection is instant,
@@ -152,6 +152,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
       onQrCode(wallet);
       onDesktopUri(wallet);
     }
+    console.log(wallet);
 
     connectToWallet(wallet);
     setSelectedOptionId(wallet.id);

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -76,6 +76,11 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
 
   const { connector } = useContext(WalletButtonContext);
 
+  // The `WalletButton` component made the connect modal appear empty when trying to connect.
+  // This happened because of a mix up between EIP-6963 and RainbowKit connectors. 
+  // The problem was finding the correct `wallet.id`. `WalletButton` uses RainbowKit's id, 
+  // but EIP-6963 uses `rdns` for its id. We now don't merge EIP-6963 and RainbowKit 
+  // connectors if user interacts with `WalletButton` component.
   const mergeEIP6963WithRkConnectors = !connector;
 
   const wallets = useWalletConnectors(mergeEIP6963WithRkConnectors)

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -127,7 +127,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
     const sWallet = wallets.find((w) => wallet.id === w.id);
 
     const uri = await sWallet?.getQrCodeUri?.();
-    console.log({ uri });
+
     setQrCodeUri(uri);
 
     // This timeout prevents the UI from flickering if connection is instant,
@@ -152,7 +152,6 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
       onQrCode(wallet);
       onDesktopUri(wallet);
     }
-    console.log(wallet);
 
     connectToWallet(wallet);
     setSelectedOptionId(wallet.id);

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -77,9 +77,9 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
   const { connector } = useContext(WalletButtonContext);
 
   // The `WalletButton` component made the connect modal appear empty when trying to connect.
-  // This happened because of a mix up between EIP-6963 and RainbowKit connectors. 
-  // The problem was finding the correct `wallet.id`. `WalletButton` uses RainbowKit's id, 
-  // but EIP-6963 uses `rdns` for its id. We now don't merge EIP-6963 and RainbowKit 
+  // This happened because of a mix up between EIP-6963 and RainbowKit connectors.
+  // The problem was finding the correct `wallet.id`. `WalletButton` uses RainbowKit's id,
+  // but EIP-6963 uses `rdns` for its id. We now don't merge EIP-6963 and RainbowKit
   // connectors if user interacts with `WalletButton` component.
   const mergeEIP6963WithRkConnectors = !connector;
 

--- a/site/data/en-US/docs/wallet-button.mdx
+++ b/site/data/en-US/docs/wallet-button.mdx
@@ -5,7 +5,7 @@ description: Using and customizing the WalletButton
 
 # WalletButton
 
-> Note: The current `WalletButton` component uses EIP-1193 wallet standard, but will be migrated over to EIP-6963 in the near future.
+> Note: The `WalletButton` currently relies on the EIP-1193 wallet standard, but will support EIP-6963 in the near future.
 
 The new `WalletButton` component helps dApps with custom wallet list implementations adopt RainbowKit and all of it's maintenance-free benefits.
 

--- a/site/data/en-US/docs/wallet-button.mdx
+++ b/site/data/en-US/docs/wallet-button.mdx
@@ -5,6 +5,8 @@ description: Using and customizing the WalletButton
 
 # WalletButton
 
+> Note: The current `WalletButton` component uses EIP-1193 wallet standard, but will be migrated over to EIP-6963 in the near future.
+
 The new `WalletButton` component helps dApps with custom wallet list implementations adopt RainbowKit and all of it's maintenance-free benefits.
 
 ```tsx


### PR DESCRIPTION
## Changes
- Don't merge EIP-6963 connectors with RainbowKit connectors. Some injected providers can override `window.ethereum` if you have many wallet extensions at once. This can mark `installed` as false for them then display an empty state when opening connect modal because of the merge logic:

![Screenshot 2024-03-10 at 03 26 01](https://github.com/rainbow-me/rainbowkit/assets/53529533/f3da4626-b51b-4cec-b111-6200eece8c03)

- Updated `WalletButton` documentation page to mention that we don't support EIP-6963 yet, but currently working towards it.

## What to test
1. Go to [this](https://rainbowkit-example-g685n4ro5-rainbowdotme.vercel.app/) preview link
2. Make sure you have metamask, rainbow and coinbase wallet installed
3. Click on the Coinbase Wallet (WalletButton component)
4. Make sure you don't get an empty state in the connect modal. Currently that's what's happening now.

_We shouldn't open the connect modal if wallet is installed, but `window.ethereum` or `window.ethereum.providers` can be overridden easily and it's better to just show something rather than nothing, like we had in v1._ 

_We'll work towards on EIP-6963 support for `WalletButton` component._
