### PR TITLE
fix: walletconnect metadata.url origin mismatch

### DIFF
--- a/.changeset/itchy-chefs-think.md
+++ b/.changeset/itchy-chefs-think.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Resolved a warning for mismatched dApp url metadata on recent versions of WalletConnect

--- a/packages/rainbowkit/src/wallets/computeWalletConnectMetaData.ts
+++ b/packages/rainbowkit/src/wallets/computeWalletConnectMetaData.ts
@@ -16,7 +16,8 @@ export const computeWalletConnectMetaData = ({
   return {
     name: appName,
     description: appDescription ?? appName,
-    url: appUrl ?? (typeof window !== 'undefined' ? window.location.href : ''),
+    url:
+      appUrl ?? (typeof window !== 'undefined' ? window.location.origin : ''),
     icons: [...(appIcon ? [appIcon] : [])],
   };
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR addresses a warning related to mismatched dApp URL metadata in recent versions of `WalletConnect` by updating the URL logic in the `computeWalletConnectMetaData.ts` file.

### Detailed summary
- Updated the `url` assignment in `computeWalletConnectMetaData.ts` to use `window.location.origin` instead of `window.location.href` when `appUrl` is not provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->