### PR TITLE
feat: beam wallet support

### DIFF
--- a/packages/example/src/wagmi.ts
+++ b/packages/example/src/wagmi.ts
@@ -1,6 +1,7 @@
 import { type Chain, getDefaultConfig } from '@rainbow-me/rainbowkit';
 import {
   argentWallet,
+  beamWallet,
   berasigWallet,
   bestWallet,
   bifrostWallet,
@@ -208,6 +209,7 @@ export const config = getDefaultConfig({
       groupName: 'Other',
       wallets: [
         argentWallet,
+        beamWallet,
         berasigWallet,
         bestWallet,
         bifrostWallet,

--- a/packages/rainbowkit/src/types/utils.ts
+++ b/packages/rainbowkit/src/types/utils.ts
@@ -20,6 +20,7 @@ export type WalletProviderFlags =
   | 'isApexWallet'
   | 'isAvalanche'
   | 'isBackpack'
+  | 'isBeam'
   | 'isBifrost'
   | 'isBitKeep'
   | 'isBitski'

--- a/packages/rainbowkit/src/wallets/walletConnectors/beamWallet/beamWallet.svg
+++ b/packages/rainbowkit/src/wallets/walletConnectors/beamWallet/beamWallet.svg
@@ -1,0 +1,34 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 4C0 1.79086 1.79086 0 4 0H26C28.2091 0 30 1.79086 30 4V7.5H0V4Z" fill="url(#paint0_linear_1_64)"/>
+<path d="M0 22.5H30V26C30 28.2091 28.2091 30 26 30H4C1.79086 30 0 28.2091 0 26V22.5Z" fill="url(#paint1_linear_1_64)"/>
+<path d="M0 7.5H30V15H0V7.5Z" fill="url(#paint2_linear_1_64)"/>
+<path d="M0 7.5H30V15H0V7.5Z" fill="url(#paint3_linear_1_64)"/>
+<path d="M0 15H30V22.5H0V15Z" fill="url(#paint4_linear_1_64)"/>
+<defs>
+<linearGradient id="paint0_linear_1_64" x1="15.1077" y1="3.9375" x2="15.1065" y2="12.3047" gradientUnits="userSpaceOnUse">
+<stop stop-color="#BBDBFF"/>
+<stop offset="0.328125" stop-color="#139EDD"/>
+<stop offset="0.598958" stop-color="#B9F7EA"/>
+</linearGradient>
+<linearGradient id="paint1_linear_1_64" x1="13.7101" y1="26.4375" x2="13.709" y2="34.8047" gradientUnits="userSpaceOnUse">
+<stop stop-color="#BBFFCA"/>
+<stop offset="0.328125" stop-color="#48DD13"/>
+<stop offset="0.598958" stop-color="#008805"/>
+</linearGradient>
+<linearGradient id="paint2_linear_1_64" x1="13.6837" y1="8.42591" x2="13.6828" y2="15.301" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF6A9A"/>
+<stop offset="0.529819" stop-color="#FF5544"/>
+<stop offset="0.955545" stop-color="#E63E33"/>
+</linearGradient>
+<linearGradient id="paint3_linear_1_64" x1="13.3728" y1="11.4375" x2="13.3718" y2="19.8047" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF6B6B"/>
+<stop offset="0.328125" stop-color="#FE1414"/>
+<stop offset="0.598958" stop-color="#8E0900"/>
+</linearGradient>
+<linearGradient id="paint4_linear_1_64" x1="13.8986" y1="18.9375" x2="13.8975" y2="27.3047" gradientUnits="userSpaceOnUse">
+<stop stop-color="#F1E869"/>
+<stop offset="0.328125" stop-color="#FEA514"/>
+<stop offset="0.598958" stop-color="#FF4539"/>
+</linearGradient>
+</defs>
+</svg>

--- a/packages/rainbowkit/src/wallets/walletConnectors/beamWallet/beamWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/beamWallet/beamWallet.ts
@@ -1,0 +1,21 @@
+import type { Wallet } from "../../Wallet";
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from "../../getInjectedConnector";
+
+export const beamWallet = (): Wallet => ({
+  id: "beam",
+  name: "Beam",
+  iconUrl: async () => (await import("./beamWallet.svg")).default,
+  rdns: "com.onbeam",
+  iconBackground: "#000000",
+  installed: hasInjectedProvider({
+    flag: "isBeam",
+    namespace: "beam.provider",
+  }),
+  createConnector: getInjectedConnector({
+    flag: "isBeam",
+    namespace: "beam.provider",
+  }),
+});

--- a/packages/rainbowkit/src/wallets/walletConnectors/beamWallet/beamWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/beamWallet/beamWallet.ts
@@ -14,6 +14,9 @@ export const beamWallet = (): Wallet => ({
     flag: "isBeam",
     namespace: "beam.provider",
   }),
+  downloadUrls: {
+    // We expect Beam to be explicitly installed by the app that uses it, a download URL is not required.
+  },
   createConnector: getInjectedConnector({
     flag: "isBeam",
     namespace: "beam.provider",

--- a/packages/rainbowkit/src/wallets/walletConnectors/index.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/index.ts
@@ -1,4 +1,5 @@
 import { argentWallet } from './argentWallet/argentWallet';
+import { beamWallet } from './beamWallet/beamWallet';
 import { berasigWallet } from './berasigWallet/berasigWallet';
 import { bestWallet } from './bestWallet/bestWallet';
 import { bifrostWallet } from './bifrostWallet/bifrostWallet';
@@ -64,6 +65,7 @@ import { zerionWallet } from './zerionWallet/zerionWallet';
 
 export {
   argentWallet,
+  beamWallet,
   berasigWallet,
   bestWallet,
   bifrostWallet,

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -20,6 +20,7 @@ function isMetaMask(ethereum?: WindowProvider['ethereum']): boolean {
   if (ethereum.isApexWallet) return false;
   if (ethereum.isAvalanche) return false;
   if (ethereum.isBackpack) return false;
+  if (ethereum.isBeam) return false;
   if (ethereum.isBifrost) return false;
   if (ethereum.isBitKeep) return false;
   if (ethereum.isBitski) return false;

--- a/site/data/en-US/docs/custom-wallet-list.mdx
+++ b/site/data/en-US/docs/custom-wallet-list.mdx
@@ -110,6 +110,12 @@ import { oneInchWallet } from '@rainbow-me/rainbowkit/wallets';
 import { argentWallet } from '@rainbow-me/rainbowkit/wallets';
 ```
 
+#### Beam
+
+```tsx
+import { beamWallet } from '@rainbow-me/rainbowkit/wallets';
+```
+
 #### BeraSig
 
 ```tsx


### PR DESCRIPTION
This PR adds the Beam SDK connector for apps that connect to the Beam SDK via RainbowKit. For more information see [https://github.com/BuildOnBeam/beam-sdk-web](https://github.com/BuildOnBeam/beam-sdk-web) and [https://docs.onbeam.com](https://docs.onbeam.com). 