### PR TITLE
fix: CI/CD & cleanup tests

### DIFF
--- a/packages/rainbowkit/src/components/ChainModal/ChainModal.test.tsx
+++ b/packages/rainbowkit/src/components/ChainModal/ChainModal.test.tsx
@@ -35,7 +35,6 @@ describe('<ChainModal />', () => {
     const modal = renderWithProviders(
       <ChainModalWithConnectButton onClose={onClose} />,
       {
-        mock: true,
         chains,
       },
     );
@@ -111,9 +110,9 @@ describe('<ChainModal />', () => {
   it('Closes on close button press', async () => {
     let onCloseGotCalled = false;
 
-    const modal = renderWithProviders(
-      <ChainModal onClose={() => (onCloseGotCalled = true)} open />,
-    );
+    const modal = await renderChainModalWithConnectedWallet([mainnet], () => {
+      onCloseGotCalled = true;
+    });
 
     const closeButton = await modal.findByLabelText('Close');
 

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButton.test.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButton.test.tsx
@@ -9,7 +9,6 @@ import { ConnectButton } from './ConnectButton';
 describe('<ConnectButton />', () => {
   const renderTextButton = (locale?: Locale) => {
     const options = {
-      mock: true,
       props: {
         chains: [mainnet],
         ...(locale ? { locale } : {}),

--- a/packages/rainbowkit/src/components/ConnectModal/ConnectModal.test.tsx
+++ b/packages/rainbowkit/src/components/ConnectModal/ConnectModal.test.tsx
@@ -9,7 +9,6 @@ import { ConnectModal } from './ConnectModal';
 describe('<ConnectModal />', () => {
   const renderHeaderLabelModal = async (locale?: Locale) => {
     const options = {
-      mock: true,
       props: {
         chains: [mainnet],
         ...(locale ? { locale } : {}),

--- a/packages/rainbowkit/src/components/WalletButton/WalletButton.test.tsx
+++ b/packages/rainbowkit/src/components/WalletButton/WalletButton.test.tsx
@@ -1,14 +1,42 @@
 import React from 'react';
-import { describe, expect, it } from 'vitest';
+import {
+  SpyInstance,
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { mainnet } from 'wagmi/chains';
 import { renderWithProviders } from '../../../test';
+import { mockWallet } from '../../../test/mockWallet';
 import { WalletButton } from './WalletButton';
+
+let mockError: ReturnType<SpyInstance['mockImplementation']>;
+
+beforeAll(() => {
+  // Silence the error logs if the component throws an error.
+  // This is due to how the node.js environment works.
+  mockError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterAll(() => {
+  mockError.mockRestore();
+});
 
 describe('<WalletButton />', () => {
   const getWalletButtonLabel = async (connectorId?: string) => {
+    const wallets = [
+      { id: 'rainbow', name: 'Rainbow' },
+      { id: 'metaMask', name: 'MetaMask' },
+      { id: 'coinbase', name: 'Coinbase Wallet' },
+    ].map(({ id, name }) => mockWallet(id, name));
+
     const { findByTestId } = renderWithProviders(
       <WalletButton wallet={connectorId} />,
       {
+        mockWallets: [{ groupName: 'Popular', wallets }],
         chains: [mainnet],
       },
     );
@@ -46,7 +74,7 @@ describe('<WalletButton />', () => {
         renderWithProviders(<WalletButton wallet={connector} />, {
           chains: [mainnet],
         }),
-      ).toThrow('Connector not found');
+      ).toThrowError('Connector not found');
     }
   });
 });

--- a/packages/rainbowkit/src/components/WalletButton/WalletButton.test.tsx
+++ b/packages/rainbowkit/src/components/WalletButton/WalletButton.test.tsx
@@ -16,8 +16,7 @@ import { WalletButton } from './WalletButton';
 let mockError: ReturnType<SpyInstance['mockImplementation']>;
 
 beforeAll(() => {
-  // Silence the error logs if the component throws an error.
-  // This is due to how the node.js environment works.
+  // Silence the error logs if the component throws an error
   mockError = vi.spyOn(console, 'error').mockImplementation(() => {});
 });
 

--- a/packages/rainbowkit/test/index.tsx
+++ b/packages/rainbowkit/test/index.tsx
@@ -13,11 +13,11 @@ import {
   polygon,
   zora,
 } from 'wagmi/chains';
-import { MockParameters, mock } from 'wagmi/connectors';
+import { mock } from 'wagmi/connectors';
 import type { RainbowKitProviderProps } from '../src/components/RainbowKitProvider/RainbowKitProvider';
 import { RainbowKitProvider } from '../src/components/RainbowKitProvider/RainbowKitProvider';
+import { WalletList } from '../src/wallets/Wallet';
 import { connectorsForWallets } from '../src/wallets/connectorsForWallets';
-import { getDefaultWallets } from '../src/wallets/getDefaultWallets';
 
 const defaultChains: readonly [Chain, ...Chain[]] = [
   mainnet,
@@ -36,34 +36,28 @@ export function renderWithProviders(
   component: ReactElement,
   options?: {
     chains?: readonly [Chain, ...Chain[]];
-    mock?: boolean;
-    mockFeatures?: MockParameters['features'];
+    mockWallets?: WalletList;
     props?: Omit<RainbowKitProviderProps, 'children'>;
   },
 ) {
   const supportedChains = options?.chains || defaultChains;
 
-  const { wallets } = getDefaultWallets();
-
   const config = createConfig({
     chains: supportedChains,
-    connectors: options?.mock
-      ? [
+    connectors: options?.mockWallets
+      ? connectorsForWallets(options.mockWallets, {
+          appName: 'rainbowkit.com',
+          projectId: process.env.WALLETCONNECT_PROJECT_ID ?? 'YOUR_PROJECT_ID',
+        })
+      : [
           mock({
-            ...(options?.mockFeatures
-              ? { features: options?.mockFeatures }
-              : {}),
             accounts: [
               '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
               '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
               '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
             ],
           }),
-        ]
-      : connectorsForWallets(wallets, {
-          appName: 'rainbowkit.com',
-          projectId: process.env.WALLETCONNECT_PROJECT_ID ?? 'YOUR_PROJECT_ID',
-        }),
+        ],
     transports: {
       [mainnet.id]: http(),
       [polygon.id]: http(),

--- a/packages/rainbowkit/test/index.tsx
+++ b/packages/rainbowkit/test/index.tsx
@@ -18,6 +18,7 @@ import type { RainbowKitProviderProps } from '../src/components/RainbowKitProvid
 import { RainbowKitProvider } from '../src/components/RainbowKitProvider/RainbowKitProvider';
 import { WalletList } from '../src/wallets/Wallet';
 import { connectorsForWallets } from '../src/wallets/connectorsForWallets';
+import { mockedAccounts } from './mockWallet';
 
 const defaultChains: readonly [Chain, ...Chain[]] = [
   mainnet,
@@ -51,11 +52,7 @@ export function renderWithProviders(
         })
       : [
           mock({
-            accounts: [
-              '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-              '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-              '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
-            ],
+            accounts: mockedAccounts,
           }),
         ],
     transports: {

--- a/packages/rainbowkit/test/mockWallet.ts
+++ b/packages/rainbowkit/test/mockWallet.ts
@@ -1,0 +1,30 @@
+import type { Address } from 'viem';
+import { createConnector } from 'wagmi';
+import { mock } from 'wagmi/connectors';
+import { Wallet, WalletDetailsParams } from '../src/wallets/Wallet';
+
+export const mockedAccounts: readonly [Address, ...Address[]] = [
+  '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+];
+
+export const mockWallet = (id: string, name: string) => {
+  return (): Wallet => ({
+    id,
+    name,
+    iconBackground: '#fff',
+    iconUrl: '',
+    installed: true,
+    createConnector: (walletDetails: WalletDetailsParams) => {
+      return createConnector((config) => ({
+        ...mock({
+          accounts: mockedAccounts,
+        })(config),
+        id,
+        name,
+        ...walletDetails,
+      }));
+    },
+  });
+};


### PR DESCRIPTION
## Changes  

- Remove `getDefaultWallets` since WalletConnect sessions might fail due to socket relay bridging timeouts
- Added own `mockWallet` connector. This will help us get fast tests and avoid issues with WalletConnect wallets
- Suppressed console errors in `WalletButton.test.tsx` to reduce logs in the node environment when component throws an error