### PR TITLE
fix: include safeWallet in getDefaultConfig

### DIFF
--- a/.changeset/twelve-poets-itch.md
+++ b/.changeset/twelve-poets-itch.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Added `safeWallet` wallet connector to `getDefaultConfig` by default to improve the Safe Wallet app browser connection flow with a Safe button included by default in the wallet list

--- a/packages/rainbowkit/src/config/getDefaultConfig.ts
+++ b/packages/rainbowkit/src/config/getDefaultConfig.ts
@@ -9,6 +9,7 @@ import {
   coinbaseWallet,
   metaMaskWallet,
   rainbowWallet,
+  safeWallet,
   walletConnectWallet,
 } from '../wallets/walletConnectors';
 
@@ -77,6 +78,7 @@ export const getDefaultConfig = <
       {
         groupName: 'Popular',
         wallets: [
+          safeWallet,
           rainbowWallet,
           coinbaseWallet,
           metaMaskWallet,


### PR DESCRIPTION
## Changes
- follow up to #2060 to include `safeWallet` by default in `getDefaultConfig` wallet list