### PR TITLE
Migrate QRCode to cuer

### DIFF
--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -53,7 +53,6 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
-    "@types/qrcode": "^1.5.5",
     "@types/ua-parser-js": "^0.7.39",
     "@vanilla-extract/css-utils": "0.1.4",
     "@vanilla-extract/private": "1.0.6",
@@ -70,7 +69,7 @@
     "@vanilla-extract/dynamic": "2.1.2",
     "@vanilla-extract/sprinkles": "1.6.3",
     "clsx": "2.1.1",
-    "qrcode": "1.5.4",
+    "cuer": "^0.0.2",
     "react-remove-scroll": "2.6.2",
     "ua-parser-js": "^1.0.37"
   },

--- a/packages/rainbowkit/src/components/QRCode/QRCode.tsx
+++ b/packages/rainbowkit/src/components/QRCode/QRCode.tsx
@@ -1,36 +1,37 @@
-import QRCodeUtil from 'qrcode';
-import React, { type ReactElement, useMemo } from 'react';
+import React from 'react';
+import { Cuer } from 'cuer';
 import { AsyncImage } from '../AsyncImage/AsyncImage';
 import { Box, type BoxProps } from '../Box/Box';
 import { QRCodeBackgroundClassName } from '../ConnectOptions/DesktopOptions.css';
 
-const generateMatrix = (
-  value: string,
-  errorCorrectionLevel: QRCodeUtil.QRCodeErrorCorrectionLevel,
-) => {
-  const arr = Array.prototype.slice.call(
-    QRCodeUtil.create(value, { errorCorrectionLevel }).modules.data,
-    0,
-  );
-  const sqrt = Math.sqrt(arr.length);
-  return arr.reduce(
-    (rows, key, index) =>
-      (index % sqrt === 0
-        ? rows.push([key])
-        : rows[rows.length - 1].push(key)) && rows,
-    [],
-  );
-};
+export type ErrorCorrectionLevel =
+  | 'L'
+  | 'M'
+  | 'Q'
+  | 'H'
+  | 'low'
+  | 'medium'
+  | 'quartile'
+  | 'high';
 
