### PR TITLE
chore: return raw translation message if missing in steps section

### DIFF
--- a/.changeset/thirty-years-mate.md
+++ b/.changeset/thirty-years-mate.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fixed a bug that caused a "missing translation" message in the connect modal when users created their own wallet with steps. This happened due to how we store the translations internally. Now, if a translation is missing, we'll display the original message from the user. This fix applies only to the connect modal steps section.

--- a/.changeset/thirty-years-mate.md
+++ b/.changeset/thirty-years-mate.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Fixed a bug that caused a "missing translation" message in the connect modal when users created their own wallet with steps. This happened due to how we store the translations internally. Now, if a translation is missing, we'll display the original message from the user. This fix applies only to the connect modal steps section.
+Resolved an issue for Custom Wallets that displayed a "missing translation" error for instructions during connect and installation flows. Now Custom Wallets will display their original strings without attempted translation.

--- a/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
@@ -860,10 +860,14 @@ export function InstructionMobileDetail({
             </Box>
             <Box display="flex" flexDirection="column" gap="4">
               <Text color="modalText" size="14" weight="bold">
-                {i18n.t(d.title)}
+                {i18n.t(d.title, undefined, {
+                  rawKeyIfTranslationMissing: true,
+                })}
               </Text>
               <Text color="modalTextSecondary" size="14" weight="medium">
-                {i18n.t(d.description)}
+                {i18n.t(d.description, undefined, {
+                  rawKeyIfTranslationMissing: true,
+                })}
               </Text>
             </Box>
           </Box>
@@ -947,10 +951,14 @@ export function InstructionExtensionDetail({
             </Box>
             <Box display="flex" flexDirection="column" gap="4">
               <Text color="modalText" size="14" weight="bold">
-                {i18n.t(d.title)}
+                {i18n.t(d.title, undefined, {
+                  rawKeyIfTranslationMissing: true,
+                })}
               </Text>
               <Text color="modalTextSecondary" size="14" weight="medium">
-                {i18n.t(d.description)}
+                {i18n.t(d.description, undefined, {
+                  rawKeyIfTranslationMissing: true,
+                })}
               </Text>
             </Box>
           </Box>
@@ -1036,10 +1044,14 @@ export function InstructionDesktopDetail({
             </Box>
             <Box display="flex" flexDirection="column" gap="4">
               <Text color="modalText" size="14" weight="bold">
-                {i18n.t(d.title)}
+                {i18n.t(d.title, undefined, {
+                  rawKeyIfTranslationMissing: true,
+                })}
               </Text>
               <Text color="modalTextSecondary" size="14" weight="medium">
-                {i18n.t(d.description)}
+                {i18n.t(d.description, undefined, {
+                  rawKeyIfTranslationMissing: true,
+                })}
               </Text>
             </Box>
           </Box>

--- a/packages/rainbowkit/src/locales/I18n.ts
+++ b/packages/rainbowkit/src/locales/I18n.ts
@@ -1,3 +1,7 @@
+interface TranslationOptions {
+  rawKeyIfTranslationMissing?: boolean;
+}
+
 type GenericTranslationObject = Record<string, any>;
 
 const defaultOptions = {
@@ -73,7 +77,11 @@ export class I18n {
     return translatedString;
   }
 
-  public t(key: string, replacements?: Record<string, string>): string {
+  public t(
+    key: string,
+    replacements?: Record<string, string>,
+    options?: TranslationOptions,
+  ): string {
     const translationKey = `${this.locale}.${key}`;
     const translation = this.translations[translationKey];
 
@@ -92,6 +100,12 @@ export class I18n {
           );
         }
       }
+
+      // If translation is missing -> return the raw key instead.
+      // This is useful if someone were to create their own RainbowKit
+      // wallet with steps, but translations are missing. In this case
+      // we don't want to throw missing translation message.
+      if (options?.rawKeyIfTranslationMissing) return key;
 
       return this.missingMessage(key);
     }


### PR DESCRIPTION
## Changes
- If translation is missing for a wallet in the steps section of the connect modal it'll return raw key instead of a "missing translation" message

## Screen recordings / screenshots

Before:
![image](https://github.com/rainbow-me/rainbowkit/assets/53529533/f16f6a5d-47f2-4a5b-915a-088f40c2438f)

After:
![image](https://github.com/rainbow-me/rainbowkit/assets/53529533/ae66a58f-4f85-4d73-bc8a-7a87747df746)

## What to test
1. Try to go to any wallet and change the string of the steps. Could be any `qrCode`, `desktop` or `extension` steps.
2. Open the connect modal, select the wallet, see the steps and make sure a raw key message is being returned instead of the "missing translation" message.