### PR TITLE
chore: tree shake chain and account modals

### DIFF
--- a/.changeset/wise-phones-refuse.md
+++ b/.changeset/wise-phones-refuse.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Implemented tree shaking for chain and account modals to prevent them from bundling when unused.


### PR DESCRIPTION
## Changes

Applied tree shaking for chain and account modals to prevent them from bundling when unused.

## Screen recordings / screenshots

Here you can see that account and chain modals are bundled separately if they're being used.


https://github.com/user-attachments/assets/8fac1595-89a8-4f01-8e63-7f83b406897a



## What to test

- Whenever you don't use `useAccountModal` hook you shouldn't see account modal being bundled in network tab.
- Whenever you don't use `useChainModal` hook you shouldn't see chain modal being bundled in network tab.