### PR TITLE
fix: touchpad zoom and pan on dialogs

### DIFF
--- a/.changeset/few-tigers-press.md
+++ b/.changeset/few-tigers-press.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+The `react-remove-scroll` dependency has been removed due to issues with the zoom feature in the browser. Instead a custom hook `useScrollLock` has been added to allow zoom functionality while maintaining the same workflow.

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -69,7 +69,6 @@
     "@vanilla-extract/sprinkles": "1.6.1",
     "clsx": "2.1.0",
     "qrcode": "1.5.3",
-    "react-remove-scroll": "2.5.7",
     "ua-parser-js": "^1.0.37"
   },
   "repository": {

--- a/packages/rainbowkit/src/components/Dialog/Dialog.tsx
+++ b/packages/rainbowkit/src/components/Dialog/Dialog.tsx
@@ -3,10 +3,9 @@ import React, {
   ReactNode,
   useCallback,
   useEffect,
-  useState,
 } from 'react';
 import { createPortal } from 'react-dom';
-import { RemoveScroll } from 'react-remove-scroll';
+import { useScrollLock } from '../../hooks/useScrollLock';
 import { isMobile } from '../../utils/isMobile';
 import { Box } from '../Box/Box';
 import { useThemeRootProps } from '../RainbowKitProvider/RainbowKitProvider';
@@ -25,6 +24,8 @@ interface DialogProps {
 }
 
 export function Dialog({ children, onClose, open, titleId }: DialogProps) {
+  useScrollLock(open);
+
   useEffect(() => {
     const handleEscape = (event: KeyboardEvent) =>
       open && event.key === 'Escape' && onClose();
@@ -34,13 +35,6 @@ export function Dialog({ children, onClose, open, titleId }: DialogProps) {
     return () => document.removeEventListener('keydown', handleEscape);
   }, [open, onClose]);
 
-  const [bodyScrollable, setBodyScrollable] = useState(true);
-  useEffect(() => {
-    setBodyScrollable(
-      getComputedStyle(window.document.body).overflow !== 'hidden',
-    );
-  }, []);
-
   const handleBackdropClick = useCallback(() => onClose(), [onClose]);
   const themeRootProps = useThemeRootProps();
   const mobile = isMobile();
@@ -49,28 +43,26 @@ export function Dialog({ children, onClose, open, titleId }: DialogProps) {
     <>
       {open
         ? createPortal(
-            <RemoveScroll enabled={bodyScrollable}>
-              <Box {...themeRootProps}>
-                <Box
-                  {...themeRootProps}
-                  alignItems={mobile ? 'flex-end' : 'center'}
-                  aria-labelledby={titleId}
-                  aria-modal
-                  className={styles.overlay}
-                  onClick={handleBackdropClick}
-                  position="fixed"
-                  role="dialog"
+            <Box {...themeRootProps}>
+              <Box
+                {...themeRootProps}
+                alignItems={mobile ? 'flex-end' : 'center'}
+                aria-labelledby={titleId}
+                aria-modal
+                className={styles.overlay}
+                onClick={handleBackdropClick}
+                position="fixed"
+                role="dialog"
+              >
+                <FocusTrap
+                  className={styles.content}
+                  onClick={stopPropagation}
+                  role="document"
                 >
-                  <FocusTrap
-                    className={styles.content}
-                    onClick={stopPropagation}
-                    role="document"
-                  >
-                    {children}
-                  </FocusTrap>
-                </Box>
+                  {children}
+                </FocusTrap>
               </Box>
-            </RemoveScroll>,
+            </Box>,
             document.body,
           )
         : null}

--- a/packages/rainbowkit/src/hooks/useScrollLock.ts
+++ b/packages/rainbowkit/src/hooks/useScrollLock.ts
@@ -1,0 +1,65 @@
+import { useEffect, useLayoutEffect, useRef } from 'react';
+
+type OriginalStyle = {
+  overflow: CSSStyleDeclaration['overflow'];
+  paddingRight: CSSStyleDeclaration['paddingRight'];
+};
+
+const IS_SERVER = typeof window === 'undefined';
+
+export function useScrollLock(locked: boolean) {
+  const target = useRef<HTMLElement | null>(null);
+  const originalStyle = useRef<OriginalStyle | null>(null);
+
+  const lock = () => {
+    if (target.current) {
+      const { overflow, paddingRight } = target.current.style;
+
+      // Save the original styles
+      originalStyle.current = { overflow, paddingRight };
+
+      // Prevent width reflow
+      const offsetWidth =
+        target.current === document.body
+          ? window.innerWidth
+          : target.current.offsetWidth;
+      const currentPaddingRight =
+        parseInt(window.getComputedStyle(target.current).paddingRight, 10) || 0;
+
+      const scrollbarWidth = offsetWidth - target.current.scrollWidth;
+      target.current.style.paddingRight = `${
+        scrollbarWidth + currentPaddingRight
+      }px`;
+
+      // Lock the scroll
+      target.current.style.overflow = 'hidden';
+    }
+  };
+
+  const unlock = () => {
+    if (target.current && originalStyle.current) {
+      target.current.style.overflow = originalStyle.current.overflow;
+
+      // Only reset padding right if we changed it
+      target.current.style.paddingRight = originalStyle.current.paddingRight;
+    }
+  };
+
+  const useHook = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+  useHook(() => {
+    if (IS_SERVER) return;
+
+    target.current = document.body;
+
+    if (locked) {
+      lock();
+    } else {
+      unlock();
+    }
+
+    return () => {
+      unlock();
+    };
+  }, [locked]);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,9 +447,6 @@ importers:
       react-dom:
         specifier: '>=18'
         version: 18.3.0(react@18.3.0)
-      react-remove-scroll:
-        specifier: 2.5.7
-        version: 2.5.7(@types/react@18.3.0)(react@18.3.0)
       ua-parser-js:
         specifier: ^1.0.37
         version: 1.0.37
@@ -10088,16 +10085,6 @@ packages:
 
   react-remove-scroll@2.5.5:
     resolution: {integrity: sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  react-remove-scroll@2.5.7:
-    resolution: {integrity: sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==}
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -25632,17 +25619,6 @@ snapshots:
       '@types/react': 18.3.0
 
   react-remove-scroll@2.5.5(@types/react@18.3.0)(react@18.3.0):
-    dependencies:
-      react: 18.3.0
-      react-remove-scroll-bar: 2.3.4(@types/react@18.3.0)(react@18.3.0)
-      react-style-singleton: 2.2.1(@types/react@18.3.0)(react@18.3.0)
-      tslib: 2.5.0
-      use-callback-ref: 1.3.0(@types/react@18.3.0)(react@18.3.0)
-      use-sidecar: 1.1.2(@types/react@18.3.0)(react@18.3.0)
-    optionalDependencies:
-      '@types/react': 18.3.0
-
-  react-remove-scroll@2.5.7(@types/react@18.3.0)(react@18.3.0):
     dependencies:
       react: 18.3.0
       react-remove-scroll-bar: 2.3.4(@types/react@18.3.0)(react@18.3.0)


### PR DESCRIPTION
Fixes https://github.com/rainbow-me/rainbowkit/issues/1990

Tested on
- macOS Safari
- macOS Firefox
- macOS Chrome
- iOS Safari

The react-disable-scroll library was removed since this is where the bug originates. Instead, it's replaced with a technique similar to [usehook-ts](https://usehooks-ts.com/react-hook/use-scroll-lock).

https://github.com/rainbow-me/rainbowkit/assets/8162609/24c02139-0aa7-4c75-b5e4-d555302b75ad