### PR TITLE
fix: disable husky hooks in release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   pnpm: 10.4.1
+  HUSKY: 0 # Avoid pre-commit hook tests
   RAINBOW_PROVIDER_API_KEY: RAINBOW_PROVIDER_API_KEY
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-pnpm lint && pnpm test
+if git diff --cached --name-only | grep -q "packages/create-rainbowkit/templates"; then
+  pnpm lint && pnpm test && pnpm test:cli
+else
+  pnpm lint && pnpm test
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,3 @@
 #!/bin/bash
 
-if git diff --cached --name-only | grep -q "packages/create-rainbowkit/templates"; then
-  pnpm lint && pnpm test && pnpm test:cli
-else
-  pnpm lint && pnpm test
-fi
+pnpm lint && pnpm test


### PR DESCRIPTION
## Changes
- avoid pre-commit hook tests to mitigate `test:cli` failures