### PR TITLE
fix: download option, back button for download flow

### DIFF
--- a/.changeset/silly-mugs-melt.md
+++ b/.changeset/silly-mugs-melt.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fixed an issue where some options in the "Get Wallet" flow would appear as a blank page, or lack a back button to return to the Connect flow.

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -300,7 +300,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
         ? WalletStep.Connect
         : compactModeEnabled
           ? WalletStep.None
-          : WalletStep.Get;
+          : initialWalletStep;
       break;
     case WalletStep.Download:
       walletContent = selectedWallet && (

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -86,6 +86,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
   const wallets = useWalletConnectors(mergeEIP6963WithRkConnectors)
     .filter((wallet) => wallet.ready || !!wallet.extensionDownloadUrl)
     .sort((a, b) => a.groupIndex - b.groupIndex);
+  const unfilteredWallets = useWalletConnectors();
 
   const groupedWallets = groupBy(wallets, (wallet) => wallet.groupName);
 
@@ -172,8 +173,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
   };
 
   const getWalletDownload = (id: string) => {
-    setSelectedOptionId(id);
-    const sWallet = wallets.find((w) => id === w.id);
+    const sWallet = unfilteredWallets.find((w) => id === w.id);
     const isMobile = sWallet?.downloadUrls?.qrCode;
     const isDesktop = !!sWallet?.desktopDownloadUrl;
     const isExtension = !!sWallet?.extensionDownloadUrl;
@@ -300,7 +300,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
         ? WalletStep.Connect
         : compactModeEnabled
           ? WalletStep.None
-          : null;
+          : WalletStep.Get;
       break;
     case WalletStep.Download:
       walletContent = selectedWallet && (


### PR DESCRIPTION
## Changes
- duplicate usage of `useWalletConnectors` as an unfiltered lookup for eip-6963 connectors in `getWalletDownload`
- displaying back button in get wallet flow
- avoid selecting populating connector via get flow (wallet list selection)