### PR TITLE
docs(zh-CN): improve Chinese translations for custom features

### DIFF
--- a/site/data/zh-CN/docs/custom-connect-button.mdx
+++ b/site/data/zh-CN/docs/custom-connect-button.mdx
@@ -122,7 +122,7 @@ export const YourApp = () => {
       required: false,
       type: 'object | undefined',
       description:
-        '包含当前账户详细信息的对象，详情如下所述',
+        '包含当前账户详细信息的对象，如下所述',
     },
     {
       name: 'account.address',
@@ -130,8 +130,7 @@ export const YourApp = () => {
       type: 'string',
       description: (
         <>
-          完整的账户地址，例如：
-          "0x7a3d05c70581bD345fe117c06e45f9669205384f"
+          完整的账户地址，例如 "0x7a3d05c70581bD345fe117c06e45f9669205384f"
         </>
       ),
     },
@@ -139,7 +138,7 @@ export const YourApp = () => {
       name: 'account.balanceDecimals',
       required: false,
       type: 'string | undefined	',
-      description: '以小数表示的账户余额',
+      description: '账户余额（以小数表示）',
     },
     {
       name: 'account.balanceFormatted',
@@ -147,7 +146,7 @@ export const YourApp = () => {
       type: 'string | undefined	',
       description: (
         <>
-          格式化为字符串的账户余额，例如：{' '}
+          账户余额格式化为字符串，例如 {' '}
           <code>1.234567890123456789</code>
         </>
       ),
@@ -158,7 +157,7 @@ export const YourApp = () => {
       type: 'string | undefined	',
       description: (
         <>
-          余额的货币符号，例如：<code>ETH</code>
+          账户余额的符号，例如 <code>ETH</code>
         </>
       ),
     },
@@ -168,7 +167,7 @@ export const YourApp = () => {
       type: 'string | undefined	',
       description: (
         <>
-          格式化为3位有效数字的余额以及符号，例如：<code>1.23 ETH</code>
+          将余额格式化为3位有效数字，并带有符号，例如{' '}<code>1.23 ETH</code>
         </>
       ),
     },
@@ -178,8 +177,7 @@ export const YourApp = () => {
       type: 'string',
       description: (
         <>
-          ENS 名称或地址的缩写版本，例如：{' '}
-          <code>"rainbowwallet.eth"</code> 或 <code>"0x7a…384f"</code>
+          ENS 名称或地址的截断版本，例如{' '}<code>"rainbowwallet.eth"</code> 或 <code>"0x7a…384f"</code>
         </>
       ),
     },
@@ -187,7 +185,7 @@ export const YourApp = () => {
       name: 'account.ensAvatar',
       required: false,
       type: 'string	| undefined',
-      description: 'ENS头像 URI',
+      description: 'ENS 头像的 URI',
     },
     {
       name: 'account.ensName',
@@ -195,7 +193,7 @@ export const YourApp = () => {
       type: 'string	| undefined',
       description: (
         <>
-          ENS名称，例如：<code>rainbowwallet.eth</code>
+          ENS名称，例如{' '}<code>rainbowwallet.eth</code>
         </>
       ),
     },
@@ -204,7 +202,7 @@ export const YourApp = () => {
       required: false,
       type: 'boolean',
       description:
-        '布尔值，指示账户是否有当前链的待处理交易',
+        '布尔值，表示当前链上该账户是否有待处理的交易',
     },
   ]}
 />
@@ -218,27 +216,27 @@ export const YourApp = () => {
       required: false,
       type: 'object | undefined',
       description:
-        '包含当前链详细信息的对象，详情如下所述',
+        '包含当前链的详细信息的对象，如下所述',
     },
     {
       name: 'chain.hasIcon',
       required: false,
       type: 'boolean',
-      description: '链是否有指定的图标',
+      description: '是否为链指定了图标',
     },
     {
       name: 'chain.iconUrl',
       required: false,
       type: 'string | undefined',
       description:
-        '链图标的 URL（在下载 Base64 数据 URLs 时可能也未定义）',
+        '链图标 URL（在下载 Base64 数据 URL 时可能也是未定义的）',
     },
     {
       name: 'chain.iconBackground',
       required: false,
       type: 'string | undefined',
       description:
-        '图标加载时可见的链图标背景',
+        '图片加载时会显示的链图标背景',
     },
     {
       name: 'chain.id',
@@ -246,7 +244,7 @@ export const YourApp = () => {
       type: 'number',
       description: (
         <>
-          链ID，例如：<code>1</code>
+          链 ID,例如 <code>1</code>
         </>
       ),
     },
@@ -256,7 +254,7 @@ export const YourApp = () => {
       type: 'string | undefined',
       description: (
         <>
-          链名称，例如：<code>"Ethereum"</code>
+          链名称，例如 <code>"Ethereum"</code>
         </>
       ),
     },
@@ -265,7 +263,7 @@ export const YourApp = () => {
       required: false,
       type: 'boolean | undefined',
       description:
-        '布尔值，指示当前链是否不受支持',
+        '一个布尔值，表示当前链是否被支持。',
     },
   ]}
 />
@@ -278,44 +276,44 @@ export const YourApp = () => {
       name: 'openAccountModal',
       required: false,
       type: '() => void',
-      description: '打开账户模态的函数',
+      description: '打开账户模态窗口的函数',
     },
     {
       name: 'openChainModal',
       required: false,
       type: '() => void',
-      description: '打开链模态的函数',
+      description: '打开链模态对话框的函数',
     },
     {
       name: 'openConnectModal',
       required: false,
       type: '() => void',
-      description: '打开连接模态的函数',
+      description: '打开连接钱包模态框的函数',
     },
     {
       name: 'accountModalOpen',
       required: false,
       type: 'boolean',
       description:
-        '布尔值，指示账户模态是否已打开',
+        '指示账户模态窗口是否打开的布尔值',
     },
     {
       name: 'chainModalOpen',
       required: false,
       type: 'boolean',
-      description: '布尔值，指示链模态是否已打开',
+      description: '一个布尔值，指示链式模态框是否打开',
     },
     {
       name: 'connectModalOpen',
       required: false,
       type: 'boolean',
       description:
-        '布尔值，指示连接模态是否已打开',
+        '表示连接模态框是否打开的布尔值',
     },
   ]}
 />
 
