### PR TITLE
separate wagmi config params from config

### DIFF
--- a/packages/rainbowkit/src/config/getDefaultConfig.ts
+++ b/packages/rainbowkit/src/config/getDefaultConfig.ts
@@ -1,106 +1,16 @@
-import type { Transport } from 'viem';
-import { http, type CreateConfigParameters } from 'wagmi';
 import { createConfig } from 'wagmi';
-import type { RainbowKitChain } from '../components/RainbowKitProvider/RainbowKitChainContext';
-import type { WalletList } from '../wallets/Wallet';
-import { computeWalletConnectMetaData } from '../wallets/computeWalletConnectMetaData';
-import { connectorsForWallets } from '../wallets/connectorsForWallets';
 import {
-  coinbaseWallet,
-  metaMaskWallet,
-  rainbowWallet,
-  safeWallet,
-  walletConnectWallet,
-} from '../wallets/walletConnectors';
-
-export type _chains = readonly [RainbowKitChain, ...RainbowKitChain[]];
-
-// Define the '_transports' type as a Record
-// It maps each 'Chain' id to a 'Transport'
-export type _transports = Record<_chains[number]['id'], Transport>;
-
-interface GetDefaultConfigParameters<
-  chains extends _chains,
-  transports extends _transports,
-> extends Omit<
-    CreateConfigParameters<chains, transports>,
-    // If you use 'client' you can't use 'transports' (we force to use 'transports')
-    // More info here https://wagmi.sh/core/api/createConfig#client
-    // We will also use our own 'connectors' instead of letting user specifying it
-    'client' | 'connectors'
-  > {
-  appName: string;
-  appDescription?: string;
-  appUrl?: string;
-  appIcon?: string;
-  wallets?: WalletList;
-  projectId: string;
-}
-
-const createDefaultTransports = <
-  chains extends _chains,
-  transports extends _transports,
->(
-  chains: chains,
-): transports => {
-  const transportsObject = chains.reduce((acc: transports, chain) => {
-    const key = chain.id as keyof transports;
-    acc[key] = http() as transports[keyof transports]; // Type assertion here
-    return acc;
-  }, {} as transports);
-
-  return transportsObject;
-};
+  type GetDefaultConfigParameters,
+  type _chains,
+  type _transports,
+  getDefaultConfigParameters,
+} from './getDefaultConfigParameters';
 
 export const getDefaultConfig = <
   chains extends _chains,
   transports extends _transports,
