### PR TITLE
feat: Add Amoy Testnet configuration to RainbowKit

### DIFF
--- a/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
@@ -174,7 +174,6 @@ const scrollIcon: IconMetadata = {
 };
 
 const chainMetadataByName: Record<ChainName, ChainMetadata | null> = {
-  amoy: {chainId: 80002, name: 'Amoy Network',... amoyIcon},
   arbitrum: { chainId: 42_161, name: 'Arbitrum', ...arbitrumIcon },
   arbitrumGoerli: { chainId: 421_613, ...arbitrumIcon },
   arbitrumSepolia: { chainId: 421_614, ...arbitrumIcon },
@@ -210,7 +209,7 @@ const chainMetadataByName: Record<ChainName, ChainMetadata | null> = {
   optimismKovan: { chainId: 69, ...optimismIcon },
   optimismSepolia: { chainId: 11155420, ...optimismIcon },
   polygon: { chainId: 137, name: 'Polygon', ...polygonIcon },
-  polygonAmoy: {chainId: 80002, name: 'Amoy Network',... polygonIcon},
+  polygonAmoy: {chainId: 80002, ... polygonIcon},
   polygonMumbai: { chainId: 80_001, ...polygonIcon },
   rinkeby: { chainId: 4, ...ethereumIcon },
   ropsten: { chainId: 3, ...ethereumIcon },

--- a/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
@@ -4,6 +4,7 @@ import type { RainbowKitChain } from './RainbowKitChainContext';
 // Sourced from https://github.com/tmm/wagmi/blob/main/packages/core/src/constants/chains.ts
 // This is just so we can clearly see which of wagmi's first-class chains we provide metadata for
 type ChainName =
+  | 'amoy'
   | 'arbitrum'
   | 'arbitrumGoerli'
   | 'arbitrumSepolia'
@@ -66,6 +67,10 @@ type ChainMetadata = {
   name?: string;
 } & IconMetadata;
 
+const amoyIcon: IconMetadata = {
+  iconBackground:'#9f71ec',
+  iconUrl: async () => (await import ('./chainIcons/polygon.svg')).default,
+}
 const arbitrumIcon: IconMetadata = {
   iconBackground: '#96bedc',
   iconUrl: async () => (await import('./chainIcons/arbitrum.svg')).default,
@@ -172,6 +177,7 @@ const scrollIcon: IconMetadata = {
 };
 
 const chainMetadataByName: Record<ChainName, ChainMetadata | null> = {
+  amoy: {chainId: 80002, name: 'Amoy Network',... amoyIcon},
   arbitrum: { chainId: 42_161, name: 'Arbitrum', ...arbitrumIcon },
   arbitrumGoerli: { chainId: 421_613, ...arbitrumIcon },
   arbitrumSepolia: { chainId: 421_614, ...arbitrumIcon },

--- a/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
@@ -67,7 +67,6 @@ type ChainMetadata = {
   name?: string;
 } & IconMetadata;
 
-
 const arbitrumIcon: IconMetadata = {
   iconBackground: '#96bedc',
   iconUrl: async () => (await import('./chainIcons/arbitrum.svg')).default,

--- a/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/provideRainbowKitChains.ts
@@ -4,7 +4,6 @@ import type { RainbowKitChain } from './RainbowKitChainContext';
 // Sourced from https://github.com/tmm/wagmi/blob/main/packages/core/src/constants/chains.ts
 // This is just so we can clearly see which of wagmi's first-class chains we provide metadata for
 type ChainName =
-  | 'amoy'
   | 'arbitrum'
   | 'arbitrumGoerli'
   | 'arbitrumSepolia'
@@ -40,6 +39,7 @@ type ChainName =
   | 'optimismGoerli'
   | 'optimismSepolia'
   | 'polygon'
+  | 'polygonAmoy'
   | 'polygonMumbai'
   | 'rinkeby'
   | 'ropsten'
@@ -67,10 +67,7 @@ type ChainMetadata = {
   name?: string;
 } & IconMetadata;
 
-const amoyIcon: IconMetadata = {
-  iconBackground:'#9f71ec',
-  iconUrl: async () => (await import ('./chainIcons/polygon.svg')).default,
-}
+
 const arbitrumIcon: IconMetadata = {
   iconBackground: '#96bedc',
   iconUrl: async () => (await import('./chainIcons/arbitrum.svg')).default,
@@ -213,6 +210,7 @@ const chainMetadataByName: Record<ChainName, ChainMetadata | null> = {
   optimismKovan: { chainId: 69, ...optimismIcon },
   optimismSepolia: { chainId: 11155420, ...optimismIcon },
   polygon: { chainId: 137, name: 'Polygon', ...polygonIcon },
+  polygonAmoy: {chainId: 80002, name: 'Amoy Network',... polygonIcon},
   polygonMumbai: { chainId: 80_001, ...polygonIcon },
   rinkeby: { chainId: 4, ...ethereumIcon },
   ropsten: { chainId: 3, ...ethereumIcon },


### PR DESCRIPTION
*Description:
This pull request adds support for the Amoy Testnet to RainbowKit's chain list. 
The configuration includes:
```
Chain ID: 80002
Network Name: Amoy Testnet
Native Currency: MATIC
RPC URL: https://rpc-amoy.polygon.technology/
Block Explorer: https://amoy.polygonscan.com/
Icon: Polygon's existing ico
```n
*Why:
The Amoy Testnet is an important Sepolia-anchored testnet for Polygon PoS, and including it in RainbowKit ensures developers can easily interact with it using RainbowKit's network selector.
Let me know if additional adjustments are needed.**