-### 通用状态属性
+### 常规状态属性
 
 <PropsTable
   data={[
@@ -331,7 +329,8 @@ export const YourApp = () => {
       required: false,
       type: '"loading" | "unauthenticated" | "authenticated" | undefined',
       description:
-        '身份验证状态，或如果未配置身份验证，则为未定义',
+        '身份验证状态，如果尚未配置身份验证，则为 undefined',
     },
   ]}
 />
+

--- a/site/data/zh-CN/docs/custom-wallets.mdx
+++ b/site/data/zh-CN/docs/custom-wallets.mdx
@@ -19,19 +19,19 @@ description: 创建一个自定义钱包
       name: 'id',
       required: true,
       type: 'string',
-      description: '每个钱包的唯一ID',
+      description: '钱包的唯一 ID',
     },
     {
       name: 'name',
       required: true,
       type: 'string',
-      description: '可读的钱包名称',
+      description: '人类可读的钱包名称',
     },
     {
       name: 'rdns',
       required: false,
       type: 'string',
-      description: '支持EIP6963的钱包的RDNS',
+      description: '支持 EIP6963 的钱包的 RDNS',
     },
     {
       name: 'shortName',
@@ -44,20 +44,20 @@ description: 创建一个自定义钱包
       required: true,
       type: 'string | (() => Promise<string>)',
       description:
-        '钱包图标的URL，或解析为Base64数据URL的Promise',
+        '钱包图标的网址，或者一个解析为 Base64 数据网址的 promise',
     },
     {
       name: 'iconAccent',
       required: false,
       type: 'string',
       description:
-        '用于同时拥有浏览器扩展和移动应用的钱包下载流程中的强调颜色',
+        '在下载流程中用于同时具有浏览器扩展和移动应用程序的钱包的强调色',
     },
     {
       name: 'iconBackground',
       required: true,
       type: 'string',
-      description: '钱包图标加载期间的背景颜色',
+      description: '钱包图标加载时的背景颜色',
     },
     {
       name: 'installed',
@@ -65,8 +65,7 @@ description: 创建一个自定义钱包
       type: 'boolean | undefined',
       description: (
         <>
-          钱包是否安装，或为{' '}
-          <code>undefined</code>如果不确定
+            钱包是否已知安装，如果未安装则为 <code>undefined</code>
         </>
       ),
     },
