### PR TITLE
fix: metamask button fallback (`1.3.x`)

### DIFF
--- a/.changeset/odd-lizards-tickle.md
+++ b/.changeset/odd-lizards-tickle.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Updated `metaMaskWallet` to allow connection to Rainbow Wallet when MetaMask overrides through `window.ethereum.providers`.

--- a/.changeset/odd-lizards-tickle.md
+++ b/.changeset/odd-lizards-tickle.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Updated `metaMaskWallet` to allow connection to Rainbow Wallet when MetaMask overrides through `window.ethereum.providers`.
+Resolved an issue where the MetaMask button would not fallback to an available wallet provider if MetaMask was not active. Now you can continue to use the MetaMask button to interact with all wallets, or directly with MetaMask when it is active.

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -57,6 +57,7 @@ function isMetaMask(ethereum?: (typeof window)['ethereum']): boolean {
   if (ethereum.isPhantom) return false;
   if (ethereum.isPortal) return false;
   if (ethereum.isRabby) return false;
+  if (ethereum.isRainbow) return false;
   if (ethereum.isStatus) return false;
   if (ethereum.isTalisman) return false;
   if (ethereum.isTally) return false;

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -122,11 +122,8 @@ export const metaMaskWallet = ({
             chains,
             options: {
               getProvider: () =>
-                providers
-                  ? providers.find(isMetaMask)
-                  : typeof window !== 'undefined'
-                    ? window.ethereum
-                    : undefined,
+                providers?.find(isMetaMask) ||
+                (typeof window !== 'undefined' ? window.ethereum : undefined),
               ...options,
             },
           });

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -57,7 +57,6 @@ function isMetaMask(ethereum?: (typeof window)['ethereum']): boolean {
   if (ethereum.isPhantom) return false;
   if (ethereum.isPortal) return false;
   if (ethereum.isRabby) return false;
-  if (ethereum.isRainbow) return false;
   if (ethereum.isStatus) return false;
   if (ethereum.isTalisman) return false;
   if (ethereum.isTally) return false;

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -122,7 +122,7 @@ export const metaMaskWallet = ({
             chains,
             options: {
               getProvider: () =>
-                providers?.find(isMetaMask) ||
+                (Array.isArray(providers) && providers.find(isMetaMask)) ||
                 (typeof window !== 'undefined' ? window.ethereum : undefined),
               ...options,
             },


### PR DESCRIPTION
## Changes
- When metamask and rainbow wallet are injected, `metaMaskWallet` ignores rainbow wallet in `window.ethereum.providers`. This means if a user is trying to connect to metamask when they have rainbow wallet it won't connect to rainbow wallet.