### PR TITLE
chore: fix string comparison in comment watchdog

### DIFF
--- a/.github/workflows/comment-watchdog.yml
+++ b/.github/workflows/comment-watchdog.yml
@@ -44,7 +44,7 @@ jobs:
           echo "Comment authored by $COMMENT_USER"
           
           # Check if the comment user is allowlisted
-          if grep -q "$COMMENT_USER" allowlisted_users.txt; then
+          if grep -qF "$COMMENT_USER" allowlisted_users.txt; then
             echo "Comment by $COMMENT_USER is from an allowlisted user. No action taken."
             exit 0
           fi


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the condition that checks if a comment user is allowlisted in the `.github/workflows/comment-watchdog.yml` file. It changes the `grep` command to use the `-qF` option for a fixed string search.

### Detailed summary
- Changed `grep -q` to `grep -qF` for fixed string matching of `$COMMENT_USER` against `allowlisted_users.txt`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->