### PR TITLE
fix: wrong browser link and background shown

### DIFF
--- a/.changeset/tasty-cobras-fix.md
+++ b/.changeset/tasty-cobras-fix.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Resolved an issue where `Object.keys(navigator)` was returning an empty array, causing to return the default browser link instead of the current browser link.

--- a/.changeset/tasty-cobras-fix.md
+++ b/.changeset/tasty-cobras-fix.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Resolved an issue where `Object.keys(navigator)` was returning an empty array, causing to return the default browser link instead of the current browser link.
+Resolved an issue where `Object.keys(navigator).length` returned `0` because it couldn't access object properties due to how `navigator` window API works. This fix should now show the desired browser link and background when trying to install an extension from connect modal.

--- a/packages/rainbowkit/src/utils/browsers.ts
+++ b/packages/rainbowkit/src/utils/browsers.ts
@@ -27,8 +27,7 @@ export enum BrowserType {
 
 export function getBrowser(): BrowserType {
   // bail out if `navigator` or `navigator.userAgent` is not available
-  if (typeof navigator === 'undefined' || Object.keys(navigator).length === 0)
-    return BrowserType.Browser;
+  if (typeof navigator === 'undefined') return BrowserType.Browser;
   const ua = navigator.userAgent?.toLowerCase();
   // @ts-ignore - brave is not in the navigator type
   if (navigator.brave?.isBrave) return BrowserType.Brave;


### PR DESCRIPTION
## Changes
- `Object.keys(navigator).length` was returning `0`. This was due to the `navigator` window API inability to access object properties. Now the correct browser link and background is displayed when attempting to install an extension from the connect modal.

## Screen recordings / screenshots

**Before**
 
<img width="732" alt="before" src="https://github.com/rainbow-me/rainbowkit/assets/53529533/b5533557-a0d2-4da8-b944-e583fa51b671">


**After**

<img width="736" alt="after" src="https://github.com/rainbow-me/rainbowkit/assets/53529533/e25bd36b-1dc8-4d9b-b9af-be13abea9a1a">

## What to test
1. Make sure it shows the correct browser link and background when attempting to install an extension from the connect modal.