### PR TITLE
feat: pass openChainModal even if connectionStatus is not connected

### DIFF
--- a/packages/rainbowkit/src/components/RainbowKitProvider/ModalContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/ModalContext.tsx
@@ -116,8 +116,7 @@ export function ModalProvider({ children }: ModalProviderProps) {
             isCurrentChainSupported && connectionStatus === 'connected'
               ? openAccountModal
               : undefined,
-          openChainModal:
-            connectionStatus === 'connected' ? openChainModal : undefined,
+          openChainModal,
           openConnectModal:
             connectionStatus === 'disconnected' ||
             connectionStatus === 'unauthenticated'


### PR DESCRIPTION
Some DEXes often support multiple chains. Users tend to play around without connecting to the websites.

With the current value of ModalContext, it's not possible for users to switch chains without connecting wallets.