->({
-  appName,
-  appDescription,
-  appUrl,
-  appIcon,
-  wallets,
-  projectId,
-  ...wagmiParameters
-}: GetDefaultConfigParameters<chains, transports>) => {
-  const { transports, chains, ...restWagmiParameters } = wagmiParameters;
-
-  const metadata = computeWalletConnectMetaData({
-    appName,
-    appDescription,
-    appUrl,
-    appIcon,
-  });
-
-  const connectors = connectorsForWallets(
-    wallets || [
-      {
-        groupName: 'Popular',
-        wallets: [
-          safeWallet,
-          rainbowWallet,
-          coinbaseWallet,
-          metaMaskWallet,
-          walletConnectWallet,
-        ],
-      },
-    ],
-    {
-      projectId,
-      appName,
-      appDescription,
-      appUrl,
-      appIcon,
-      walletConnectParameters: { metadata },
-    },
-  );
-
-  return createConfig({
-    connectors,
-    chains,
-    transports:
-      transports || createDefaultTransports<chains, transports>(chains),
-    ...restWagmiParameters,
-  });
+>(
+  params: GetDefaultConfigParameters<chains, transports>,
+) => {
+  return createConfig(getDefaultConfigParameters(params));
 };

--- a/packages/rainbowkit/src/config/getDefaultConfigParameters.ts
+++ b/packages/rainbowkit/src/config/getDefaultConfigParameters.ts
@@ -1,0 +1,105 @@
+import type { Transport } from 'viem';
+import { http, type CreateConfigParameters } from 'wagmi';
+import type { RainbowKitChain } from '../components/RainbowKitProvider/RainbowKitChainContext';
+import type { WalletList } from '../wallets/Wallet';
+import { computeWalletConnectMetaData } from '../wallets/computeWalletConnectMetaData';
+import { connectorsForWallets } from '../wallets/connectorsForWallets';
+import {
+  coinbaseWallet,
+  metaMaskWallet,
+  rainbowWallet,
+  safeWallet,
+  walletConnectWallet,
+} from '../wallets/walletConnectors';
+
+export type _chains = readonly [RainbowKitChain, ...RainbowKitChain[]];
+
+// Define the '_transports' type as a Record
+// It maps each 'Chain' id to a 'Transport'
+export type _transports = Record<_chains[number]['id'], Transport>;
+
+export interface GetDefaultConfigParameters<
+  chains extends _chains,
+  transports extends _transports,
+> extends Omit<
+    CreateConfigParameters<chains, transports>,
+    // If you use 'client' you can't use 'transports' (we force to use 'transports')
+    // More info here https://wagmi.sh/core/api/createConfig#client
+    // We will also use our own 'connectors' instead of letting user specifying it
+    'client' | 'connectors'
+  > {
+  appName: string;
+  appDescription?: string;
+  appUrl?: string;
+  appIcon?: string;
+  wallets?: WalletList;
+  projectId: string;
+}
+
+const createDefaultTransports = <
+  chains extends _chains,
+  transports extends _transports,
+>(
+  chains: chains,
+): transports => {
+  const transportsObject = chains.reduce((acc: transports, chain) => {
+    const key = chain.id as keyof transports;
+    acc[key] = http() as transports[keyof transports]; // Type assertion here
+    return acc;
+  }, {} as transports);
+
+  return transportsObject;
+};
+
+export const getDefaultConfigParameters = <
+  chains extends _chains,
+  transports extends _transports,
+>({
+  appName,
+  appDescription,
+  appUrl,
+  appIcon,
+  wallets,
+  projectId,
+  ...wagmiParameters
+}: GetDefaultConfigParameters<chains, transports>) => {
+  const { transports, chains, ...restWagmiParameters } = wagmiParameters;
+
+  const metadata = computeWalletConnectMetaData({
+    appName,
+    appDescription,
+    appUrl,
+    appIcon,
+  });
+
+  const connectors = connectorsForWallets(
+    wallets || [
+      {
+        groupName: 'Popular',
+        wallets: [
+          safeWallet,
+          rainbowWallet,
+          coinbaseWallet,
+          metaMaskWallet,
+          walletConnectWallet,
+        ],
+      },
+    ],
+    {
+      projectId,
+      appName,
+      appDescription,
+      appUrl,
+      appIcon,
+      walletConnectParameters: { metadata },
+    },
+  );
+
+  return {
+    connectors,
+    chains,
+    transports:
+      transports || createDefaultTransports<chains, transports>(chains),
+    ...restWagmiParameters,
+  };
+};

--- a/packages/rainbowkit/src/index.ts
+++ b/packages/rainbowkit/src/index.ts
@@ -2,6 +2,7 @@ export { ConnectButton } from './components/ConnectButton/ConnectButton';
 export { WalletButton } from './components/WalletButton/WalletButton';
 export { RainbowKitProvider } from './components/RainbowKitProvider/RainbowKitProvider';
 export { getDefaultConfig } from './config/getDefaultConfig';
+export { getDefaultConfigParameters } from './config/getDefaultConfigParameters';
 export { getDefaultWallets } from './wallets/getDefaultWallets';
 export { getWalletConnectConnector } from './wallets/getWalletConnectConnector';
 export { connectorsForWallets } from './wallets/connectorsForWallets';


### PR DESCRIPTION
I want to use a custom Viem client with RainbowKit so that I can extend with a few custom actions, but the way RainbowKit constructs a Wagmi client means I can't make these changes on the client itself.

By separating out the `getDefaultConfigParameters` from `getDefaultConfig`, I can still lean on RainbowKit defaults, make adjustments to these params, then call `createConfig` with the adjusted params. This felt like an easier lift than adding support for the `client` arg here.

This change is backwards compatible, just relocates the param creation to its own file/export.