### PR TITLE
chore: tweak `CONTRIBUTING.md`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ It's never a fun experience to have your pull request declined after investing a
 
 ## Prerequisites
 
-This project uses [`pnpm`](https://pnpm.io) as a package manager.
+This project uses [`pnpm`](https://pnpm.io) as a package manager. The required `pnpm` version to get started is `8.15.5`.
 
 ## Development environment
 


### PR DESCRIPTION
## Changes
- Some users face errors when they try to kickstart the project. That's because they don't have the correct `pnpm` version and we don't mention anywhere what version they should use. They would manually have to go to `package.json` to find out. This PR will just mention in `CONTRIBUTING.md` that you should use pnpm version `8.15.5`.