### PR TITLE
fix: include rabbyWallet in getDefaultConfig

### DIFF
--- a/packages/rainbowkit/src/wallets/getDefaultWallets.ts
+++ b/packages/rainbowkit/src/wallets/getDefaultWallets.ts
@@ -8,6 +8,7 @@ import { coinbaseWallet } from './walletConnectors/coinbaseWallet/coinbaseWallet
 import { metaMaskWallet } from './walletConnectors/metaMaskWallet/metaMaskWallet';
 import { rainbowWallet } from './walletConnectors/rainbowWallet/rainbowWallet';
 import { safeWallet } from './walletConnectors/safeWallet/safeWallet';
+import { rabbyWallet } from './walletConnectors/rabbyWallet/rabbyWallet';
 import { walletConnectWallet } from './walletConnectors/walletConnectWallet/walletConnectWallet';
 
 export function getDefaultWallets(parameters: ConnectorsForWalletsParameters): {
@@ -27,6 +28,7 @@ export function getDefaultWallets(parameters?: ConnectorsForWalletsParameters) {
         coinbaseWallet,
         metaMaskWallet,
         walletConnectWallet,
+        rabbyWallet,
       ],
     },
   ];

--- a/site/components/Provider/Provider.tsx
+++ b/site/components/Provider/Provider.tsx
@@ -5,6 +5,7 @@ import {
   ledgerWallet,
   omniWallet,
   trustWallet,
+  rabbyWallet,
 } from '@rainbow-me/rainbowkit/wallets';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type React from 'react';
@@ -63,6 +64,7 @@ const config = getDefaultConfig({
         omniWallet,
         imTokenWallet,
         ledgerWallet,
+        rabbyWallet,
       ],
     },
   ],


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `rabbyWallet` to the wallet configuration in the `Provider.tsx` component and updates the `getDefaultWallets` function to include `rabbyWallet` in the default wallet list.

### Detailed summary
- Added `rabbyWallet` to the wallet imports in `site/components/Provider/Provider.tsx`.
- Included `rabbyWallet` in the wallet configuration array within `getDefaultConfig`.
- Imported `rabbyWallet` in `packages/rainbowkit/src/wallets/getDefaultWallets.ts`.
- Added `rabbyWallet` to the default wallets array in the `getDefaultWallets` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->