### PR TITLE
fix: rainbow button styling export

### DIFF
--- a/.changeset/ninety-berries-sniff.md
+++ b/.changeset/ninety-berries-sniff.md
@@ -1,0 +1,9 @@
+---
+"@rainbow-me/rainbow-button": patch
+---
+
+Resolved an issue where the Rainbow Button styling was not exported. You can now import the styling in your project like so:
+
+```tsx
+import '@rainbow-me/rainbow-button/styles.css';
+```

--- a/packages/rainbow-button/styles.css/package.json
+++ b/packages/rainbow-button/styles.css/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "../dist/index.css"
+}


### PR DESCRIPTION
## Changes
- Resolved an issue where the Rainbow Button styling was not exported at `@rainbow-me/rainbow-button/styles.css`