@@ -75,7 +74,7 @@ description: 创建一个自定义钱包
       required: false,
       type: '{ android?: string, ios?: string, mobile?: string, qrCode?: string, chrome?: string, firefox?: string, edge?: string, safari?: string, opera?: string, browserExtension?: string } | undefined',
       typeSimple: 'DownloadUrls | undefined',
-      description: '包含下载URL的对象',
+      description: '包含下载网址的对象',
     },
     {
       name: 'hidden',
@@ -83,7 +82,7 @@ description: 创建一个自定义钱包
       type: '(args: { wallets: Array<{ id: string, connector: Connector, installed?: boolean }> }) => boolean',
       typeSimple: '(args) => boolean | undefined',
       description:
-        '用于计算该钱包是否应从列表中隐藏的函数。这对定义通用备用钱包很有用，例如内置的“注入式钱包”备用使用此功能',
+        '用于检测这个钱包是否应该从列表中隐藏的函数。这对于定义通用回退钱包很有用,例如内置的 "Injected Wallet" 回退利用了此功能',
     },
     {
       name: 'createConnector',
@@ -91,7 +90,7 @@ description: 创建一个自定义钱包
       type: '() => RainbowKitConnector',
       typeSimple: 'RainbowKitConnector',
       description:
-        '用于提供不同连接方法的连接器实例和配置的函数，将在下面介绍',
+        '提供连接器实例和不同连接方法的配置的函数，如下所述',
     },
     {
       name: 'mobile',
@@ -99,14 +98,14 @@ description: 创建一个自定义钱包
       type: '{ getUri?: (uri: string) => string }',
       typeSimple: 'object',
       description:
-        '用于解析移动钱包连接URI的函数',
+        '用于解析移动钱包连接 URI 的函数',
     },
     {
       name: 'desktop',
       required: false,
       type: '{ getUri?: (uri: string) => string }',
       typeSimple: 'object',
-      description: '用于解析桌面应用程序深层链接的函数',
+      description: '用于解析桌面应用深层链接的函数',
     },
     {
       name: 'qrCode',
@@ -114,7 +113,7 @@ description: 创建一个自定义钱包
       type: "{ getUri: (uri: string) => string, instructions?: { learnMoreUrl: string, steps: Array<{ step: 'install' | 'create' | 'scan', title: string, description: string }> }}}",
       typeSimple: 'object',
       description:
-        '对象中包含解析二维码URI的函数，以及可选的移动钱包设置说明',
+        '包含一个用于解析二维码URI的函数的对象,以及可选的移动钱包设置说明',
     },
     {
       name: 'extension',
@@ -122,14 +121,14 @@ description: 创建一个自定义钱包
       type: "{ instructions?: { learnMoreUrl: string, steps: Array<{ step: 'install' | 'create' | 'scan', title: string, description: string }> }}}",
       typeSimple: 'object',
       description:
-        '对象中包含可选的浏览器扩展程序安装说明',
+        '包含可选的浏览器扩展设置说明的对象',
     },
     {
       name: 'createConnector',
       required: true,
       type: "createConnector: (details: WalletDetailsParams) => CreateConnectorFn",
       typeSimple: '(details: WalletDetailsParams) => CreateConnectorFn',
-      description: '用于提供连接器实例的函数',
+      description: '提供连接器实例的函数',
     },
   ]}
 />
