### PR TITLE
feat: use InjectedConnector in binance dapp browser

### DIFF
--- a/.changeset/breezy-tigers-work.md
+++ b/.changeset/breezy-tigers-work.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Improved support for the Binance Wallet dApp browser

--- a/packages/rainbowkit/src/types/utils.ts
+++ b/packages/rainbowkit/src/types/utils.ts
@@ -23,6 +23,7 @@ export type WalletProviderFlags =
   | 'isBifrost'
   | 'isBitKeep'
   | 'isBitski'
+  | 'isBinance'
   | 'isBlockWallet'
   | 'isBraveWallet'
   | 'isCoinbaseWallet'

--- a/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
@@ -1,5 +1,9 @@
 import { isAndroid } from '../../../utils/isMobile';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export type BinanceWalletOptions = DefaultWalletOptions;
@@ -7,49 +11,71 @@ export type BinanceWalletOptions = DefaultWalletOptions;
 export const binanceWallet = ({
   projectId,
   walletConnectParameters,
-}: BinanceWalletOptions): Wallet => ({
-  id: 'binance',
-  name: 'Binance Wallet',
-  iconUrl: async () => (await import('./binanceWallet.svg')).default,
-  iconBackground: '#000000',
-  downloadUrls: {
-    android: 'https://play.google.com/store/apps/details?id=com.binance.dev',
-    ios: 'https://apps.apple.com/us/app/id1436799971',
-    mobile: 'https://www.binance.com/en/download',
-    qrCode: 'https://www.binance.com/en/web3wallet',
-  },
-  mobile: {
-    getUri: (uri: string) => {
-      return isAndroid()
-        ? uri
-        : `bnc://app.binance.com/cedefi/wc?uri=${encodeURIComponent(uri)}`;
+}: BinanceWalletOptions): Wallet => {
+  const isBinanceInjected = hasInjectedProvider({
+    flag: 'isBinance',
+  });
+  const shouldUseWalletConnect = !isBinanceInjected;
+
+  return {
+    id: 'binance',
+    name: 'Binance Wallet',
+    rdns: 'com.binance.wallet',
+    iconUrl: async () => (await import('./binanceWallet.svg')).default,
+    iconBackground: '#000000',
+    installed: !shouldUseWalletConnect ? isBinanceInjected : undefined,
+    downloadUrls: {
+      android: 'https://play.google.com/store/apps/details?id=com.binance.dev',
+      ios: 'https://apps.apple.com/us/app/id1436799971',
+      mobile: 'https://www.binance.com/en/download',
+      qrCode: 'https://www.binance.com/en/web3wallet',
     },
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl: 'https://www.binance.com/en/web3wallet',
-      steps: [
-        {
-          description: 'wallet_connectors.binance.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.binance.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.binance.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.binance.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.binance.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.binance.qr_code.step3.title',
-        },
-      ],
-    },
-  },
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    mobile: shouldUseWalletConnect
+      ? {
+          getUri: (uri: string) => {
+            return isAndroid()
+              ? uri
+              : `bnc://app.binance.com/cedefi/wc?uri=${encodeURIComponent(
+                  uri,
+                )}`;
+          },
+        }
+      : undefined,
+    qrCode: shouldUseWalletConnect
+      ? {
+          getUri: (uri: string) => uri,
+          instructions: {
+            learnMoreUrl: 'https://www.binance.com/en/web3wallet',
+            steps: [
+              {
+                description:
+                  'wallet_connectors.binance.qr_code.step1.description',
+                step: 'install',
+                title: 'wallet_connectors.binance.qr_code.step1.title',
+              },
+              {
+                description:
+                  'wallet_connectors.binance.qr_code.step2.description',
+                step: 'create',
+                title: 'wallet_connectors.binance.qr_code.step2.title',
+              },
+              {
+                description:
+                  'wallet_connectors.binance.qr_code.step3.description',
+                step: 'scan',
+                title: 'wallet_connectors.binance.qr_code.step3.title',
+              },
+            ],
+          },
+        }
+      : undefined,
+    createConnector: shouldUseWalletConnect
+      ? getWalletConnectConnector({
+          projectId,
+          walletConnectParameters,
+        })
+      : getInjectedConnector({
+          flag: 'isBinance',
+        }),
+  };
+};


### PR DESCRIPTION
# Changes

In the original Binance Wallet configuration, `WalletConnectConnector` was used for connections in **all** cases. However, within the built-in browser of Binance Wallet, we provide an `InjectedProvider`, so using `InjectedConnector` is a better approach. This is because our Android environment currently does not support using WalletConnect within the built-in browser of Binance Wallet, which has caused some users to be unable to connect their wallets in dApps.


## Bad case video

https://github.com/user-attachments/assets/c8463026-9c8c-414a-b1c5-74cb0bbbffdb

## Modified behaviour video

https://github.com/user-attachments/assets/0ce07c5d-a757-4c8b-8e9d-91ef1c75605f




