### PR TITLE
chore: `coinbaseWalletParameters` for `connectorsForWallets`

### DIFF
--- a/.changeset/curvy-parents-push.md
+++ b/.changeset/curvy-parents-push.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Introduced `coinbaseWalletParameters` parameter in `connectorsForWallets` to support `coinbaseWallet` connector parameters.

--- a/packages/rainbowkit/src/wallets/Wallet.ts
+++ b/packages/rainbowkit/src/wallets/Wallet.ts
@@ -1,5 +1,8 @@
 import { Connector, CreateConnectorFn } from 'wagmi';
-import { WalletConnectParameters } from 'wagmi/connectors';
+import {
+  CoinbaseWalletParameters,
+  WalletConnectParameters,
+} from 'wagmi/connectors';
 import { CoinbaseWalletOptions } from './walletConnectors/coinbaseWallet/coinbaseWallet';
 import { WalletConnectWalletOptions } from './walletConnectors/walletConnectWallet/walletConnectWallet';
 
@@ -101,6 +104,13 @@ export type WalletList = {
 export type RainbowKitWalletConnectParameters = Omit<
   WalletConnectParameters,
   'showQrModal' | 'projectId'
+>;
+
+// `appName`, `appLogoUrl`, `headlessMode`, and `darkMode` are already
+// provided on our end. Rest of parameters can be included as needed
+export type RainbowKitCoinbaseWalletParameters = Omit<
+  CoinbaseWalletParameters,
+  'appName' | 'appLogoUrl' | 'headlessMode' | 'darkMode'
 >;
 
 export type RainbowKitDetails = Omit<Wallet, 'createConnector' | 'hidden'> & {

--- a/packages/rainbowkit/src/wallets/connectorsForWallets.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.ts
@@ -3,6 +3,7 @@ import { isHexString } from '../utils/colors';
 import { omitUndefinedValues } from '../utils/omitUndefinedValues';
 import { uniqueBy } from '../utils/uniqueBy';
 import type {
+  RainbowKitCoinbaseWalletParameters,
   RainbowKitWalletConnectParameters,
   Wallet,
   WalletDetailsParams,
@@ -23,6 +24,7 @@ export interface ConnectorsForWalletsParameters {
   appUrl?: string;
   appIcon?: string;
   walletConnectParameters?: RainbowKitWalletConnectParameters;
+  coinbaseWalletParameters?: RainbowKitCoinbaseWalletParameters;
 }
 
 export const connectorsForWallets = (
@@ -30,6 +32,7 @@ export const connectorsForWallets = (
   {
     projectId,
     walletConnectParameters,
+    coinbaseWalletParameters,
     appName,
     appDescription,
     appUrl,
@@ -72,13 +75,15 @@ export const connectorsForWallets = (
         // `option` is being used only for `walletConnectWallet` wallet
         options: {
           metadata: walletConnectMetaData,
-          ...walletConnectParameters,
+          ...(walletConnectParameters ?? {}),
         },
+        // `walletOptions` is being used only for `coinbaseWallet` wallet
+        walletOptions: coinbaseWalletParameters,
         // Every other wallet that supports walletConnect flow and is not
         // `walletConnectWallet` wallet will have `walletConnectParameters` property
         walletConnectParameters: {
           metadata: walletConnectMetaData,
-          ...walletConnectParameters,
+          ...(walletConnectParameters ?? {}),
         },
       });
 

--- a/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
@@ -1,17 +1,23 @@
 import { createConnector } from 'wagmi';
 import { coinbaseWallet as coinbaseWagmiWallet } from 'wagmi/connectors';
 import { isIOS } from '../../../utils/isMobile';
-import { Wallet, WalletDetailsParams } from '../../Wallet';
+import {
+  RainbowKitCoinbaseWalletParameters,
+  Wallet,
+  WalletDetailsParams,
+} from '../../Wallet';
 import { hasInjectedProvider } from '../../getInjectedConnector';
 
 export interface CoinbaseWalletOptions {
   appName: string;
   appIcon?: string;
+  walletOptions?: RainbowKitCoinbaseWalletParameters;
 }
 
 export const coinbaseWallet = ({
   appName,
   appIcon,
+  walletOptions,
 }: CoinbaseWalletOptions): Wallet => {
   const isCoinbaseWalletInjected = hasInjectedProvider({
     flag: 'isCoinbaseWallet',
@@ -101,8 +107,10 @@ export const coinbaseWallet = ({
     createConnector: (walletDetails: WalletDetailsParams) =>
       createConnector((config) => ({
         ...coinbaseWagmiWallet({
+          ...(walletOptions ?? {}),
           appName,
           appLogoUrl: appIcon,
+          darkMode: false,
           headlessMode: true,
         })(config),
         ...walletDetails,


### PR DESCRIPTION
## Changes
- Some users right now can't pass in `coinbaseWallet` parameters directly in `connectorsForWallets`. This PR fixes it.