### PR TITLE
chore: log comment authors in watchdog

### DIFF
--- a/.github/workflows/comment-watchdog.yml
+++ b/.github/workflows/comment-watchdog.yml
@@ -39,6 +39,9 @@ jobs:
           COMMENT_ID=$(jq -r '.comment.id' < "$GITHUB_EVENT_PATH")
           COMMENT_BODY=$(jq -r '.comment.body' < "$GITHUB_EVENT_PATH")
           COMMENT_USER=$(jq -r '.comment.user.login' < "$GITHUB_EVENT_PATH")
+
+          # Log the comment author
+          echo "Comment authored by $COMMENT_USER"
           
           # Check if the comment user is allowlisted
           if grep -q "$COMMENT_USER" allowlisted_users.txt; then


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a logging feature to the GitHub Actions workflow, specifically to log the author of a comment made on a pull request.

### Detailed summary
- Added a line to log the comment author with `echo "Comment authored by $COMMENT_USER"` in the `.github/workflows/comment-watchdog.yml` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->