### PR TITLE
Migrate QRCode to cuer

### DIFF
--- a/.changeset/stale-moose-mix.md
+++ b/.changeset/stale-moose-mix.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Improved QR Code error correction and rendering with [`cuer`](https://github.com/wevm/cuer)

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -69,7 +69,7 @@
     "@vanilla-extract/dynamic": "2.1.2",
     "@vanilla-extract/sprinkles": "1.6.3",
     "clsx": "2.1.1",
-    "cuer": "^0.0.2",
+    "cuer": "0.0.2",
     "react-remove-scroll": "2.6.2",
     "ua-parser-js": "^1.0.37"
   },

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -53,7 +53,6 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
-    "@types/qrcode": "^1.5.5",
     "@types/ua-parser-js": "^0.7.39",
     "@vanilla-extract/css-utils": "0.1.4",
     "@vanilla-extract/private": "1.0.6",
@@ -70,7 +69,7 @@
     "@vanilla-extract/dynamic": "2.1.2",
     "@vanilla-extract/sprinkles": "1.6.3",
     "clsx": "2.1.1",
-    "qrcode": "1.5.4",
+    "cuer": "^0.0.2",
     "react-remove-scroll": "2.6.2",
     "ua-parser-js": "^1.0.37"
   },

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -53,6 +53,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/qrcode": "^1.5.5",
     "@types/ua-parser-js": "^0.7.39",
     "@vanilla-extract/css-utils": "0.1.4",
     "@vanilla-extract/private": "1.0.6",
@@ -69,7 +70,7 @@
     "@vanilla-extract/dynamic": "2.1.2",
     "@vanilla-extract/sprinkles": "1.6.3",
     "clsx": "2.1.1",
-    "cuer": "^0.0.2",
+    "qrcode": "1.5.4",
     "react-remove-scroll": "2.6.2",
     "ua-parser-js": "^1.0.37"
   },