@@ -142,64 +141,64 @@ description: 创建一个自定义钱包
       name: 'android',
       required: false,
       type: 'string',
-      description: 'Google Play URL',
+      description: 'Google Play 网址',
     },
     {
       name: 'ios',
       required: false,
       type: 'string',
-      description: 'Apple App Store URL',
+      description: 'Apple App Store 网址',
     },
     {
       name: 'mobile',
       required: false,
       type: 'string',
       description:
-        '当`android`或`ios`不可用时移动用户的着陆页',
+        '当 `android` 或 `ios` 不可用时，移动用户的登录页面',
     },
     {
       name: 'qrCode',
       required: false,
       type: 'string',
       description:
-        '扫描移动下载二维码后的用户着陆页',
+        '移动端下载二维码扫描后的登陆页面',
     },
     {
       name: 'chrome',
       required: false,
       type: 'string',
-      description: 'Chrome Web Store URL',
+      description: 'Chrome Web Store 网址',
     },
     {
       name: 'edge',
       required: false,
       type: 'string',
-      description: 'Microsoft Edge Add-ons URL',
+      description: 'Microsoft Edge Add-ons 网址',
     },
     {
       name: 'firefox',
       required: false,
       type: 'string',
-      description: 'Firefox 浏览器附加组件 URL',
+      description: 'Firefox Browser Add-ons 网址',
     },
     {
       name: 'opera',
       required: false,
       type: 'string',
-      description: 'Opera 附加组件 URL',
+      description: 'Opera add-ons 网址',
     },
     {
       name: 'safari',
       required: false,
       type: 'string',
-      description: 'Mac App Store URL',
+      description: 'Mac App Store 网址',
     },
     {
       name: 'browserExtension',
       required: false,
       type: 'string',
       description:
-        '桌面扩展用户的着陆页，当浏览器兼容的URL不可用时',
+        '当浏览器不兼容某些网址时，桌面扩展用户会看到的登陆页面',
     },
   ]}
 />


### PR DESCRIPTION
## Description
This PR improves Chinese translations for the custom connect button and custom wallets documentation.

### Changes Made
- Enhanced translation clarity in `custom-connect-button.mdx`
- Refined Chinese content in `custom-wallets.mdx`
- Fixed terminology consistency
- Improved readability for Chinese users

### Checklist
- [x] Documentation changes only
- [x] Followed translation style guide
- [x] Maintained markdown formatting
- [x] No code changes
- [x] Passed all lint, format and test checks (`pnpm lint`, `pnpm format`, `pnpm test`)

### Screenshots (if applicable)
<!-- Add screenshots if there are visual changes -->
![CleanShot 2024-11-04 at 15 53 22@2x](https://github.com/user-attachments/assets/6fe03f58-488f-48cf-8d1d-24e8147b1a3c)
![CleanShot 2024-11-04 at 15 53 48@2x](https://github.com/user-attachments/assets/ccb00998-1df1-41fd-853a-1990bb0366c1)


### Additional Notes
Please review the Chinese translations for accuracy and clarity. Let me know if any adjustments are needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Chinese translations and terminology in custom connect button and custom wallets docs, clarifying prop descriptions and headings.
> 
> - **Docs (zh-CN)**:
>   - `site/data/zh-CN/docs/custom-connect-button.mdx`:
>     - Clarifies `account.*`, `chain.*`, and modal state prop descriptions; tightens examples.
>     - Renames heading to `常规状态属性` and standardizes phrasing (e.g., "链 ID", "网址").
>   - `site/data/zh-CN/docs/custom-wallets.mdx`:
>     - Refines wallet prop descriptions and terminology (spacing in "唯一 ID", EIP6963, "网址").
>     - Polishes download URLs labels and instruction text for mobile/extension/QR code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c78501748ea05b6e34e0315a3ebf6dd18f5f9ddc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->