### PR TITLE
fix: `metaMaskWallet` causing the app to crash due to `window.ethereum.providers` override

### DIFF
--- a/.changeset/late-toys-confess.md
+++ b/.changeset/late-toys-confess.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fixed an issue where `metaMaskWallet` would cause the app to crash if MetaMask, Coinbase, and Rainbow wallets were installed. This happened due to a conflict with `window.ethereum.providers`, which caused an infinite loop when these wallets overrode each other.

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -43,7 +43,6 @@ function isMetaMask(ethereum?: WindowProvider['ethereum']): boolean {
   if (ethereum.isPhantom) return false;
   if (ethereum.isPortal) return false;
   if (ethereum.isRabby) return false;
-  if (ethereum.isRainbow) return false;
   if (ethereum.isStatus) return false;
   if (ethereum.isTalisman) return false;
   if (ethereum.isTally) return false;


### PR DESCRIPTION
### Changes
- Fixed an issue where `metaMaskWallet` would cause the app to crash if MetaMask, Coinbase, and Rainbow wallets were installed. This happened due to a conflict with `window.ethereum.providers`, which caused an infinite loop when these wallets overrode each other.