### PR TITLE
feat: `siwe` support for smart wallets

### DIFF
--- a/.changeset/wet-mice-invent.md
+++ b/.changeset/wet-mice-invent.md
@@ -1,0 +1,7 @@
+---
+"example": patch
+"with-next-siwe-iron-session": patch
+"with-next-siwe-next-auth": patch
+---
+
+Added Sign-in with Ethereum support for smart wallets

--- a/examples/with-next-siwe-iron-session/pages/_app.tsx
+++ b/examples/with-next-siwe-iron-session/pages/_app.tsx
@@ -32,7 +32,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const { wallets } = getDefaultWallets();
 
-const config = getDefaultConfig({
+export const wagmiConfig = getDefaultConfig({
   appName: 'RainbowKit demo',
   projectId: 'YOUR_PROJECT_ID',
   wallets: [
@@ -143,7 +143,7 @@ export default function App({ Component, pageProps }: AppProps) {
   }, []);
 
   return (
-    <WagmiProvider config={config}>
+    <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
         <RainbowKitAuthenticationProvider
           adapter={authAdapter}

--- a/examples/with-next-siwe-next-auth/pages/_app.tsx
+++ b/examples/with-next-siwe-next-auth/pages/_app.tsx
@@ -32,7 +32,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const { wallets } = getDefaultWallets();
 
-const config = getDefaultConfig({
+export const wagmiConfig = getDefaultConfig({
   appName: 'RainbowKit demo',
   projectId: 'YOUR_PROJECT_ID',
   wallets: [
@@ -67,7 +67,7 @@ export default function App({
 }>) {
   return (
     <SessionProvider refetchInterval={0} session={pageProps.session}>
-      <WagmiProvider config={config}>
+      <WagmiProvider config={wagmiConfig}>
         <QueryClientProvider client={queryClient}>
           <RainbowKitSiweNextAuthProvider
             getSiweMessageOptions={getSiweMessageOptions}

--- a/examples/with-next-siwe-next-auth/pages/api/auth/[...nextauth].ts
+++ b/examples/with-next-siwe-next-auth/pages/api/auth/[...nextauth].ts
@@ -8,6 +8,8 @@ import NextAuth, { NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import { getCsrfToken } from 'next-auth/react';
 import { SiweMessage } from 'siwe';
+import { Address, publicActions } from 'viem';
+import { wagmiConfig } from '../../_app';
 
 export function getAuthOptions(req: IncomingMessage): NextAuthOptions {
   const providers = [
@@ -39,7 +41,18 @@ export function getAuthOptions(req: IncomingMessage): NextAuthOptions {
             return null;
           }
 
-          await siwe.verify({ signature: credentials?.signature || '' });
+          const wagmiClient = wagmiConfig.getClient().extend(publicActions);
+
+          const isValid = await wagmiClient.verifyMessage({
+            address: siwe.address as Address,
+            signature: credentials?.signature as Address,
+            message: siwe.prepareMessage(),
+          });
+
+          if (!isValid) {
+            throw new Error('Invalid message');
+          }
+
           return {
             id: siwe.address,
           };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "postinstall": "husky install",
-    "dev": "pnpm --recursive --parallel --filter @rainbow-me/rainbow* --filter with-next-siwe-next-auth dev",
+    "dev": "pnpm --recursive --parallel --filter @rainbow-me/rainbow* --filter example dev",
     "dev:lib": "pnpm --parallel --filter @rainbow-me/rainbow* dev",
     "dev:example": "pnpm dev:lib & pnpm --filter example dev",
     "dev:site": "pnpm dev:lib & pnpm --filter site dev",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "postinstall": "husky install",
-    "dev": "pnpm --recursive --parallel --filter @rainbow-me/rainbow* --filter example dev",
+    "dev": "pnpm --recursive --parallel --filter @rainbow-me/rainbow* --filter with-next-siwe-next-auth dev",
     "dev:lib": "pnpm --parallel --filter @rainbow-me/rainbow* dev",
     "dev:example": "pnpm dev:lib & pnpm --filter example dev",
     "dev:site": "pnpm dev:lib & pnpm --filter site dev",

--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -144,7 +144,7 @@ const sei = {
   contracts: {},
 } as const satisfies Chain;
 
-const config = getDefaultConfig({
+export const wagmiConfig = getDefaultConfig({
   appName: 'RainbowKit Demo',
   projectId,
   chains: [
@@ -535,7 +535,7 @@ function RainbowKitApp({
                           }
                           value={selectedInitialChainId ?? 'default'}
                         >
-                          {[undefined, ...config.chains].map((chain) => (
+                          {[undefined, ...wagmiConfig.chains].map((chain) => (
                             <option
                               key={chain?.id ?? ''}
                               value={chain?.id ?? ''}
@@ -729,7 +729,7 @@ export default function App(
       </Head>
 
       <SessionProvider refetchInterval={0} session={appProps.pageProps.session}>
-        <WagmiProvider config={config}>
+        <WagmiProvider config={wagmiConfig}>
           <QueryClientProvider client={queryClient}>
             <RainbowKitApp {...appProps} />
           </QueryClientProvider>

--- a/packages/example/pages/api/auth/[...nextauth].ts
+++ b/packages/example/pages/api/auth/[...nextauth].ts
@@ -8,6 +8,8 @@ import NextAuth, { NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import { getCsrfToken } from 'next-auth/react';
 import { SiweMessage } from 'siwe';
+import { Address, publicActions } from 'viem';
+import { wagmiConfig } from '../../_app';
 
 export function getAuthOptions(req: IncomingMessage): NextAuthOptions {
   const providers = [
@@ -39,7 +41,18 @@ export function getAuthOptions(req: IncomingMessage): NextAuthOptions {
             return null;
           }
 
-          await siwe.verify({ signature: credentials?.signature || '' });
+          const wagmiClient = wagmiConfig.getClient().extend(publicActions);
+
+          const isValid = await wagmiClient.verifyMessage({
+            address: siwe.address as Address,
+            signature: credentials?.signature as Address,
+            message: siwe.prepareMessage(),
+          });
+
+          if (!isValid) {
+            throw new Error('Invalid message');
+          }
+
           return {
             id: siwe.address,
           };

--- a/packages/rainbowkit-siwe-next-auth/README.md
+++ b/packages/rainbowkit-siwe-next-auth/README.md
@@ -14,6 +14,8 @@ This package is designed to work with the [official Sign-In with Ethereum boiler
 
 If you haven't already, first set up your [Next.js](https://nextjs.org) project with the [official Sign-In with Ethereum boilerplate for NextAuth.js.](https://docs.login.xyz/integrations/nextauth.js)
 
+[Sign-In with Ethereum](https://login.xyz) doesn't support smart wallet signature verification. If you're interested in adding support for smart wallets, please refer to the [smart wallet](https://www.smartwallet.dev/guides/siwe) documentation for guidance.
+
 ### Install
 
 Install the `@rainbow-me/rainbowkit-siwe-next-auth` package and its peer dependency, [ethers](https://docs.ethers.org/v5/).

--- a/site/data/en-US/docs/authentication.mdx
+++ b/site/data/en-US/docs/authentication.mdx
@@ -15,6 +15,8 @@ While it's possible to [integrate with custom back-ends and message formats,](/d
 
 If you haven't already, first set up your [Next.js](https://nextjs.org) project with the [official Sign-In with Ethereum boilerplate for NextAuth.js.](https://docs.login.xyz/integrations/nextauth.js)
 
+[Sign-In with Ethereum](https://login.xyz) doesn't support smart wallet signature verification. If you're interested in adding support for smart wallets, please refer to the [smart wallet](https://www.smartwallet.dev/guides/siwe) documentation for guidance.
+
 #### Install
 
 Install the `@rainbow-me/rainbowkit-siwe-next-auth` package and its peer dependency, [ethers](https://docs.ethers.org/v5/).

--- a/site/data/en-US/docs/custom-authentication.mdx
+++ b/site/data/en-US/docs/custom-authentication.mdx
@@ -15,6 +15,8 @@ First create an authentication adapter. This allows RainbowKit to create/prepare
 
 As an example, we could make an authentication adapter that lets us use [Sign-In with Ethereum](https://login.xyz) against some [custom API endpoints.](https://wagmi.sh/examples/sign-in-with-ethereum)
 
+Note that [Sign-In with Ethereum](https://login.xyz) currently doesn't support smart wallet signature verification. For guidance on adding support for smart wallets, please refer to the [smart wallet](https://www.smartwallet.dev/guides/siwe) documentation.
+
 ```tsx
 import { createAuthenticationAdapter } from '@rainbow-me/rainbowkit';
 import { SiweMessage } from 'siwe';


### PR DESCRIPTION
## Changes
- Sign-in with ethereum support for smart wallets

## What to test
1. Go to `packages/with-next-siwe-iron-session`, `packages/with-next-siwe-next-auth` and `packages/example`. Make sure to set `sepolia` chain as your only chain for `createConfig`, since coinbase smart wallet only works for testnet chains on localhost.
2. Go through the Sign-in with Ethereum flow and make sure everything works as expected both for EOA wallets and for smart wallets like coinbase smart wallet.