### PR TITLE
fix(connectors): avoid duplicate walletConnector registration

### DIFF
--- a/.changeset/fresh-eggs-cheer.md
+++ b/.changeset/fresh-eggs-cheer.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": minor
+---
+
+Fix duplicated addition of walletConnector in connectors list

--- a/packages/rainbowkit/src/wallets/connectorsForWallets.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.ts
@@ -160,6 +160,7 @@ export const connectorsForWallets = (
           }),
         ),
       );
+      continue;
     }
 
     const connector = createConnector(walletMetaData());


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing an issue related to the addition of `walletConnector` in the connectors list within the `connectorsForWallets.ts` file.

### Detailed summary
- Added a `continue;` statement in `connectorsForWallets.ts` to prevent further processing in certain conditions.
- Updated the changelog in `fresh-eggs-cheer.md` to reflect a minor version change for `@rainbow-me/rainbowkit` and documented the fix for the duplicated addition of `walletConnector`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->