### PR TITLE
fix: resolve issue where Kaikas wallet does not prompt user to connect upon icon click

### DIFF
--- a/packages/rainbowkit/src/types/utils.ts
+++ b/packages/rainbowkit/src/types/utils.ts
@@ -86,6 +86,7 @@ export type WalletProvider = Evaluate<
 export type WindowProvider = {
   coinbaseWalletExtension?: WalletProvider | undefined;
   ethereum?: WalletProvider | undefined;
+  klaytn?: WalletProvider | undefined;
   phantom?: { ethereum: WalletProvider } | undefined;
   providers?: any[] | undefined; // Adjust the type as needed
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
@@ -93,7 +93,7 @@ export const kaikasWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({
-          namespace: 'ethereum',
+          namespace: 'klaytn',
         }),
   };
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
@@ -4,6 +4,7 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
+import { isMobile } from '../../../utils/isMobile';
 
 export type KaikasWalletOptions = DefaultWalletOptions;
 
@@ -92,8 +93,6 @@ export const kaikasWallet = ({
           projectId,
           walletConnectParameters,
         })
-      : getInjectedConnector({
-          namespace: 'klaytn',
-        }),
+      : getInjectedConnector(isMobile() ? { target: typeof window !== 'undefined' ? window.klaytn : undefined } : { namespace: 'klaytn' }),
   };
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
@@ -93,7 +93,7 @@ export const kaikasWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({
-          namespace: 'ethereum',
+          target: typeof window !== 'undefined' ? window.ethereum : undefined,
         }),
   };
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
@@ -17,8 +17,8 @@ export const kaikasWallet = ({
 
   const shouldUseWalletConnect = !isKaikasWalletInjected;
 
-  const getUri = (uri: string) => {
-    return `kaikas://walletconnect?uri=${encodeURIComponent(uri)}`;
+  const getUri = () => {
+    return `kaikas://wallet/browser?url=${encodeURI(window.location.origin)}`
   };
 
   return {
@@ -36,7 +36,7 @@ export const kaikasWallet = ({
       android: 'https://play.google.com/store/apps/details?id=io.klutch.wallet',
       mobile: 'https://app.kaikas.io',
     },
-    mobile: { getUri: shouldUseWalletConnect ? getUri : undefined },
+    mobile: { getUri: shouldUseWalletConnect ? getUri : (uri: string) => `kaikas://wc?uri=${encodeURIComponent(uri)}` },
     qrCode: shouldUseWalletConnect
       ? {
           getUri: (uri: string) => uri,
@@ -93,7 +93,7 @@ export const kaikasWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({
-          namespace: 'klaytn',
+          namespace: 'ethereum',
         }),
   };
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
@@ -93,7 +93,7 @@ export const kaikasWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({
-          target: typeof window !== 'undefined' ? window.ethereum : undefined,
+          namespace: 'ethereum',
         }),
   };
 };


### PR DESCRIPTION
Currently, clicking on the Kaikas app on mobile takes users to the Kaikas app but does not prompt them to link their wallet.

This seems to be because the Kaikas app does not support EIP-1193.
So I made it work by making the service available in the browser inside the Kaikas app

Now Kaikas is working properly on mobile 😄