### PR TITLE
fix: let `metaMaskWallet` connect to rainbow wallet if overidden

### DIFF
--- a/.changeset/fast-files-clean.md
+++ b/.changeset/fast-files-clean.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Updated `metaMaskWallet` to allow connection to Rainbow Wallet when MetaMask overrides through `window.ethereum.providers`.
+foResolved an issue where the MetaMask button would not fallback to an available wallet provider if MetaMask was not active and EIP-6963 feature was turned off. Now you can continue to use the MetaMask button to interact with all wallets, or directly with MetaMask when it is active.

--- a/.changeset/fast-files-clean.md
+++ b/.changeset/fast-files-clean.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Updated `metaMaskWallet` to allow connection to Rainbow Wallet when MetaMask overrides through `window.ethereum.providers`.

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -41,6 +41,7 @@ function isMetaMask(ethereum?: (typeof window)['ethereum']): boolean {
   if (ethereum.isPhantom) return false;
   if (ethereum.isPortal) return false;
   if (ethereum.isRabby) return false;
+  if (ethereum.isRainbow) return false;
   if (ethereum.isStatus) return false;
   if (ethereum.isTalisman) return false;
   if (ethereum.isTally) return false;
@@ -64,6 +65,8 @@ export const metaMaskWallet = ({
   // in window.providers scenarios with multiple wallets injected.
   const isMetaMaskInjected = hasInjectedProvider({ flag: 'isMetaMask' });
   const shouldUseWalletConnect = !isMetaMaskInjected;
+
+  const providers = typeof window !== 'undefined' && window.ethereum?.providers;
 
   const getUri = (uri: string) => {
     return isAndroid()
@@ -158,9 +161,8 @@ export const metaMaskWallet = ({
         })
       : getInjectedConnector({
           target:
-            typeof window !== 'undefined'
-              ? window.ethereum?.providers?.find(isMetaMask) ?? window.ethereum
-              : undefined,
+            (Array.isArray(providers) && providers.find(isMetaMask)) ||
+            (typeof window !== 'undefined' ? window.ethereum : undefined),
         }),
   };
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -41,7 +41,6 @@ function isMetaMask(ethereum?: (typeof window)['ethereum']): boolean {
   if (ethereum.isPhantom) return false;
   if (ethereum.isPortal) return false;
   if (ethereum.isRabby) return false;
-  if (ethereum.isRainbow) return false;
   if (ethereum.isStatus) return false;
   if (ethereum.isTalisman) return false;
   if (ethereum.isTally) return false;


### PR DESCRIPTION
## Changes
- When metamask and rainbow wallet are injected, `metaMaskWallet` ignores rainbow wallet in `window.ethereum.providers`. This means if a user is not using EIP-6963 feature, then rainbow wallet won't work if someone clicks on metamask.