### PR TITLE
fix: shim disconnect

### DIFF
--- a/.changeset/thick-seas-jam.md
+++ b/.changeset/thick-seas-jam.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Disconnects will now remain persistent for `window.ethereum` and EIP-6963 connectors

--- a/packages/rainbowkit/src/wallets/getInjectedConnector.ts
+++ b/packages/rainbowkit/src/wallets/getInjectedConnector.ts
@@ -80,13 +80,16 @@ function createInjectedConnector(provider?: any): CreateConnector {
     // Create the injected configuration object conditionally based on the provider.
     const injectedConfig = provider
       ? {
+          shimDisconnect: true,
           target: () => ({
             id: walletDetails.rkDetails.id,
             name: walletDetails.rkDetails.name,
             provider,
           }),
         }
-      : {};
+      : {
+          shimDisconnect: true,
+        };
 
     return createConnector((config) => ({
       // Spread the injectedConfig object, which may be empty or contain the target function

--- a/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
@@ -19,7 +19,7 @@ export const safeWallet = (): Wallet => ({
   },
   createConnector: (walletDetails: WalletDetailsParams) => {
     return createConnector((config) => ({
-      ...safe()(config),
+      ...safe({ shimDisconnect: true })(config),
       ...walletDetails,
     }));
   },


### PR DESCRIPTION
## Changes
- added `shimDisconnect` flag during connector preparation to prevent automatic reconnects of disconnected connectors

## Known issue
- Wagmi currently iterates through EIP-6963 connectors and attempts to reconnect, seemingly ignoring `wagmi.WALLET_ID.disconnected` flags in localstorage. On `reconnect` upon `hydrate`, Wagmi seems to move to the next EIP-6963 connector and fire `connect`. After a series of connects and reconnects, there will be multiple different disconnect flags in localstorage for various wallets (even though we connected with the same wallet). This behavior results in `shimDisconnect` functionality not working as expected
<img width="492" alt="Screenshot 2024-03-21 at 12 31 59 AM" src="https://github.com/rainbow-me/rainbowkit/assets/4412473/6563a1c7-4186-4c65-b5c6-30712a2bb655">
<img width="773" alt="Screenshot 2024-03-21 at 12 23 31 AM" src="https://github.com/rainbow-me/rainbowkit/assets/4412473/0b53605d-0d15-471c-958e-bf872b1a957c">

https://github.com/wevm/wagmi/blob/97237bb05c30860b9b12c094e82a38ce59d9bedf/packages/core/src/hydrate.ts#L33
https://github.com/wevm/wagmi/blob/c403563be5dd3ab36d8582e69071ce87294468c2/packages/core/src/actions/reconnect.ts#L20