### PR TITLE
feat: rainbowkitprovider add classname

### DIFF
--- a/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
@@ -65,6 +65,7 @@ export interface RainbowKitProviderProps {
   avatar?: AvatarComponent;
   modalSize?: ModalSizes;
   locale?: Locale;
+  clasName?: string;
 }
 
 const defaultTheme = lightTheme();
@@ -80,6 +81,7 @@ export function RainbowKitProvider({
   modalSize = ModalSizeOptions.WIDE,
   showRecentTransactions = false,
   theme = defaultTheme,
+  clasName,
 }: RainbowKitProviderProps) {
   usePreloadImages();
   useFingerprint();
@@ -117,7 +119,10 @@ export function RainbowKitProvider({
                         <ShowBalanceProvider>
                           <ModalProvider>
                             {theme ? (
-                              <div {...createThemeRootProps(id)}>
+                              <div
+                                {...createThemeRootProps(id)}
+                                className={clasName}
+                              >
                                 <style
                                   // biome-ignore lint/security/noDangerouslySetInnerHtml: TODO
                                   dangerouslySetInnerHTML={{


### PR DESCRIPTION
When I used the theme attribute, I could not customize the style of the outer div, so I added the className attribute so that I could customize the style of the div, such as the height, etc