### PR TITLE
fix: typos in documentation files

### DIFF
--- a/packages/rainbowkit/src/wallets/getInjectedConnector.ts
+++ b/packages/rainbowkit/src/wallets/getInjectedConnector.ts
@@ -35,7 +35,7 @@ function getWindowProviderNamespace(namespace: string) {
 }
 
 /*
- * Checks if the explict provider or window ethereum exists
+ * Checks if the explicit provider or window ethereum exists
  */
 export function hasInjectedProvider({
   flag,

--- a/site/components/DocsLayout/DocsLayout.tsx
+++ b/site/components/DocsLayout/DocsLayout.tsx
@@ -59,7 +59,7 @@ export function DocsLayout({ children }: { children: React.ReactNode }) {
     setIsOpen(false);
   }, []);
 
-  // Listen to route change so we can programatically close
+  // Listen to route change so we can programmatically close
   // the docs mobile menu when changing routes.
   useEffect(() => {
     router.events.on('routeChangeStart', handleRouteChange);


### PR DESCRIPTION
Corrected `explict` to `explicit`
Corrected `programatically` to `programmatically`