### PR TITLE
fix: await connectWallet for walletbutton

### DIFF
--- a/.changeset/calm-snakes-roll.md
+++ b/.changeset/calm-snakes-roll.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Update `connect` prop to include `await` when connecting to a wallet in `WalletButton` component.
+Amended the `connect` prop type for `WalletButton.Custom` components to expect a promise, and improved the synchronous connection flow for the `WalletButton`

--- a/.changeset/calm-snakes-roll.md
+++ b/.changeset/calm-snakes-roll.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Update `connect` prop to include `await` when connecting to a wallet in `WalletButton` component.

--- a/.changeset/calm-snakes-roll.md
+++ b/.changeset/calm-snakes-roll.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Amended the `connect` prop type for `WalletButton.Custom` components to expect a promise, and improved the synchronous connection flow for the `WalletButton`
+Improved the synchronous connection flow for the `WalletButton` and `WalletButton.Custom` components

--- a/packages/rainbowkit/src/components/WalletButton/WalletButtonRenderer.tsx
+++ b/packages/rainbowkit/src/components/WalletButton/WalletButtonRenderer.tsx
@@ -33,7 +33,7 @@ export interface WalletButtonRendererProps {
     ready: boolean;
     mounted: boolean;
     connector: WalletConnector;
-    connect: () => void;
+    connect: () => Promise<void>;
   }) => ReactNode;
 }
 
@@ -142,7 +142,7 @@ export function WalletButtonRenderer({
             return;
           }
 
-          connectWallet();
+          await connectWallet();
         },
       })}
     </>


### PR DESCRIPTION
What changed:
- updated WalletButtonRendererProps `connect` type to be a Promise matching the handler returned
- await  `connectWallet` promise during connect