### PR TITLE
fix: 404's Links

### DIFF
--- a/site/data/id/docs/authentication.mdx
+++ b/site/data/id/docs/authentication.mdx
@@ -141,5 +141,5 @@ export default function AuthenticatedPage({
 
 Untuk informasi lebih lanjut tentang mengelola sesi, Anda dapat merujuk ke dokumentasi berikut:
 
-- [Panduan otentikasi Next.js](https://nextjs.org/docs/authentication)
+- [Panduan otentikasi Next.js](https://nextjs.org/docs/app/building-your-application/authentication)
 - [Dokumentasi NextAuth](https://next-auth.js.org)

--- a/site/data/ko/docs/authentication.mdx
+++ b/site/data/ko/docs/authentication.mdx
@@ -141,5 +141,5 @@ export default function AuthenticatedPage({
 
 세션 관리에 대한 자세한 정보는 다음 문서를 참조하십시오:
 
-- [Next.js 인증 가이드](https://nextjs.org/docs/authentication)
+- [Next.js 인증 가이드](https://nextjs.org/docs/app/building-your-application/authentication)
 - [NextAuth 문서](https://next-auth.js.org)


### PR DESCRIPTION
Hi, I noticed that one of the links in the authentication documentation was outdated, so I went ahead and fixed it. The broken Next.js authentication link has been updated.