### PR TITLE
fix: handle mobile connect rejection

### DIFF
--- a/.changeset/b93dd648.md
+++ b/.changeset/b93dd648.md
@@ -1,0 +1,4 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+Fix mobile connect error handling when requests are rejected.

--- a/.changeset/b93dd648.md
+++ b/.changeset/b93dd648.md
@@ -1,4 +1,5 @@
 ---
 "@rainbow-me/rainbowkit": patch
 ---
-Fix mobile connect error handling when requests are rejected.
+
+Fixed error handling when connect requests are rejected on mobile.

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.test.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.test.tsx
@@ -1,0 +1,44 @@
+import user from '@testing-library/user-event';
+import { screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { mainnet } from 'wagmi/chains';
+import { renderWithProviders } from '../../../test';
+import type { WalletConnector } from '../../wallets/useWalletConnectors';
+import { WalletButton } from './MobileOptions';
+
+const connectMock = vi.fn(() => Promise.reject(new Error('rejected')));
+
+const failingWallet: WalletConnector = {
+  id: 'mock',
+  name: 'Mock',
+  iconUrl: '',
+  iconBackground: '#fff',
+  ready: true,
+  connect: connectMock,
+  recent: false,
+};
+
+describe('<WalletButton />', () => {
+  it('catches rejected connect() calls', async () => {
+    const unhandled = vi.fn();
+    window.addEventListener('unhandledrejection', unhandled);
+
+    renderWithProviders(
+      <WalletButton wallet={failingWallet} onClose={() => {}} />,
+      {
+        chains: [mainnet],
+      },
+    );
+
+    const button = screen.getByTestId('rk-wallet-option-mock');
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(connectMock).toHaveBeenCalled();
+      expect(unhandled).not.toHaveBeenCalled();
+    });
+
+    window.removeEventListener('unhandledrejection', unhandled);
+  });
+});

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -121,7 +121,11 @@ export function WalletButton({
       return;
     }
 
-    connect?.();
+    try {
+      await connect?.();
+    } catch {
+      // Ignore connection errors so they don't surface as uncaught
+    }
   }, [connect, getMobileUri, showWalletConnectModal, onClose, name, id]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- catch `connect()` in `MobileOptions` to avoid unhandled rejections
- add e2e test for rejected connect requests
- add changeset

## Testing
- `CI=true pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684118be24dc8325b7ce117d496532ec

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling for connection requests in the mobile version of the `rainbowkit` library. It ensures that rejected connection attempts do not surface as uncaught errors and adds tests to verify this behavior.

### Detailed summary
- Updated error handling in `MobileOptions.tsx` to catch rejected connection requests.
- Added a test in `MobileOptions.test.tsx` to verify that rejected `connect()` calls do not trigger unhandled promise rejections.
- Introduced a mock wallet connector for testing purposes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->