### PR TITLE
Fix group name in connectors test

### DIFF
--- a/packages/rainbowkit/src/wallets/connectorsForWallets.test.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.test.ts
@@ -60,7 +60,7 @@ describe('connectorsForWallets', () => {
       });
 
       const connectors = connectorsForWallets(
-        [{ groupName: 'groupName: "Test Group 1"', wallets: [customWallet] }],
+        [{ groupName: 'Test Group 1', wallets: [customWallet] }],
         {
           projectId: exampleProjectId,
           appName: 'rainbowkit.com',


### PR DESCRIPTION
## Summary
- fix the `groupName` string in `connectorsForWallets.test.ts`

## Testing
- `pnpm test` *(fails: Connect Timeout Error)*

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting the `groupName` format in the `connectorsForWallets` function call within the test file.

### Detailed summary
- Updated `groupName` from `'groupName: "Test Group 1"'` to `'Test Group 1'` in the test case for `connectorsForWallets`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->