### PR TITLE
feat(CoinbaseWalletOptions): add preference

### DIFF
--- a/.changeset/large-lies-wink.md
+++ b/.changeset/large-lies-wink.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Add `preference` to CoinbaseWalletOptions

--- a/packages/rainbowkit/src/config/getDefaultConfig.ts
+++ b/packages/rainbowkit/src/config/getDefaultConfig.ts
@@ -1,6 +1,7 @@
 import type { Transport } from 'viem';
 import { http, CreateConfigParameters } from 'wagmi';
 import { createConfig } from 'wagmi';
+import { CoinbaseWalletParameters } from 'wagmi/connectors';
 import type { RainbowKitChain } from '../components/RainbowKitProvider/RainbowKitChainContext';
 import type { WalletList } from '../wallets/Wallet';
 import { computeWalletConnectMetaData } from '../wallets/computeWalletConnectMetaData';
@@ -34,6 +35,7 @@ interface GetDefaultConfigParameters<
   appIcon?: string;
   wallets?: WalletList;
   projectId: string;
+  coinbaseWalletPreference?: CoinbaseWalletParameters<'4'>['preference'];
 }
 
 const createDefaultTransports = <
@@ -61,6 +63,7 @@ export const getDefaultConfig = <
   appIcon,
   wallets,
   projectId,
+  coinbaseWalletPreference,
   ...wagmiParameters
 }: GetDefaultConfigParameters<chains, transports>) => {
   const { transports, chains, ...restWagmiParameters } = wagmiParameters;
@@ -90,6 +93,7 @@ export const getDefaultConfig = <
       appDescription,
       appUrl,
       appIcon,
+      coinbaseWalletPreference,
       walletConnectParameters: { metadata },
     },
   );

--- a/packages/rainbowkit/src/wallets/connectorsForWallets.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.ts
@@ -1,4 +1,5 @@
 import type { CreateConnectorFn } from 'wagmi';
+import { CoinbaseWalletParameters } from 'wagmi/connectors';
 import { isHexString } from '../utils/colors';
 import { omitUndefinedValues } from '../utils/omitUndefinedValues';
 import { uniqueBy } from '../utils/uniqueBy';
@@ -22,6 +23,7 @@ export interface ConnectorsForWalletsParameters {
   appDescription?: string;
   appUrl?: string;
   appIcon?: string;
+  coinbaseWalletPreference?: CoinbaseWalletParameters<'4'>['preference'];
   walletConnectParameters?: RainbowKitWalletConnectParameters;
 }
 
@@ -29,11 +31,12 @@ export const connectorsForWallets = (
   walletList: WalletList,
   {
     projectId,
-    walletConnectParameters,
+    walletConnectParameters = {},
     appName,
     appDescription,
     appUrl,
     appIcon,
+    coinbaseWalletPreference,
   }: ConnectorsForWalletsParameters,
 ): CreateConnectorFn[] => {
   if (!walletList.length) {
@@ -69,6 +72,8 @@ export const connectorsForWallets = (
         projectId,
         appName,
         appIcon,
+        // `preference` is being used only for `coinbaseWallet` wallet
+        preference: coinbaseWalletPreference,
         // `option` is being used only for `walletConnectWallet` wallet
         options: {
           metadata: walletConnectMetaData,

--- a/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
@@ -1,16 +1,21 @@
 import { CreateConnectorFn, createConnector } from 'wagmi';
-import { coinbaseWallet as coinbaseConnector } from 'wagmi/connectors';
+import {
+  CoinbaseWalletParameters,
+  coinbaseWallet as coinbaseConnector,
+} from 'wagmi/connectors';
 import { isIOS } from '../../../utils/isMobile';
 import { Wallet, WalletDetailsParams } from '../../Wallet';
 
 export interface CoinbaseWalletOptions {
   appName: string;
   appIcon?: string;
+  preference?: CoinbaseWalletParameters<'4'>['preference'];
 }
 
 export const coinbaseWallet = ({
   appName,
   appIcon,
+  preference,
 }: CoinbaseWalletOptions): Wallet => {
   const getUri = (uri: string) => uri;
   const ios = isIOS();
@@ -97,6 +102,7 @@ export const coinbaseWallet = ({
       const connector: CreateConnectorFn = coinbaseConnector({
         appName,
         appLogoUrl: appIcon,
+        preference,
       });
 
       return createConnector((config) => ({


### PR DESCRIPTION
The Coinbase Wallet Wagmi connector now has a `preference` argument, with type `'all' | 'smartWalletOnly' | 'eoaOnly' | undefined`. 

Being able to pass this preference allows app developers better configurability of the Coinbase Wallet popup. Preference based behavior documented [here](https://www.smartwallet.dev/sdk/makeWeb3Provider#parameters). 

Additionally, ahead of Smart Wallet mainnets launch––as of Coinbase Wallet SDK version `4.0.2` (used in [Wagmi ^2.9.5](https://github.com/wevm/wagmi/releases/tag/wagmi%402.9.5))––the Smart Wallet option will no longer show in the Coinbase Wallet popup when the sending app is on `localhost`. Developers found the host based behavior confusing. Now, if developers using versions `^4.0.0` want to see the Smart Wallet in the popup ahead of mainnets launch, they need to pass `smartWalletOnly`. 