### PR TITLE
fix: navigator object is empty

### DIFF
--- a/.changeset/wicked-avocados-chew.md
+++ b/.changeset/wicked-avocados-chew.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Resolved an issue where `navigator.userAgent.toLowerCase()` would error out if `navigator.userAgent` was undefined.

--- a/.changeset/wicked-avocados-chew.md
+++ b/.changeset/wicked-avocados-chew.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Resolved an issue where `navigator.userAgent.toLowerCase()` would error out if `navigator.userAgent` was undefined.
+Resolved an issue in development where browser detection would throw an error if `navigator.userAgent` was unavailable in the browser.

--- a/packages/rainbowkit/src/utils/browsers.ts
+++ b/packages/rainbowkit/src/utils/browsers.ts
@@ -26,6 +26,7 @@ export enum BrowserType {
 
 export function getBrowser(): BrowserType {
   if (typeof navigator === 'undefined') return BrowserType.Browser;
+  if (Object.keys(navigator).length === 0) return BrowserType.Browser;
   const ua = navigator.userAgent.toLowerCase();
   // @ts-ignore - brave is not in the navigator type
   if (navigator.brave?.isBrave) return BrowserType.Brave;

--- a/packages/rainbowkit/src/utils/browsers.ts
+++ b/packages/rainbowkit/src/utils/browsers.ts
@@ -26,15 +26,14 @@ export enum BrowserType {
 
 export function getBrowser(): BrowserType {
   if (typeof navigator === 'undefined') return BrowserType.Browser;
-  if (Object.keys(navigator).length === 0) return BrowserType.Browser;
-  const ua = navigator.userAgent.toLowerCase();
+  const ua = navigator.userAgent?.toLowerCase();
   // @ts-ignore - brave is not in the navigator type
   if (navigator.brave?.isBrave) return BrowserType.Brave;
-  if (ua.indexOf('edg/') > -1) return BrowserType.Edge;
-  if (ua.indexOf('op') > -1) return BrowserType.Opera;
+  if (ua?.indexOf('edg/') > -1) return BrowserType.Edge;
+  if (ua?.indexOf('op') > -1) return BrowserType.Opera;
   if (isArc()) return BrowserType.Arc;
-  if (ua.indexOf('chrome') > -1) return BrowserType.Chrome;
-  if (ua.indexOf('firefox') > -1) return BrowserType.Firefox;
+  if (ua?.indexOf('chrome') > -1) return BrowserType.Chrome;
+  if (ua?.indexOf('firefox') > -1) return BrowserType.Firefox;
   if (isSafari()) return BrowserType.Safari;
   return BrowserType.Browser;
 }

--- a/packages/rainbowkit/src/utils/browsers.ts
+++ b/packages/rainbowkit/src/utils/browsers.ts
@@ -1,6 +1,7 @@
 export function isSafari(): boolean {
   return (
     typeof navigator !== 'undefined' &&
+    typeof navigator.userAgent !== 'undefined' &&
     /Version\/([0-9._]+).*Safari/.test(navigator.userAgent) // Source: https://github.com/DamonOehlman/detect-browser/blob/master/src/index.ts
   );
 }
@@ -25,7 +26,9 @@ export enum BrowserType {
 }
 
 export function getBrowser(): BrowserType {
-  if (typeof navigator === 'undefined') return BrowserType.Browser;
+  // bail out if `navigator` or `navigator.userAgent` is not available
+  if (typeof navigator === 'undefined' || Object.keys(navigator).length === 0)
+    return BrowserType.Browser;
   const ua = navigator.userAgent?.toLowerCase();
   // @ts-ignore - brave is not in the navigator type
   if (navigator.brave?.isBrave) return BrowserType.Brave;


### PR DESCRIPTION
Navigator object is empty in some cases and as a result throws an error in getBrowser preventing the user from using the app in dev mode. This checks if is an empty object and then returns Browser.browser, simple fix. reference to https://github.com/rainbow-me/rainbowkit/issues/2036#issuecomment-2156252957