### PR TITLE
docs: change the bitget wallet name

### DIFF
--- a/site/data/es-419/docs/custom-wallet-list.mdx
+++ b/site/data/es-419/docs/custom-wallet-list.mdx
@@ -104,7 +104,7 @@ Las siguientes billeteras se proporcionan a través del objeto `wallet` (en orde
 import { argentWallet } from '@rainbow-me/rainbowkit/wallets';
 ```
 
-#### BitKeep
+#### Bitget
 
 ```tsx
 import { bitgetWallet } from '@rainbow-me/rainbowkit/wallets';

--- a/site/data/pt-BR/docs/custom-wallet-list.mdx
+++ b/site/data/pt-BR/docs/custom-wallet-list.mdx
@@ -104,7 +104,7 @@ As seguintes carteiras são fornecidas através do objeto `wallet` (em ordem alf
 import { argentWallet } from '@rainbow-me/rainbowkit/wallets';
 ```
 
-#### BitKeep
+#### Bitget
 
 ```tsx
 import { bitgetWallet } from '@rainbow-me/rainbowkit/wallets';

--- a/site/data/zh-CN/docs/custom-wallet-list.mdx
+++ b/site/data/zh-CN/docs/custom-wallet-list.mdx
@@ -104,7 +104,7 @@ import { safeWallet } from '@rainbow-me/rainbowkit/wallets';
 import { argentWallet } from '@rainbow-me/rainbowkit/wallets';
 ```
 
-#### BitKeep
+#### Bitget
 
 ```tsx
 import { bitgetWallet } from '@rainbow-me/rainbowkit/wallets';


### PR DESCRIPTION
This PR modifies the wallet list documentation for Spanish, Portuguese, and Simplified Chinese languages. The wallet name BitKeep has been changed to Bitget.