### PR TITLE
Fix: broken links in README files  

### DIFF
--- a/packages/rainbow-button/README.md
+++ b/packages/rainbow-button/README.md
@@ -36,7 +36,7 @@ import { createConfig, WagmiConfig } from 'wagmi';
 
 The `RainbowConnector` supports connecting with Rainbow just like Wagmi's native `MetaMaskConnector` from `wagmi/connectors/metaMask`.
 
-Create an instance of the `RainbowConnector` and provide it in your wagmi config `connectors` list. Supply your `chains` list and your WalletConnect v2 `projectId`. You can obtain a `projectId` from [WalletConnect Cloud](https://cloud.walletconnect.com/sign-in). This is absolutely free and only takes a few minutes.
+Create an instance of the `RainbowConnector` and provide it in your wagmi config `connectors` list. Supply your `chains` list and your WalletConnect v2 `projectId`. You can obtain a `projectId` from [WalletConnect Cloud]https://cloud.reown.com/sign-in). This is absolutely free and only takes a few minutes.
 
 ```tsx
 const config = createConfig({

--- a/packages/rainbowkit-siwe-next-auth/README.md
+++ b/packages/rainbowkit-siwe-next-auth/README.md
@@ -126,7 +126,7 @@ export default function AuthenticatedPage({ address }: AuthenticatedPageProps) {
 
 For more information about managing the session, you can refer to the following documentation:
 
-- [Next.js authentication guide](https://nextjs.org/docs/authentication)
+- [Next.js authentication guide](https://nextjs.org/docs/app/building-your-application/authentication)
 - [NextAuth documentation](https://next-auth.js.org)
 
 ## Contributing


### PR DESCRIPTION
These changes improving documentation usability and user experience.
### Changes introduced  
- Corrected broken and incorrect links in two README files:  
  - `packages/rainbow-button/README.md`:  
    - Fixed WalletConnect Cloud link:  
      `https://cloud.reown.com/sign-in` → `https://cloud.walletconnect.com/sign-in`.  
  - `packages/rainbowkit-siwe-next-auth/README.md`:  
    - Fixed Next.js authentication guide link:  
      `https://nextjs.org/docs/authentication` → `https://nextjs.org/docs/app/building-your-application/authentication`.  