### PR TITLE
chore: cleanup polyfills.ts in create-react-app example

### DIFF
--- a/examples/with-create-react-app/package.json
+++ b/examples/with-create-react-app/package.json
@@ -17,7 +17,8 @@
     "util": "0.12.5",
     "viem": "2.9.31",
     "wagmi": "^2.9.2",
-    "@tanstack/react-query": "^5.28.4"
+    "@tanstack/react-query": "^5.28.4",
+    "buffer": "^6.0.3"
   },
   "scripts": {
     "dev": "GENERATE_SOURCEMAP=false react-scripts start",

--- a/examples/with-create-react-app/src/index.tsx
+++ b/examples/with-create-react-app/src/index.tsx
@@ -1,3 +1,4 @@
+import './polyfills';
 import '@rainbow-me/rainbowkit/styles.css';
 import './index.css';
 import React from 'react';

--- a/examples/with-create-react-app/src/polyfills.ts
+++ b/examples/with-create-react-app/src/polyfills.ts
@@ -1,0 +1,3 @@
+import { Buffer } from 'buffer';
+(window as any).global = window;
+(window as any).Buffer = Buffer;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
       react-scripts:
         specifier: 5.0.1
         version: 5.0.1(@babel/plugin-syntax-flow@7.24.1(@babel/core@7.16.0))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.16.0))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.20.2)(eslint@8.15.0)(react@18.3.0)(type-fest@3.13.1)(typescript@5.4.2)
@@ -2899,9 +2902,11 @@ packages:
   '@humanwhocodes/config-array@0.9.5':
     resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/object-schema@1.2.1':
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@ioredis/commands@1.2.0':
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
@@ -10522,6 +10527,7 @@ packages:
 
   rimraf@2.6.3:
     resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@3.0.2:


### PR DESCRIPTION
Add a buffer polyfill in the create-react-app example.

* **Add polyfills.ts file:**
  - Create `examples/with-create-react-app/src/polyfills.ts` file.
  - Import `Buffer` from `buffer`.
  - Assign `window` to `global` on `window`.
  - Assign `Buffer` to `Buffer` on `window`.

* **Modify index.tsx:**
  - Add import statement for `polyfills.ts` at the top of the file.

* **Update package.json:**
  - Add `buffer` as a dependency.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rainbow-me/rainbowkit?shareId=471f6986-400f-47fc-b479-cd3c57621382).