### PR TITLE
fix: fix incorrect import of esbuild-plugin-replace in build.js

### DIFF
--- a/packages/rainbowkit/build.js
+++ b/packages/rainbowkit/build.js
@@ -2,7 +2,7 @@ import { vanillaExtractPlugin } from '@vanilla-extract/esbuild-plugin';
 import autoprefixer from 'autoprefixer';
 import { config } from 'dotenv';
 import * as esbuild from 'esbuild';
-import { replace } from 'esbuild-plugin-replace';
+import replace from 'esbuild-plugin-replace';
 import postcss from 'postcss';
 import prefixSelector from 'postcss-prefix-selector';
 import readdir from 'recursive-readdir-files';


### PR DESCRIPTION
The import for `esbuild-plugin-replace` was incorrect—it doesn't provide a named export `replace`.
This caused an error when building. Updated it to use the default import instead.