--- a/packages/rainbowkit/src/components/QRCode/QRCode.tsx
+++ b/packages/rainbowkit/src/components/QRCode/QRCode.tsx
@@ -32,25 +32,6 @@ export function QRCode({
 
   const resolvedLogoUrl = useAsyncImage(logoUrl);
 
-  const arena = resolvedLogoUrl ? (
-    <Cuer.Arena>
-      <img
-        alt=""
-        src={resolvedLogoUrl}
-        style={{
-          background: logoBackground,
-          borderColor: 'rgba(0, 0, 0, 0.06)',
-          borderRadius: 13,
-          borderStyle: 'solid',
-          borderWidth: 1,
-          height: '100%',
-          objectFit: 'cover',
-          width: '100%',
-        }}
-      />
-    </Cuer.Arena>
-  ) : null;
-
   return (
     <Box
       borderColor="generalBorder"
@@ -69,10 +50,27 @@ export function QRCode({
         }}
         userSelect="none"
       >
-        <Cuer.Root color="black" errorCorrection={ecc} size={size} value={uri}>
-          <Cuer.Finder />
-          <Cuer.Cells />
-          {arena}
+        <Cuer.Root errorCorrection={ecc} size={size} value={uri}>
+          <Cuer.Cells radius={1} />
+          <Cuer.Finder radius={0.25} />
+          {resolvedLogoUrl && (
+            <Cuer.Arena>
+              <img
+                alt="Wallet Logo"
+                src={resolvedLogoUrl}
+                style={{
+                  background: logoBackground,
+                  borderColor: 'rgba(0, 0, 0, 0.06)',
+                  borderStyle: 'solid',
+                  borderWidth: '0.01px',
+                  borderRadius: '19%',
+                  height: '86%',
+                  objectFit: 'cover',
+                  width: '86%',
+                }}
+              />
+            </Cuer.Arena>
+          )}
         </Cuer.Root>
       </Box>
     </Box>

--- a/packages/rainbowkit/src/components/QRCode/QRCode.tsx
+++ b/packages/rainbowkit/src/components/QRCode/QRCode.tsx
@@ -1,27 +1,41 @@
-import React from 'react';
-import { Cuer } from 'cuer';
+import QRCodeUtil from 'qrcode';
+import React, { type ReactElement, useMemo } from 'react';
+import { AsyncImage } from '../AsyncImage/AsyncImage';
 import { Box, type BoxProps } from '../Box/Box';
-import { useAsyncImage } from '../AsyncImage/useAsyncImage';
 import { QRCodeBackgroundClassName } from '../ConnectOptions/DesktopOptions.css';
 
-export type ErrorCorrectionLevel = 'low' | 'medium' | 'quartile' | 'high';
+const generateMatrix = (
+  value: string,
+  errorCorrectionLevel: QRCodeUtil.QRCodeErrorCorrectionLevel,
+) => {
+  const arr = Array.prototype.slice.call(
+    QRCodeUtil.create(value, { errorCorrectionLevel }).modules.data,
+    0,
+  );
+  const sqrt = Math.sqrt(arr.length);
+  return arr.reduce(
+    (rows, key, index) =>
+      (index % sqrt === 0
+        ? rows.push([key])
+        : rows[rows.length - 1].push(key)) && rows,
+    [],
+  );
+};
 
-interface Props {
-  ecc?: ErrorCorrectionLevel;
+type Props = {
+  ecl?: QRCodeUtil.QRCodeErrorCorrectionLevel;
   logoBackground?: string;
   logoUrl?: string | (() => Promise<string>);
   logoMargin?: number;
   logoSize?: number;
   size?: number;
   uri: string;
-}
+};
 
 export function QRCode({
-  ecc = 'medium',
+  ecl = 'M',
   logoBackground,
-  // biome-ignore lint/correctness/noUnusedVariables: API compatibility
   logoMargin = 10,
-  // biome-ignore lint/correctness/noUnusedVariables: API compatibility
   logoSize = 50,
   logoUrl,
   size: sizeProp = 200,
@@ -30,26 +44,78 @@ export function QRCode({
   const padding: NonNullable<BoxProps['padding']> = '20';
   const size = sizeProp - Number.parseInt(padding, 10) * 2;
 
-  const resolvedLogoUrl = useAsyncImage(logoUrl);
+  const dots = useMemo(() => {
+    const dots: ReactElement[] = [];
+    const matrix = generateMatrix(uri, ecl);
+    const cellSize = size / matrix.length;
+    const qrList = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 0, y: 1 },
+    ];
 
-  const arena = resolvedLogoUrl ? (
-    <Cuer.Arena>
-      <img
-        alt=""
-        src={resolvedLogoUrl}
-        style={{
-          background: logoBackground,
-          borderColor: 'rgba(0, 0, 0, 0.06)',
-          borderRadius: 13,
-          borderStyle: 'solid',
-          borderWidth: 1,
-          height: '100%',
-          objectFit: 'cover',
-          width: '100%',
-        }}
-      />
-    </Cuer.Arena>
-  ) : null;
+    // biome-ignore lint/complexity/noForEach: TODO
+    qrList.forEach(({ x, y }) => {
+      const x1 = (matrix.length - 7) * cellSize * x;
+      const y1 = (matrix.length - 7) * cellSize * y;
+      for (let i = 0; i < 3; i++) {
+        dots.push(
+          <rect
+            fill={i % 2 !== 0 ? 'white' : 'black'}
+            height={cellSize * (7 - i * 2)}
+            key={`${i}-${x}-${y}`}
+            rx={(i - 2) * -5 + (i === 0 ? 2 : 0)} // calculated border radius for corner squares
+            ry={(i - 2) * -5 + (i === 0 ? 2 : 0)} // calculated border radius for corner squares
+            width={cellSize * (7 - i * 2)}
+            x={x1 + cellSize * i}
+            y={y1 + cellSize * i}
+          />,
+        );
+      }
+    });
+
+    const clearArenaSize = Math.floor((logoSize + 25) / cellSize);
+    const matrixMiddleStart = matrix.length / 2 - clearArenaSize / 2;
+    const matrixMiddleEnd = matrix.length / 2 + clearArenaSize / 2 - 1;
+
+    matrix.forEach((row: QRCodeUtil.QRCode[], i: number) => {
+      row.forEach((_: any, j: number) => {
+        if (matrix[i][j]) {
+          if (
+            !(
+              (i < 7 && j < 7) ||
+              (i > matrix.length - 8 && j < 7) ||
+              (i < 7 && j > matrix.length - 8)
+            )
+          ) {
+            if (
+              !(
+                i > matrixMiddleStart &&
+                i < matrixMiddleEnd &&
+                j > matrixMiddleStart &&
+                j < matrixMiddleEnd
+              )
+            ) {
+              dots.push(
+                <circle
+                  cx={i * cellSize + cellSize / 2}
+                  cy={j * cellSize + cellSize / 2}
+                  fill="black"
+                  key={`circle-${i}-${j}`}
+                  r={cellSize / 3} // calculate size of single dots
+                />,
+              );
+            }
+          }
+        }
+      });
+    });
+
+    return dots;
+  }, [ecl, logoSize, size, uri]);
+
+  const logoPosition = size / 2 - logoSize / 2;
+  const logoWrapperSize = logoSize + logoMargin * 2;
 
   return (
     <Box
@@ -69,11 +135,39 @@ export function QRCode({
         }}
         userSelect="none"
       >
-        <Cuer.Root color="black" errorCorrection={ecc} size={size} value={uri}>
-          <Cuer.Finder />
-          <Cuer.Cells />
-          {arena}
-        </Cuer.Root>
+        <Box
+          display="flex"
+          justifyContent="center"
+          position="relative"
+          style={{
+            height: 0,
+            top: logoPosition,
+            width: size,
+          }}
+          width="full"
+        >
+          <AsyncImage
+            background={logoBackground}
+            borderColor={{ custom: 'rgba(0, 0, 0, 0.06)' }}
+            borderRadius="13"
+            height={logoSize}
+            src={logoUrl}
+            width={logoSize}
+          />
+        </Box>
+        <svg height={size} style={{ all: 'revert' }} width={size}>
+          <title>QR Code</title>
+          <defs>
+            <clipPath id="clip-wrapper">
+              <rect height={logoWrapperSize} width={logoWrapperSize} />
+            </clipPath>
+            <clipPath id="clip-logo">
+              <rect height={logoSize} width={logoSize} />
+            </clipPath>
+          </defs>
+          <rect fill="transparent" height={size} width={size} />
+          {dots}
+        </svg>
       </Box>
     </Box>
   );

--- a/packages/rainbowkit/src/components/QRCode/QRCode.tsx
+++ b/packages/rainbowkit/src/components/QRCode/QRCode.tsx
@@ -1,41 +1,27 @@
-import QRCodeUtil from 'qrcode';
-import React, { type ReactElement, useMemo } from 'react';
-import { AsyncImage } from '../AsyncImage/AsyncImage';
+import React from 'react';
+import { Cuer } from 'cuer';
 import { Box, type BoxProps } from '../Box/Box';
+import { useAsyncImage } from '../AsyncImage/useAsyncImage';
 import { QRCodeBackgroundClassName } from '../ConnectOptions/DesktopOptions.css';
 
-const generateMatrix = (
-  value: string,
-  errorCorrectionLevel: QRCodeUtil.QRCodeErrorCorrectionLevel,
-) => {
-  const arr = Array.prototype.slice.call(
-    QRCodeUtil.create(value, { errorCorrectionLevel }).modules.data,
-    0,
-  );
-  const sqrt = Math.sqrt(arr.length);
-  return arr.reduce(
-    (rows, key, index) =>
-      (index % sqrt === 0
-        ? rows.push([key])
-        : rows[rows.length - 1].push(key)) && rows,
-    [],
-  );
-};
+export type ErrorCorrectionLevel = 'low' | 'medium' | 'quartile' | 'high';
 
-type Props = {
-  ecl?: QRCodeUtil.QRCodeErrorCorrectionLevel;
+interface Props {
+  ecc?: ErrorCorrectionLevel;
   logoBackground?: string;
   logoUrl?: string | (() => Promise<string>);
   logoMargin?: number;
   logoSize?: number;
   size?: number;
   uri: string;
-};
+}
 
 export function QRCode({
-  ecl = 'M',
+  ecc = 'medium',
   logoBackground,
+  // biome-ignore lint/correctness/noUnusedVariables: API compatibility
   logoMargin = 10,
+  // biome-ignore lint/correctness/noUnusedVariables: API compatibility
   logoSize = 50,
   logoUrl,
   size: sizeProp = 200,
@@ -44,78 +30,26 @@ export function QRCode({
   const padding: NonNullable<BoxProps['padding']> = '20';
   const size = sizeProp - Number.parseInt(padding, 10) * 2;
 
-  const dots = useMemo(() => {
-    const dots: ReactElement[] = [];
-    const matrix = generateMatrix(uri, ecl);
-    const cellSize = size / matrix.length;
-    const qrList = [
-      { x: 0, y: 0 },
-      { x: 1, y: 0 },
-      { x: 0, y: 1 },
-    ];
+  const resolvedLogoUrl = useAsyncImage(logoUrl);
 
-    // biome-ignore lint/complexity/noForEach: TODO
-    qrList.forEach(({ x, y }) => {
-      const x1 = (matrix.length - 7) * cellSize * x;
-      const y1 = (matrix.length - 7) * cellSize * y;
-      for (let i = 0; i < 3; i++) {
-        dots.push(
-          <rect
-            fill={i % 2 !== 0 ? 'white' : 'black'}
-            height={cellSize * (7 - i * 2)}
-            key={`${i}-${x}-${y}`}
-            rx={(i - 2) * -5 + (i === 0 ? 2 : 0)} // calculated border radius for corner squares
-            ry={(i - 2) * -5 + (i === 0 ? 2 : 0)} // calculated border radius for corner squares
-            width={cellSize * (7 - i * 2)}
-            x={x1 + cellSize * i}
-            y={y1 + cellSize * i}
-          />,
-        );
-      }
-    });
-
-    const clearArenaSize = Math.floor((logoSize + 25) / cellSize);
-    const matrixMiddleStart = matrix.length / 2 - clearArenaSize / 2;
-    const matrixMiddleEnd = matrix.length / 2 + clearArenaSize / 2 - 1;
-
-    matrix.forEach((row: QRCodeUtil.QRCode[], i: number) => {
-      row.forEach((_: any, j: number) => {
-        if (matrix[i][j]) {
-          if (
-            !(
-              (i < 7 && j < 7) ||
-              (i > matrix.length - 8 && j < 7) ||
-              (i < 7 && j > matrix.length - 8)
-            )
-          ) {
-            if (
-              !(
-                i > matrixMiddleStart &&
-                i < matrixMiddleEnd &&
-                j > matrixMiddleStart &&
-                j < matrixMiddleEnd
-              )
-            ) {
-              dots.push(
-                <circle
-                  cx={i * cellSize + cellSize / 2}
-                  cy={j * cellSize + cellSize / 2}
-                  fill="black"
-                  key={`circle-${i}-${j}`}
-                  r={cellSize / 3} // calculate size of single dots
-                />,
-              );
-            }
-          }
-        }
-      });
-    });
-
-    return dots;
-  }, [ecl, logoSize, size, uri]);
-
-  const logoPosition = size / 2 - logoSize / 2;
-  const logoWrapperSize = logoSize + logoMargin * 2;
+  const arena = resolvedLogoUrl ? (
+    <Cuer.Arena>
+      <img
+        alt=""
+        src={resolvedLogoUrl}
+        style={{
+          background: logoBackground,
+          borderColor: 'rgba(0, 0, 0, 0.06)',
+          borderRadius: 13,
+          borderStyle: 'solid',
+          borderWidth: 1,
+          height: '100%',
+          objectFit: 'cover',
+          width: '100%',
+        }}
+      />
+    </Cuer.Arena>
+  ) : null;
 
   return (
     <Box
@@ -135,39 +69,11 @@ export function QRCode({
         }}
         userSelect="none"
       >
-        <Box
-          display="flex"
-          justifyContent="center"
-          position="relative"
-          style={{
-            height: 0,
-            top: logoPosition,
-            width: size,
-          }}
-          width="full"
-        >
-          <AsyncImage
-            background={logoBackground}
-            borderColor={{ custom: 'rgba(0, 0, 0, 0.06)' }}
-            borderRadius="13"
-            height={logoSize}
-            src={logoUrl}
-            width={logoSize}
-          />
-        </Box>
-        <svg height={size} style={{ all: 'revert' }} width={size}>
-          <title>QR Code</title>
-          <defs>
-            <clipPath id="clip-wrapper">
-              <rect height={logoWrapperSize} width={logoWrapperSize} />
-            </clipPath>
-            <clipPath id="clip-logo">
-              <rect height={logoSize} width={logoSize} />
-            </clipPath>
-          </defs>
-          <rect fill="transparent" height={size} width={size} />
-          {dots}
-        </svg>
+        <Cuer.Root color="black" errorCorrection={ecc} size={size} value={uri}>
+          <Cuer.Finder />
+          <Cuer.Cells />
+          {arena}
+        </Cuer.Root>
       </Box>
     </Box>
   );

--- a/packages/rainbowkit/src/components/QRCode/QRCode.tsx
+++ b/packages/rainbowkit/src/components/QRCode/QRCode.tsx
@@ -10,7 +10,6 @@ interface Props {
   ecc?: ErrorCorrectionLevel;
   logoBackground?: string;
   logoUrl?: string | (() => Promise<string>);
-  logoMargin?: number;
   logoSize?: number;
   size?: number;
   uri: string;
@@ -19,8 +18,6 @@ interface Props {
 export function QRCode({
   ecc = 'medium',
   logoBackground,
-  // biome-ignore lint/correctness/noUnusedVariables: API compatibility
-  logoMargin = 10,
   // biome-ignore lint/correctness/noUnusedVariables: API compatibility
   logoSize = 50,
   logoUrl,
@@ -59,14 +56,11 @@ export function QRCode({
                 alt="Wallet Logo"
                 src={resolvedLogoUrl}
                 style={{
-                  background: logoBackground,
-                  borderColor: 'rgba(0, 0, 0, 0.06)',
-                  borderStyle: 'solid',
-                  borderWidth: '0.01px',
-                  borderRadius: '19%',
-                  height: '86%',
                   objectFit: 'cover',
-                  width: '86%',
+                  height: '88%',
+                  width: '88%',
+                  borderRadius: '22.5%',
+                  backgroundColor: logoBackground,
                 }}
               />
             </Cuer.Arena>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,9 +435,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
-      cuer:
-        specifier: ^0.0.2
-        version: 0.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.5.4)
+      qrcode:
+        specifier: 1.5.4
+        version: 1.5.4
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
@@ -466,6 +466,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.5.2(@testing-library/dom@10.4.0)
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.5
       '@types/ua-parser-js':
         specifier: ^0.7.39
         version: 0.7.39
@@ -892,6 +895,7 @@ packages:
   '@babel/plugin-proposal-class-properties@7.18.6':
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -904,24 +908,28 @@ packages:
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6':
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-numeric-separator@7.18.6':
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-optional-chaining@7.21.0':
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-private-methods@7.18.6':
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -934,6 +942,7 @@ packages:
   '@babel/plugin-proposal-private-property-in-object@7.21.11':
     resolution: {integrity: sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -3350,6 +3359,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
+    deprecated: 'The package is now available as "qr": npm install qr'
 
   '@peculiar/asn1-schema@2.3.13':
     resolution: {integrity: sha512-3Xq3a01WkHRZL8X04Zsfg//mGaA21xlL4tlVn4v2xGT0JStiztATRkMwa5b+f/HXmY2smsiLXYK46Gwgzvfg3g==}
@@ -4535,6 +4545,9 @@ packages:
   '@types/q@1.5.8':
     resolution: {integrity: sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==}
 
+  '@types/qrcode@1.5.5':
+    resolution: {integrity: sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==}
+
   '@types/qs@6.9.15':
     resolution: {integrity: sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==}
 
@@ -4973,6 +4986,7 @@ packages:
 
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    deprecated: Use your platform's native atob() and btoa() methods instead
 
   abitype@1.0.8:
     resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
@@ -6037,16 +6051,6 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
-  cuer@0.0.2:
-    resolution: {integrity: sha512-MG1BYnnSLqBnO0dOBS1Qm/TEc9DnFa9Sz2jMA24OF4hGzs8UuPjpKBMkRPF3lrpC+7b3EzULwooX9djcvsM8IA==}
-    peerDependencies:
-      react: ^19.1.0
-      react-dom: ^19.1.0
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -6340,6 +6344,7 @@ packages:
   domexception@2.0.1:
     resolution: {integrity: sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==}
     engines: {node: '>=8'}
+    deprecated: Use your platform's native DOMException instead
 
   domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
@@ -7277,6 +7282,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -7627,6 +7633,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.3:
     resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
@@ -10226,12 +10233,18 @@ packages:
   q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
+    deprecated: |-
+      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
 
-  qr@0.4.2:
-    resolution: {integrity: sha512-wCv4rt7IcPNGT0J8JiTBHx7YrZzYuzpof38y/MFYd5Sp7OTyAFYL1e110In8PrAG/ffIOVl1ha3joJ2zpYxKMQ==}
+      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 
@@ -10606,10 +10619,12 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup-plugin-terser@7.0.2:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
+    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
     peerDependencies:
       rollup: ^2.0.0
 
@@ -10915,6 +10930,7 @@ packages:
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -10961,6 +10977,7 @@ packages:
 
   stable@0.1.8:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
+    deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -11187,6 +11204,7 @@ packages:
   svgo@1.3.2:
     resolution: {integrity: sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==}
     engines: {node: '>=4.0.0'}
+    deprecated: This SVGO version is no longer supported. Upgrade to v2.x.x.
     hasBin: true
 
   svgo@2.8.0:
@@ -11959,6 +11977,7 @@ packages:
 
   w3c-hr-time@1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
+    deprecated: Use your platform's native performance.now() and performance.timeOrigin.
 
   w3c-xmlserializer@2.0.0:
     resolution: {integrity: sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==}
@@ -12176,6 +12195,7 @@ packages:
 
   workbox-cacheable-response@6.6.0:
     resolution: {integrity: sha512-JfhJUSQDwsF1Xv3EV1vWzSsCOZn4mQ38bWEBR3LdvOxSPgB65gAM6cS2CX8rkkKHRgiLrN7Wxoyu+TuH67kHrw==}
+    deprecated: workbox-background-sync@6.6.0
 
   workbox-core@6.6.0:
     resolution: {integrity: sha512-GDtFRF7Yg3DD859PMbPAYPeJyg5gJYXuBQAC+wyrWuuXgpfoOrIQIvFRZnQ7+czTIQjIr1DhLEGFzZanAT/3bQ==}
@@ -12185,6 +12205,7 @@ packages:
 
   workbox-google-analytics@6.6.0:
     resolution: {integrity: sha512-p4DJa6OldXWd6M9zRl0H6vB9lkrmqYFkRQ2xEiNdBFp9U0LhsGO7hsBscVEyH9H2/3eZZt8c97NB2FD9U2NJ+Q==}
+    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
 
   workbox-navigation-preload@6.6.0:
     resolution: {integrity: sha512-utNEWG+uOfXdaZmvhshrh7KzhDu/1iMHyQOV6Aqup8Mm78D286ugu5k9MFD9SzBT5TcwgwSORVvInaXWbvKz9Q==}
@@ -16876,6 +16897,10 @@ snapshots:
 
   '@types/q@1.5.8': {}
 
+  '@types/qrcode@1.5.5':
+    dependencies:
+      '@types/node': 20.16.5
+
   '@types/qs@6.9.15': {}
 
   '@types/range-parser@1.2.7': {}
@@ -19113,14 +19138,6 @@ snapshots:
       rrweb-cssom: 0.6.0
 
   csstype@3.1.3: {}
-
-  cuer@0.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.5.4):
-    dependencies:
-      qr: 0.4.2
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    optionalDependencies:
-      typescript: 5.5.4
 
   damerau-levenshtein@1.0.8: {}
 
@@ -24551,12 +24568,16 @@ snapshots:
 
   q@1.5.1: {}
 
-  qr@0.4.2: {}
-
   qrcode@1.5.3:
     dependencies:
       dijkstrajs: 1.0.3
       encode-utf8: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,7 +436,7 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       cuer:
-        specifier: ^0.0.2
+        specifier: 0.0.2
         version: 0.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.5.4)
       react-dom:
         specifier: ^19.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,9 +435,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
-      qrcode:
-        specifier: 1.5.4
-        version: 1.5.4
+      cuer:
+        specifier: ^0.0.2
+        version: 0.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.5.4)
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
@@ -466,9 +466,6 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.5.2(@testing-library/dom@10.4.0)
-      '@types/qrcode':
-        specifier: ^1.5.5
-        version: 1.5.5
       '@types/ua-parser-js':
         specifier: ^0.7.39
         version: 0.7.39
@@ -895,7 +892,6 @@ packages:
   '@babel/plugin-proposal-class-properties@7.18.6':
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -908,28 +904,24 @@ packages:
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6':
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-numeric-separator@7.18.6':
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-optional-chaining@7.21.0':
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-private-methods@7.18.6':
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -942,7 +934,6 @@ packages:
   '@babel/plugin-proposal-private-property-in-object@7.21.11':
     resolution: {integrity: sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -3359,7 +3350,6 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'The package is now available as "qr": npm install qr'
 
   '@peculiar/asn1-schema@2.3.13':
     resolution: {integrity: sha512-3Xq3a01WkHRZL8X04Zsfg//mGaA21xlL4tlVn4v2xGT0JStiztATRkMwa5b+f/HXmY2smsiLXYK46Gwgzvfg3g==}
@@ -4545,9 +4535,6 @@ packages:
   '@types/q@1.5.8':
     resolution: {integrity: sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==}
 
-  '@types/qrcode@1.5.5':
-    resolution: {integrity: sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==}
-
   '@types/qs@6.9.15':
     resolution: {integrity: sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==}
 
@@ -4986,7 +4973,6 @@ packages:
 
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
-    deprecated: Use your platform's native atob() and btoa() methods instead
 
   abitype@1.0.8:
     resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
@@ -6051,6 +6037,16 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  cuer@0.0.2:
+    resolution: {integrity: sha512-MG1BYnnSLqBnO0dOBS1Qm/TEc9DnFa9Sz2jMA24OF4hGzs8UuPjpKBMkRPF3lrpC+7b3EzULwooX9djcvsM8IA==}
+    peerDependencies:
+      react: ^19.1.0
+      react-dom: ^19.1.0
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -6344,7 +6340,6 @@ packages:
   domexception@2.0.1:
     resolution: {integrity: sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==}
     engines: {node: '>=8'}
-    deprecated: Use your platform's native DOMException instead
 
   domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
@@ -7282,7 +7277,6 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -7633,7 +7627,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.3:
     resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
@@ -10233,18 +10226,12 @@ packages:
   q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
-    deprecated: |-
-      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
 
-      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
+  qr@0.4.2:
+    resolution: {integrity: sha512-wCv4rt7IcPNGT0J8JiTBHx7YrZzYuzpof38y/MFYd5Sp7OTyAFYL1e110In8PrAG/ffIOVl1ha3joJ2zpYxKMQ==}
 
   qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-
-  qrcode@1.5.4:
-    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 
@@ -10619,12 +10606,10 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup-plugin-terser@7.0.2:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
-    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
     peerDependencies:
       rollup: ^2.0.0
 
@@ -10930,7 +10915,6 @@ packages:
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
-    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -10977,7 +10961,6 @@ packages:
 
   stable@0.1.8:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
-    deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -11204,7 +11187,6 @@ packages:
   svgo@1.3.2:
     resolution: {integrity: sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==}
     engines: {node: '>=4.0.0'}
-    deprecated: This SVGO version is no longer supported. Upgrade to v2.x.x.
     hasBin: true
 
   svgo@2.8.0:
@@ -11977,7 +11959,6 @@ packages:
 
   w3c-hr-time@1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
-    deprecated: Use your platform's native performance.now() and performance.timeOrigin.
 
   w3c-xmlserializer@2.0.0:
     resolution: {integrity: sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==}
@@ -12195,7 +12176,6 @@ packages:
 
   workbox-cacheable-response@6.6.0:
     resolution: {integrity: sha512-JfhJUSQDwsF1Xv3EV1vWzSsCOZn4mQ38bWEBR3LdvOxSPgB65gAM6cS2CX8rkkKHRgiLrN7Wxoyu+TuH67kHrw==}
-    deprecated: workbox-background-sync@6.6.0
 
   workbox-core@6.6.0:
     resolution: {integrity: sha512-GDtFRF7Yg3DD859PMbPAYPeJyg5gJYXuBQAC+wyrWuuXgpfoOrIQIvFRZnQ7+czTIQjIr1DhLEGFzZanAT/3bQ==}
@@ -12205,7 +12185,6 @@ packages:
 
   workbox-google-analytics@6.6.0:
     resolution: {integrity: sha512-p4DJa6OldXWd6M9zRl0H6vB9lkrmqYFkRQ2xEiNdBFp9U0LhsGO7hsBscVEyH9H2/3eZZt8c97NB2FD9U2NJ+Q==}
-    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
 
   workbox-navigation-preload@6.6.0:
     resolution: {integrity: sha512-utNEWG+uOfXdaZmvhshrh7KzhDu/1iMHyQOV6Aqup8Mm78D286ugu5k9MFD9SzBT5TcwgwSORVvInaXWbvKz9Q==}
@@ -16897,10 +16876,6 @@ snapshots:
 
   '@types/q@1.5.8': {}
 
-  '@types/qrcode@1.5.5':
-    dependencies:
-      '@types/node': 20.16.5
-
   '@types/qs@6.9.15': {}
 
   '@types/range-parser@1.2.7': {}
@@ -19138,6 +19113,14 @@ snapshots:
       rrweb-cssom: 0.6.0
 
   csstype@3.1.3: {}
+
+  cuer@0.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.5.4):
+    dependencies:
+      qr: 0.4.2
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      typescript: 5.5.4
 
   damerau-levenshtein@1.0.8: {}
 
@@ -24568,16 +24551,12 @@ snapshots:
 
   q@1.5.1: {}
 
+  qr@0.4.2: {}
+
   qrcode@1.5.3:
     dependencies:
       dijkstrajs: 1.0.3
       encode-utf8: 1.0.3
-      pngjs: 5.0.0
-      yargs: 15.4.1
-
-  qrcode@1.5.4:
-    dependencies:
-      dijkstrajs: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,9 +435,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
-      qrcode:
-        specifier: 1.5.4
-        version: 1.5.4
+      cuer:
+        specifier: ^0.0.2
+        version: 0.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.5.4)
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
@@ -466,9 +466,6 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.5.2(@testing-library/dom@10.4.0)
-      '@types/qrcode':
-        specifier: ^1.5.5
-        version: 1.5.5
       '@types/ua-parser-js':
         specifier: ^0.7.39
         version: 0.7.39
@@ -4538,9 +4535,6 @@ packages:
   '@types/q@1.5.8':
     resolution: {integrity: sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==}
 
-  '@types/qrcode@1.5.5':
-    resolution: {integrity: sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==}
-
   '@types/qs@6.9.15':
     resolution: {integrity: sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==}
 
@@ -6042,6 +6036,16 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  cuer@0.0.2:
+    resolution: {integrity: sha512-MG1BYnnSLqBnO0dOBS1Qm/TEc9DnFa9Sz2jMA24OF4hGzs8UuPjpKBMkRPF3lrpC+7b3EzULwooX9djcvsM8IA==}
+    peerDependencies:
+      react: ^19.1.0
+      react-dom: ^19.1.0
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -10223,13 +10227,11 @@ packages:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
 
+  qr@0.4.2:
+    resolution: {integrity: sha512-wCv4rt7IcPNGT0J8JiTBHx7YrZzYuzpof38y/MFYd5Sp7OTyAFYL1e110In8PrAG/ffIOVl1ha3joJ2zpYxKMQ==}
+
   qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-
-  qrcode@1.5.4:
-    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 
@@ -16874,10 +16876,6 @@ snapshots:
 
   '@types/q@1.5.8': {}
 
-  '@types/qrcode@1.5.5':
-    dependencies:
-      '@types/node': 20.16.5
-
   '@types/qs@6.9.15': {}
 
   '@types/range-parser@1.2.7': {}
@@ -19115,6 +19113,14 @@ snapshots:
       rrweb-cssom: 0.6.0
 
   csstype@3.1.3: {}
+
+  cuer@0.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.5.4):
+    dependencies:
+      qr: 0.4.2
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      typescript: 5.5.4
 
   damerau-levenshtein@1.0.8: {}
 
@@ -24545,16 +24551,12 @@ snapshots:
 
   q@1.5.1: {}
 
+  qr@0.4.2: {}
+
   qrcode@1.5.3:
     dependencies:
       dijkstrajs: 1.0.3
       encode-utf8: 1.0.3
-      pngjs: 5.0.0
-      yargs: 15.4.1
-
-  qrcode@1.5.4:
-    dependencies:
-      dijkstrajs: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
 


### PR DESCRIPTION
## Summary
- replace `qrcode` with `cuer`
- update QRCode component to use `cuer`
- style arena image with 100% sizing and object-fit cover

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_683fbc562a988325a661b94ab1642de7

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the QR code generation and rendering by replacing the `qrcode` library with `cuer`, enhancing error correction capabilities and overall rendering quality.

### Detailed summary
- Updated the dependency from `qrcode` to `cuer` in `package.json`.
- Removed `qrcode` references in `pnpm-lock.yaml`.
- Modified the `QRCode` component to use `Cuer` for QR code generation.
- Updated props in the `QRCode` component for error correction.
- Simplified the QR code rendering logic using `Cuer` components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->