### PR TITLE
fix: avoid creating a new WC connector on page reload (when already connected)

### DIFF
--- a/.changeset/warm-cooks-cover.md
+++ b/.changeset/warm-cooks-cover.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+fix: avoid creating a new WC connector on page reload (when already connected to WC)

--- a/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
@@ -31,7 +31,7 @@ import { WalletButtonProvider } from './WalletButtonContext';
 import { useFingerprint } from './useFingerprint';
 import { usePreloadImages } from './usePreloadImages';
 import { clearWalletConnectDeepLink } from './walletConnectDeepLink';
-import { clearWalletConnected } from './walletConnectConnectionStatus';
+import { clearWalletConnectConnected } from './walletConnectConnectionStatus';
 
 const ThemeIdContext = createContext<string | undefined>(undefined);
 
@@ -95,7 +95,7 @@ export function RainbowKitProvider({
 
   const onDisconnect = () => {
     clearWalletConnectDeepLink();
-    clearWalletConnected();
+    clearWalletConnectConnected();
   };
 
   useAccountEffect({ onDisconnect });

--- a/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/RainbowKitProvider.tsx
@@ -31,6 +31,7 @@ import { WalletButtonProvider } from './WalletButtonContext';
 import { useFingerprint } from './useFingerprint';
 import { usePreloadImages } from './usePreloadImages';
 import { clearWalletConnectDeepLink } from './walletConnectDeepLink';
+import { clearWalletConnected } from './walletConnectConnectionStatus';
 
 const ThemeIdContext = createContext<string | undefined>(undefined);
 
@@ -92,7 +93,12 @@ export function RainbowKitProvider({
   usePreloadImages();
   useFingerprint();
 
-  useAccountEffect({ onDisconnect: clearWalletConnectDeepLink });
+  const onDisconnect = () => {
+    clearWalletConnectDeepLink();
+    clearWalletConnected();
+  };
+
+  useAccountEffect({ onDisconnect });
 
   if (typeof theme === 'function') {
     throw new Error(

--- a/packages/rainbowkit/src/components/RainbowKitProvider/walletConnectConnectionStatus.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/walletConnectConnectionStatus.ts
@@ -14,6 +14,6 @@ export function isWalletConnectConnected(): boolean {
   return localStorage.getItem(storageKey) === 'true';
 }
 
-export function clearWalletConnected() {
+export function clearWalletConnectConnected() {
   localStorage.removeItem(storageKey);
 }

--- a/packages/rainbowkit/src/components/RainbowKitProvider/walletConnectConnectionStatus.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/walletConnectConnectionStatus.ts
@@ -1,0 +1,19 @@
+const storageKey = 'rk-WalletConnect-connected';
+
+function isLocalStorageAvailable() {
+  return typeof localStorage !== 'undefined';
+}
+
+export function setWalletConnectConnected() {
+  if (!isLocalStorageAvailable()) return;
+  localStorage.setItem(storageKey, 'true');
+}
+
+export function isWalletConnectConnected(): boolean {
+  if (!isLocalStorageAvailable()) return false;
+  return localStorage.getItem(storageKey) === 'true';
+}
+
+export function clearWalletConnected() {
+  localStorage.removeItem(storageKey);
+}

--- a/packages/rainbowkit/src/components/WalletButton/WalletButtonRenderer.tsx
+++ b/packages/rainbowkit/src/components/WalletButton/WalletButtonRenderer.tsx
@@ -23,6 +23,7 @@ import {
   useModalState,
 } from '../RainbowKitProvider/ModalContext';
 import { WalletButtonContext } from '../RainbowKitProvider/WalletButtonContext';
+import { setWalletConnectConnected } from '../RainbowKitProvider/walletConnectConnectionStatus';
 
 export interface WalletButtonRendererProps {
   wallet?: string;
@@ -75,6 +76,7 @@ export function WalletButtonRenderer({
 
   useAccountEffect({
     onConnect: () => {
+      setWalletConnectConnected();
       // If you get error on desktop and then switch to mobile view
       // and connect your wallet the error will remain there. We will
       // reset the error in case that happens.

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -7,6 +7,7 @@ import type {
   RainbowKitWalletConnectParameters,
   WalletDetailsParams,
 } from './Wallet';
+import { isWalletConnectConnected } from '../components/RainbowKitProvider/walletConnectConnectionStatus';
 
 interface GetWalletConnectConnectorParams {
   projectId: string;
@@ -45,7 +46,7 @@ const getOrCreateWalletConnectInstance = ({
   };
 
   // `rkDetailsShowQrModal` should always be `true`
-  if (rkDetailsShowQrModal) {
+  if (rkDetailsShowQrModal || isWalletConnectConnected()) {
     config = { ...config, showQrModal: true };
   }
 
@@ -72,7 +73,7 @@ function createWalletConnectConnector({
   walletConnectParameters,
 }: CreateWalletConnectConnectorParams): CreateConnectorFn {
   // Create and configure the WalletConnect connector with project ID and options.
-  return createConnector((config) => ({
+  return createConnector(config => ({
     ...getOrCreateWalletConnectInstance({
       projectId,
       walletConnectParameters,
@@ -96,7 +97,7 @@ export function getWalletConnectConnector({
 
   if (!projectId || projectId === '') {
     throw new Error(
-      'No projectId found. Every dApp must now provide a WalletConnect Cloud projectId to enable WalletConnect v2 https://www.rainbowkit.com/docs/installation#configure',
+      'No projectId found. Every dApp must now provide a WalletConnect Cloud projectId to enable WalletConnect v2 https://www.rainbowkit.com/docs/installation#configure'
     );
   }
 


### PR DESCRIPTION
Fixes https://github.com/rainbow-me/rainbowkit/issues/2232

Uses localStorage to know if there is an existing Wallet Connect connection after reloading the page. 
If yes, it avoids creating a new Wallet Connect connector (`{ ...config, showQrModal: false }`) which was leading to broken connection (with `Error: No matching key. history: <number> error.`).

The bug could be reproduced in the linked issue or in the the default rainbowkit example (Running `pnpm run dev` and following the reproduction steps in the linked issue).

