### PR TITLE
docs: fix link formatting README.md

### DIFF
--- a/packages/rainbow-button/README.md
+++ b/packages/rainbow-button/README.md
@@ -36,7 +36,7 @@ import { createConfig, WagmiConfig } from 'wagmi';
 
 The `RainbowConnector` supports connecting with Rainbow just like Wagmi's native `MetaMaskConnector` from `wagmi/connectors/metaMask`.
 
-Create an instance of the `RainbowConnector` and provide it in your wagmi config `connectors` list. Supply your `chains` list and your WalletConnect v2 `projectId`. You can obtain a `projectId` from [WalletConnect Cloud]https://cloud.reown.com/sign-in). This is absolutely free and only takes a few minutes.
+Create an instance of the `RainbowConnector` and provide it in your wagmi config `connectors` list. Supply your `chains` list and your WalletConnect v2 `projectId`. You can obtain a `projectId` from [WalletConnect Cloud](https://cloud.reown.com/sign-in). This is absolutely free and only takes a few minutes.
 
 ```tsx
 const config = createConfig({


### PR DESCRIPTION
Corrected the link formatting in the README.md file for the RainbowConnector section. Fixed the WalletConnect Cloud link to properly display as a clickable hyperlink.

Before
![Снимок экрана 2025-01-14 133450](https://github.com/user-attachments/assets/21d8ddb0-64d8-4595-93bf-a7b2c18cb3f0)
After
![Снимок экрана 2025-01-14 133506](https://github.com/user-attachments/assets/e8311a18-2047-4083-9375-5d5e560039fd)
