### PR TITLE
Improvements to RU Translation of wallet-button.mdx

### DIFF
--- a/site/data/ru/docs/wallet-button.mdx
+++ b/site/data/ru/docs/wallet-button.mdx
@@ -1,13 +1,13 @@
 ---
-title: КнопкаПортмонетка
-description: Использование и настройка КнопкиПортмонетка
+title: WalletButton
+description: Использование и настройка WalletButton
 ---
 
-# КнопкаПортмонетка
+# WalletButton
 
-> Примечание: В настоящее время `КнопкаПортмонетка` опирается на стандарт кошелька EIP-1193, но в ближайшем будущем будет поддерживать EIP-6963.
+> Примечание: В настоящее время `WalletButton` опирается на стандарт кошелька [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193), но в ближайшем будущем будет поддерживать [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963).
 
-Новый компонент `КнопкаПортмонетка` помогает dApps с кастомными списками кошельков использовать RainbowKit и все его преимущества, не требующие обслуживания.
+Новый компонент `WalletButton` помогает dApps с кастомными списками кошельков использовать RainbowKit и все его преимущества, не требующие обслуживания.
 
 ```tsx
 import { WalletButton } from '@rainbow-me/rainbowkit';
@@ -17,7 +17,7 @@ import { WalletButton } from '@rainbow-me/rainbowkit';
 <WalletButton wallet="coinbase" />
 ```
 
-Как и `ConnectButton`, компонент `КнопкаПортмонетка.Custom` доступен для кастомных реализаций и стилизации.
+Как и `ConnectButton`, компонент `WalletButton.Custom` доступен для кастомных реализаций и стилизации.
 
 ```tsx
 <WalletButton.Custom wallet="rainbow">
@@ -35,7 +35,7 @@ import { WalletButton } from '@rainbow-me/rainbowkit';
 </WalletButton.Custom>
 ```
 
-Большинство dApps лучше всего используют [ConnectButton](https://www.rainbowkit.com/docs/connect-button). Обратитесь к документации [здесь](https://www.rainbowkit.com/docs/wallet-button) для получения дополнительной информации о внедрении и использовании `КнопкаПортмонетка`.
+Большинство dApps лучше всего используют [ConnectButton](https://www.rainbowkit.com/docs/connect-button). Обратитесь к документации [здесь](https://www.rainbowkit.com/docs/wallet-button) для получения дополнительной информации о внедрении и использовании `WalletButton`.
 
 #### Демо
 


### PR DESCRIPTION
In this context, `WalletButton` is a **UI component**  and better to keep `WalletButton` in English

It’s a technical term:
   - It is directly connected to the code (`<WalletButton />` in the code).
   - Translating could cause confusion
   
Also I have added hyperlinks to eip-1193 and eip-6963 so user has quick access to deeper knowledge now. 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the component `КнопкаПортмонетка` to `WalletButton` in the documentation, reflecting a consistent naming convention in both the title and the text. 

### Detailed summary
- Changed title from `КнопкаПортмонетка` to `WalletButton`.
- Updated description to refer to `WalletButton`.
- Replaced all instances of `КнопкаПортмонетка` with `WalletButton`.
- Enhanced note with links to EIP standards.
- Maintained references to `ConnectButton` and documentation links.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->