### PR TITLE
chore: upgrade polyfill docs

### DIFF
--- a/site/data/en-US/docs/migration-guide.mdx
+++ b/site/data/en-US/docs/migration-guide.mdx
@@ -225,9 +225,7 @@ npm i viem
 
 **3. Ensure bundler and polyfill compatibility**
 
-In previous versions of wagmi that relied on [ethers](https://docs.ethers.org/v5/), the `fs`, `net`, and `tls` modules required by WalletConnect were automatically polyfilled. This is no longer the case with RainbowKit v1 + wagmi v1, which are built on [viem](https://viem.sh/).
-
-Reference our [Next.js Webpack Config](https://github.com/rainbow-me/rainbowkit/blob/main/examples/with-next/next.config.js) and [Create React App polyfills](https://github.com/rainbow-me/rainbowkit/blob/main/examples/with-create-react-app/src/polyfills.ts) samples for configuration guidance for your project.
+Reference our [Next.js Webpack Config](https://github.com/rainbow-me/rainbowkit/blob/main/examples/with-next/next.config.js) sample for configuration guidance for your project.
 
 Additional framework guides for Vite and Remix are available [here](https://www.rainbowkit.com/docs/installation#additional-build-tooling-setup).
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the migration guide for `wagmi` and `RainbowKit`, specifically addressing changes in bundler and polyfill compatibility. It removes references to automatically polyfilled modules and simplifies the guidance for configuration.

### Detailed summary
- Removed mention of `fs`, `net`, and `tls` modules being automatically polyfilled in previous versions.
- Updated the guidance to only reference the `Next.js Webpack Config` sample.
- Added a note about additional framework guides for Vite and Remix being available.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->