### PR TITLE
fix: npm init `@rainbow-me/rainbowkit@latest` not working

### DIFF
--- a/.changeset/fast-doors-divide.md
+++ b/.changeset/fast-doors-divide.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/create-rainbowkit": patch
+---
+
+Added `--legacy-peer-deps` flag when running `npm init @rainbow-me/rainbowkit@latest`.

--- a/packages/create-rainbowkit/src/cli.ts
+++ b/packages/create-rainbowkit/src/cli.ts
@@ -185,17 +185,18 @@ async function run() {
         )}. This could take a while.`,
       ),
     );
-    await execa(packageManager, ['install'], {
+    const flags = packageManager === 'npm' ? '--legacy-peer-deps' : undefined;
+    await execa(packageManager, ['install', ...(flags ? [flags] : [])], {
       cwd: targetPath,
       stdio: 'inherit',
     });
-
     if (process.env.INSTALL_WORKSPACE_RAINBOWKIT !== 'true') {
       await execa(
         packageManager,
         [
           packageManager === 'yarn' ? 'add' : 'install',
           '@rainbow-me/rainbowkit',
+          ...(flags ? [flags] : []),
         ],
         {
           cwd: targetPath,

--- a/packages/create-rainbowkit/src/cli.ts
+++ b/packages/create-rainbowkit/src/cli.ts
@@ -185,8 +185,8 @@ async function run() {
         )}. This could take a while.`,
       ),
     );
-    const flags = packageManager === 'npm' ? '--legacy-peer-deps' : undefined;
-    await execa(packageManager, ['install', ...(flags ? [flags] : [])], {
+    const flag = packageManager === 'npm' ? '--legacy-peer-deps' : undefined;
+    await execa(packageManager, ['install', ...(flag ? [flag] : [])], {
       cwd: targetPath,
       stdio: 'inherit',
     });
@@ -196,7 +196,7 @@ async function run() {
         [
           packageManager === 'yarn' ? 'add' : 'install',
           '@rainbow-me/rainbowkit',
-          ...(flags ? [flags] : []),
+          ...(flag ? [flag] : []),
         ],
         {
           cwd: targetPath,


### PR DESCRIPTION
## Changes
- Added `--legacy-peer-deps` flag when running `npm init @rainbow-me/rainbowkit@latest`