### PR TITLE
fix: phantom wallet eip-6963 connector not appearing

### DIFF
--- a/.changeset/red-apples-know.md
+++ b/.changeset/red-apples-know.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Resolved an issue where the Phantom wallet did not appear as an EIP-6963 connector.

--- a/packages/rainbowkit/src/wallets/groupedWallets.ts
+++ b/packages/rainbowkit/src/wallets/groupedWallets.ts
@@ -27,7 +27,7 @@ export const isRainbowKitConnector = (wallet: WalletInstance) => {
 export const isEIP6963Connector = (wallet: WalletInstance) => {
   return !!(
     !wallet.isRainbowKitConnector &&
-    wallet.icon?.startsWith('data:image') &&
+    wallet.icon?.replace(/\n/g, '').startsWith('data:image') &&
     wallet.uid &&
     wallet.name
   );


### PR DESCRIPTION
## Changes
- Phantom wallet had `\n` prefix string to their icon url which caused it to not show up in "Installed" section in connect modal as an EIP-6963 connector.
 