### PR TITLE
docs: fix link to polyfills samples in migration-guide.mdx

### DIFF
--- a/site/data/en-US/docs/migration-guide.mdx
+++ b/site/data/en-US/docs/migration-guide.mdx
@@ -227,7 +227,7 @@ npm i viem
 
 In previous versions of wagmi that relied on [ethers](https://docs.ethers.org/v5/), the `fs`, `net`, and `tls` modules required by WalletConnect were automatically polyfilled. This is no longer the case with RainbowKit v1 + wagmi v1, which are built on [viem](https://viem.sh/).
 
-Reference our [Next.js Webpack Config](https://github.com/rainbow-me/rainbowkit/blob/main/examples/with-next/next.config.js) and [Create React App polyfills](https://github.com/rainbow-me/rainbowkit/blob/main/examples/with-create-react-app/src/polyfills.ts) samples for configuration guidance for your project.
+Reference our [Next.js Webpack Config](https://github.com/rainbow-me/rainbowkit/blob/main/examples/with-next/next.config.js) and [Create React App polyfills](https://github.com/rainbow-me/rainbowkit/blob/1.x/examples/with-create-react-app/src/polyfills.ts) samples for configuration guidance for your project.
 
 Additional framework guides for Vite and Remix are available [here](https://www.rainbowkit.com/docs/installation#additional-build-tooling-setup).
 


### PR DESCRIPTION
if this change is good let me know - i will fix this link in translated docs. thank you. 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation regarding the polyfills required by WalletConnect in the context of using `RainbowKit` and `wagmi`. It highlights changes in polyfill requirements and provides updated links for configuration guidance.

### Detailed summary
- Clarified that `fs`, `net`, and `tls` modules are no longer automatically polyfilled with `RainbowKit v1` + `wagmi v1`.
- Updated the link for the `Create React App polyfills` sample from `main` branch to `1.x` branch.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->