### PR TITLE
feat: additional SIWE integration helpers

### DIFF
--- a/packages/rainbowkit-siwe-next-auth/src/NextAuthHandler.ts
+++ b/packages/rainbowkit-siwe-next-auth/src/NextAuthHandler.ts
@@ -1,0 +1,36 @@
+import NextAuth, { type NextAuthOptions } from 'next-auth';
+import type { Chain } from 'viem';
+import { siweAuthOptions } from './authOptions';
+
+interface NextAuthHandlerProps {
+  chain: Chain;
+  authOptions?: Partial<NextAuthOptions>;
+}
+
+/**
+ * Creates a Next.js Auth route handler with SIWE (Sign-In with Ethereum) configuration
+ * This is useful for Next.js 13+ apps using SIWE with RainbowKit
+ *
+ * @example
+ * ```typescript
+ * // app/api/auth/[...nextauth]/route.ts
+ * import { mainnet } from "viem/chains";
+ * import { NextAuthHandler } from "@rainbow-me/rainbowkit-siwe-next-auth";
+ *
+ * const { GET, POST } = NextAuthHandler({ chain: mainnet });
+ * export { GET, POST };
+ * ```
+ */
+export const NextAuthHandler = ({
+  chain,
+  authOptions = {},
+}: NextAuthHandlerProps) => {
+  const handler = NextAuth(
+    siweAuthOptions({
+      chain,
+      ...authOptions,
+    }),
+  );
+
+  return handler;
+};

--- a/packages/rainbowkit-siwe-next-auth/src/RainbowKitSiweNextAuthProviderWithSession.tsx
+++ b/packages/rainbowkit-siwe-next-auth/src/RainbowKitSiweNextAuthProviderWithSession.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React, { type ReactNode } from 'react';
+import {
+  type GetSiweMessageOptions,
+  RainbowKitSiweNextAuthProvider,
+} from './RainbowKitSiweNextAuthProvider';
+import type { Session } from 'next-auth';
+import { SessionProvider } from 'next-auth/react';
+
+interface RainbowKitSiweNextAuthProviderWithSessionProps {
+  // RainbowKitSiweNextAuthProvider props
+  enabled?: boolean;
+  getSiweMessageOptions?: GetSiweMessageOptions;
+
+  // SessionProvider props
+  session?: Session | null;
+  refetchInterval?: number;
+  refetchOnWindowFocus?: boolean;
+
+  children: ReactNode;
+}
+
+/**
+ * Combines SessionProvider and RainbowKitSiweNextAuthProvider into a single component
+ * This is useful for Next.js 13+ apps using SIWE (Sign-In with Ethereum) with RainbowKit
+ */
+export const RainbowKitSiweNextAuthProviderWithSession = ({
+  // RainbowKit SIWE props
+  enabled,
+  getSiweMessageOptions,
+  // Session props
+  session,
+  refetchInterval,
+  refetchOnWindowFocus,
+  // Common props
+  children,
+}: RainbowKitSiweNextAuthProviderWithSessionProps) => {
+  return (
+    <SessionProvider
+      session={session}
+      refetchInterval={refetchInterval}
+      refetchOnWindowFocus={refetchOnWindowFocus}
+    >
+      <RainbowKitSiweNextAuthProvider
+        enabled={enabled}
+        getSiweMessageOptions={getSiweMessageOptions}
+      >
+        {children}
+      </RainbowKitSiweNextAuthProvider>
+    </SessionProvider>
+  );
+};

--- a/packages/rainbowkit-siwe-next-auth/src/authOptions.ts
+++ b/packages/rainbowkit-siwe-next-auth/src/authOptions.ts
@@ -92,7 +92,8 @@ export const siweAuthOptions = ({
       async session({ session, token }) {
         return {
           ...session,
-          ...token,
+          id: token.id,
+          address: token.address,
           user: {
             ...session.user,
             ...token,

--- a/packages/rainbowkit-siwe-next-auth/src/authOptions.ts
+++ b/packages/rainbowkit-siwe-next-auth/src/authOptions.ts
@@ -1,0 +1,104 @@
+import type { NextAuthOptions } from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+import { type Chain, createPublicClient, http } from 'viem';
+import { parseSiweMessage } from 'viem/siwe';
+
+export interface SiweUser {
+  id: string;
+  address: string;
+}
+
+export type SiweAuthConfig = {
+  onSuccess?: (address: string) => Promise<Partial<SiweUser> | void>;
+  onError?: (error: Error) => Promise<void>;
+  chain: Chain;
+};
+
+export const siweAuthOptions = ({
+  chain,
+  ...config
+}: SiweAuthConfig): NextAuthOptions => {
+  const publicClient = createPublicClient({
+    chain,
+    transport: http(),
+  });
+
+  return {
+    providers: [
+      CredentialsProvider({
+        id: 'credentials',
+        name: 'Ethereum',
+        credentials: {
+          message: {
+            label: 'Message',
+            type: 'text',
+          },
+          signature: {
+            label: 'Signature',
+            type: 'text',
+          },
+        },
+        async authorize(credentials) {
+          try {
+            if (!credentials?.message || !credentials?.signature) return null;
+
+            const parsedMessage = parseSiweMessage(credentials.message);
+
+            const valid = await publicClient.verifySiweMessage({
+              message: credentials.message,
+              signature: credentials.signature as `0x${string}`,
+              domain: parsedMessage.domain,
+              nonce: parsedMessage.nonce,
+            });
+
+            if (valid && parsedMessage.address) {
+              const baseUser = {
+                id: parsedMessage.address,
+                address: parsedMessage.address,
+              };
+
+              const additionalData = await config?.onSuccess?.(
+                parsedMessage.address,
+              );
+
+              return {
+                ...baseUser,
+                ...additionalData,
+              };
+            }
+            return null;
+          } catch (error) {
+            console.error('SIWE verification error:', error);
+            await config?.onError?.(error as Error);
+            return null;
+          }
+        },
+      }),
+    ],
+    session: {
+      strategy: 'jwt',
+    },
+    secret: process.env.NEXTAUTH_SECRET,
+    callbacks: {
+      async jwt({ token, user }) {
+        if (user) {
+          return {
+            ...token,
+            ...user,
+          };
+        }
+        return token;
+      },
+      async session({ session, token }) {
+        return {
+          ...session,
+          ...token,
+          user: {
+            ...session.user,
+            ...token,
+          },
+        };
+      },
+    },
+  };
+};

--- a/packages/rainbowkit-siwe-next-auth/src/index.ts
+++ b/packages/rainbowkit-siwe-next-auth/src/index.ts
@@ -1,2 +1,5 @@
-export { RainbowKitSiweNextAuthProvider } from './RainbowKitSiweNextAuthProvider';
+export * from './RainbowKitSiweNextAuthProvider';
+export * from './authOptions';
+export * from './RainbowKitSiweNextAuthProviderWithSession';
+export * from './NextAuthHandler';
 export type { GetSiweMessageOptions } from './RainbowKitSiweNextAuthProvider';


### PR DESCRIPTION
This PR introduces some additional helpers for convenience.

- authOptions, for simple SIWE setup with onSuccess & onError callbacks
- RainbowKitSiweNextAuthProviderWithSession wraps with a SessionProvider
- NextAuthHandler: wraps the authOptions in NextAuth

Also updated documentation for this new functionality. Feedback very welcome!