-type Props = {
-  ecl?: QRCodeUtil.QRCodeErrorCorrectionLevel;
+interface Props {
+  ecl?: ErrorCorrectionLevel;
   logoBackground?: string;
   logoUrl?: string | (() => Promise<string>);
   logoMargin?: number;
   logoSize?: number;
   size?: number;
   uri: string;
-};
+}
+
+function mapErrorCorrection(
+  ecl: ErrorCorrectionLevel,
+): 'low' | 'medium' | 'quartile' | 'high' {
+  if (ecl === 'L' || ecl === 'low') return 'low';
+  if (ecl === 'Q' || ecl === 'quartile') return 'quartile';
+  if (ecl === 'H' || ecl === 'high') return 'high';
+  return 'medium';
+}
 
 export function QRCode({
   ecl = 'M',
@@ -44,78 +45,23 @@ export function QRCode({
   const padding: NonNullable<BoxProps['padding']> = '20';
   const size = sizeProp - Number.parseInt(padding, 10) * 2;
 
-  const dots = useMemo(() => {
-    const dots: ReactElement[] = [];
-    const matrix = generateMatrix(uri, ecl);
-    const cellSize = size / matrix.length;
-    const qrList = [
-      { x: 0, y: 0 },
-      { x: 1, y: 0 },
-      { x: 0, y: 1 },
-    ];
-
-    // biome-ignore lint/complexity/noForEach: TODO
-    qrList.forEach(({ x, y }) => {
-      const x1 = (matrix.length - 7) * cellSize * x;
-      const y1 = (matrix.length - 7) * cellSize * y;
-      for (let i = 0; i < 3; i++) {
-        dots.push(
-          <rect
-            fill={i % 2 !== 0 ? 'white' : 'black'}
-            height={cellSize * (7 - i * 2)}
-            key={`${i}-${x}-${y}`}
-            rx={(i - 2) * -5 + (i === 0 ? 2 : 0)} // calculated border radius for corner squares
-            ry={(i - 2) * -5 + (i === 0 ? 2 : 0)} // calculated border radius for corner squares
-            width={cellSize * (7 - i * 2)}
-            x={x1 + cellSize * i}
-            y={y1 + cellSize * i}
-          />,
-        );
-      }
-    });
-
-    const clearArenaSize = Math.floor((logoSize + 25) / cellSize);
-    const matrixMiddleStart = matrix.length / 2 - clearArenaSize / 2;
-    const matrixMiddleEnd = matrix.length / 2 + clearArenaSize / 2 - 1;
-
-    matrix.forEach((row: QRCodeUtil.QRCode[], i: number) => {
-      row.forEach((_: any, j: number) => {
-        if (matrix[i][j]) {
-          if (
-            !(
-              (i < 7 && j < 7) ||
-              (i > matrix.length - 8 && j < 7) ||
-              (i < 7 && j > matrix.length - 8)
-            )
-          ) {
-            if (
-              !(
-                i > matrixMiddleStart &&
-                i < matrixMiddleEnd &&
-                j > matrixMiddleStart &&
-                j < matrixMiddleEnd
-              )
-            ) {
-              dots.push(
-                <circle
-                  cx={i * cellSize + cellSize / 2}
-                  cy={j * cellSize + cellSize / 2}
-                  fill="black"
-                  key={`circle-${i}-${j}`}
-                  r={cellSize / 3} // calculate size of single dots
-                />,
-              );
-            }
-          }
-        }
-      });
-    });
-
-    return dots;
-  }, [ecl, logoSize, size, uri]);
-
-  const logoPosition = size / 2 - logoSize / 2;
-  const logoWrapperSize = logoSize + logoMargin * 2;
+  const arena = logoUrl ? (
+    <Box
+      alignItems="center"
+      display="flex"
+      justifyContent="center"
+      style={{ padding: logoMargin }}
+    >
+      <AsyncImage
+        background={logoBackground}
+        borderColor={{ custom: 'rgba(0, 0, 0, 0.06)' }}
+        borderRadius="13"
+        height={logoSize}
+        src={logoUrl}
+        width={logoSize}
+      />
+    </Box>
+  ) : undefined;
 
   return (
     <Box
@@ -135,39 +81,13 @@ export function QRCode({
         }}
         userSelect="none"
       >
-        <Box
-          display="flex"
-          justifyContent="center"
-          position="relative"
-          style={{
-            height: 0,
-            top: logoPosition,
-            width: size,
-          }}
-          width="full"
-        >
-          <AsyncImage
-            background={logoBackground}
-            borderColor={{ custom: 'rgba(0, 0, 0, 0.06)' }}
-            borderRadius="13"
-            height={logoSize}
-            src={logoUrl}
-            width={logoSize}
-          />
-        </Box>
-        <svg height={size} style={{ all: 'revert' }} width={size}>
-          <title>QR Code</title>
-          <defs>
-            <clipPath id="clip-wrapper">
-              <rect height={logoWrapperSize} width={logoWrapperSize} />
-            </clipPath>
-            <clipPath id="clip-logo">
-              <rect height={logoSize} width={logoSize} />
-            </clipPath>
-          </defs>
-          <rect fill="transparent" height={size} width={size} />
-          {dots}
-        </svg>
+        <Cuer
+          arena={arena}
+          color="black"
+          errorCorrection={mapErrorCorrection(ecl)}
+          size={size}
+          value={uri}
+        />
       </Box>
     </Box>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,9 +435,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
-      qrcode:
-        specifier: 1.5.4
-        version: 1.5.4
+      cuer:
+        specifier: ^0.0.2
+        version: 0.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.4)
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
@@ -466,9 +466,6 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.5.2(@testing-library/dom@10.4.0)
-      '@types/qrcode':
-        specifier: ^1.5.5
-        version: 1.5.5
       '@types/ua-parser-js':
         specifier: ^0.7.39
         version: 0.7.39
@@ -4524,9 +4521,6 @@ packages:
   '@types/q@1.5.8':
     resolution: {integrity: sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==}
 
-  '@types/qrcode@1.5.5':
-    resolution: {integrity: sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==}
-
   '@types/qs@6.9.15':
     resolution: {integrity: sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==}
 
@@ -6029,6 +6023,16 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  cuer@0.0.2:
+    resolution: {integrity: sha512-MG1BYnnSLqBnO0dOBS1Qm/TEc9DnFa9Sz2jMA24OF4hGzs8UuPjpKBMkRPF3lrpC+7b3EzULwooX9djcvsM8IA==}
+    peerDependencies:
+      react: ^19.0.0
+      react-dom: ^19.0.0
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -10208,13 +10212,11 @@ packages:
 
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
+  qr@0.4.2:
+    resolution: {integrity: sha512-wCv4rt7IcPNGT0J8JiTBHx7YrZzYuzpof38y/MFYd5Sp7OTyAFYL1e110In8PrAG/ffIOVl1ha3joJ2zpYxKMQ==}
+
   qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-
-  qrcode@1.5.4:
-    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 
@@ -16817,10 +16819,6 @@ snapshots:
 
   '@types/q@1.5.8': {}
 
-  '@types/qrcode@1.5.5':
-    dependencies:
-      '@types/node': 20.16.5
-
   '@types/qs@6.9.15': {}
 
   '@types/range-parser@1.2.7': {}
@@ -19058,6 +19056,14 @@ snapshots:
       rrweb-cssom: 0.6.0
 
   csstype@3.1.3: {}
+
+  cuer@0.0.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.5.4):
+    dependencies:
+      qr: 0.4.2
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      typescript: 5.5.4
 
   damerau-levenshtein@1.0.8: {}
 
@@ -24484,16 +24490,12 @@ snapshots:
 
   q@1.5.1: {}
 
+  qr@0.4.2: {}
+
   qrcode@1.5.3:
     dependencies:
       dijkstrajs: 1.0.3
       encode-utf8: 1.0.3
-      pngjs: 5.0.0
-      yargs: 15.4.1
-
-  qrcode@1.5.4:
-    dependencies:
-      dijkstrajs: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
 


### PR DESCRIPTION
## Summary
- replace `qrcode` with `cuer`
- update QRCode component to use `cuer`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_683fbc562a988325a661b94ab1642de7

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `QRCode` component in the `rainbowkit` package by replacing the `qrcode` library with `cuer` for QR code generation, modifying error correction handling, and refactoring the rendering logic.

### Detailed summary
- Removed `@types/qrcode` dependency.
- Replaced `qrcode` library with `cuer` in `packages/rainbowkit/package.json`.
- Updated `QRCode.tsx` to use `Cuer` for rendering QR codes.
- Refactored error correction handling with a new `ErrorCorrectionLevel` type.
- Simplified the QR code rendering logic, removing the `generateMatrix` function and related code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->