### PR TITLE
fix: throw error if wallet list is empty

### DIFF
--- a/.changeset/old-mugs-dance.md
+++ b/.changeset/old-mugs-dance.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Add a small check to throw an error if the wallet list is empty overall or empty within any category.

--- a/packages/rainbowkit/src/wallets/connectorsForWallets.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.ts
@@ -35,6 +35,16 @@ export const connectorsForWallets = (
     appIcon,
   }: ConnectorsForWalletsParameters,
 ): CreateConnectorFn[] => {
+  if (!walletList.length) {
+    throw new Error('No wallet list was provided');
+  }
+
+  for (const { wallets, groupName } of walletList) {
+    if (!wallets.length) {
+      throw new Error(`No wallets provided for group: ${groupName}`);
+    }
+  }
+
   let index = -1;
 
   const connectors: CreateConnectorFn[] = [];


### PR DESCRIPTION
## Changes  

- Add a small check to throw an error if the wallet list is empty overall or empty within any category
