### PR TITLE
Fixed typos

### DIFF
--- a/site/data/ms/docs/connect-button.mdx
+++ b/site/data/ms/docs/connect-button.mdx
@@ -21,7 +21,7 @@ export const YourApp = () => {
 
 ### Props
 
-Komponen `ConnectButton` menyediakan beberapa prop untuk menyesuaikan penampilannya, termasuk menukar kebolehlihatan elemen yang berbeza.
+Komponen `ConnectButton` menyediakan beberapa prop untuk menyesuaikan penampilannya, termasuk menukar kebolehlihatan element yang berbeza.
 
 <PropsTable
   data={[

--- a/site/data/vi/docs/custom-wallets.mdx
+++ b/site/data/vi/docs/custom-wallets.mdx
@@ -7,7 +7,7 @@ description: Tạo ví tùy chỉnh
 
 ## Tạo ví tùy chỉnh
 
-> Lưu ý: API này không ổn định và có khả năng thay đổi trong tương lai gần. Chúng tôi sẽ thêm nhiều ví tích hợp hơn theo thời gian. [Hãy cho chúng tôi biết](https://github.com/rainbow-me/rainbowkit/issues) nếu có bất kỳ ví cụ thể nào bạn quan tâm.
+> Lưu ý: API này không ổn định và có khả năng they, that đổi trong tương lai gần. Chúng tôi sẽ thêm nhiều ví tích hợp hơn theo thời gian. [Hãy cho chúng tôi biết](https://github.com/rainbow-me/rainbowkit/issues) nếu có bất kỳ ví cụ thể nào bạn quan tâm.
 
 Loại hàm `Wallet` được cung cấp để giúp bạn xác định ví tùy chỉnh của riêng mình. Các thuộc tính sau có thể được cấu hình trên giá trị trả về của hàm `Wallet` của bạn:
 

--- a/site/data/vi/docs/migration-guide.mdx
+++ b/site/data/vi/docs/migration-guide.mdx
@@ -171,7 +171,7 @@ const config = getDefaultConfig({
 +     ...mainnet,
 +     iconBackground: '#000',
 +     iconUrl: 'https://example.com/icons/ethereum.png',
-+   }, /* metadata overides */
++   }, /* metadata overrides */
 + ],
 });
 ```


### PR DESCRIPTION
### Changes

1. **File:** `/site/data/vi/docs/custom-wallets.mdx`
    - Fixed `thay` to `they, that` (Line 10)
1. **File:** `/site/data/vi/docs/migration-guide.mdx`
    - Fixed `overides` to `overrides` (Line 174)
1. **File:** `/site/data/ms/docs/connect-button.mdx`
    - Fixed `elemen` to `element` (Line 24)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.