### PR TITLE
Enable copying WalletConnect URI

### DIFF
--- a/.changeset/copy-uri-feature.md
+++ b/.changeset/copy-uri-feature.md
@@ -1,0 +1,6 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+The desktop WalletConnect flow now offers a "Copy URI" button instead of opening the WalletConnect modal. Mobile wallets continue to open the WalletConnect modal as before.
+

--- a/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/ConnectDetails.tsx
@@ -1,4 +1,10 @@
-import React, { type ReactNode, useContext, useEffect } from 'react';
+import React, {
+  type JSX,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 import { touchableStyles } from '../../css/touchableStyles';
 import { useWindowSize } from '../../hooks/useWindowSize';
 import { BrowserType, getBrowser, isSafari } from '../../utils/browsers';
@@ -18,6 +24,7 @@ import { CreateIcon, preloadCreateIcon } from '../Icons/Create';
 import { RefreshIcon, preloadRefreshIcon } from '../Icons/Refresh';
 import { ScanIcon, preloadScanIcon } from '../Icons/Scan';
 import { SpinnerIcon } from '../Icons/Spinner';
+import { CopiedIcon } from '../Icons/Copied';
 import { QRCode } from '../QRCode/QRCode';
 import { I18nContext } from '../RainbowKitProvider/I18nContext';
 import { ModalSizeContext } from '../RainbowKitProvider/ModalSizeContext';
@@ -192,7 +199,6 @@ export function ConnectDetail({
   changeWalletStep,
   compactModeEnabled,
   connectionError,
-  onClose,
   qrCodeUri,
   reconnect,
   wallet,
@@ -203,7 +209,6 @@ export function ConnectDetail({
   qrCodeUri?: string;
   reconnect: (wallet: WalletConnector) => void;
   wallet: WalletConnector;
-  onClose: () => void;
 }) {
   const {
     downloadUrls,
@@ -212,13 +217,21 @@ export function ConnectDetail({
     name,
     qrCode,
     ready,
-    showWalletConnectModal,
     getDesktopUri,
   } = wallet;
   const isDesktopDeepLinkAvailable = !!getDesktopUri;
   const safari = isSafari();
 
   const { i18n } = useContext(I18nContext);
+
+  const [copiedUri, setCopiedUri] = useState(false);
+
+  useEffect(() => {
+    if (copiedUri) {
+      const timer = setTimeout(() => setCopiedUri(false), 1500);
+      return () => clearTimeout(timer);
+    }
+  }, [copiedUri]);
 
   const hasExtension = !!wallet.extensionDownloadUrl;
   const hasQrCodeAndExtension = downloadUrls?.qrCode && hasExtension;
@@ -236,31 +249,34 @@ export function ConnectDetail({
     label: string;
     onClick?: () => void;
     href?: string;
-  } | null = showWalletConnectModal
-    ? {
-        description: !compactModeEnabled
-          ? i18n.t('connect.walletconnect.description.full')
-          : i18n.t('connect.walletconnect.description.compact'),
-        label: i18n.t('connect.walletconnect.open.label'),
-        onClick: () => {
-          onClose();
-          showWalletConnectModal();
-        },
-      }
-    : hasQrCode
+  } | null =
+    wallet.id === 'walletConnect'
       ? {
-          description: i18n.t('connect.secondary_action.get.description', {
-            wallet: name,
-          }),
-          label: i18n.t('connect.secondary_action.get.label'),
-          onClick: () =>
-            changeWalletStep(
-              hasQrCodeAndExtension || hasQrCodeAndDesktop
-                ? WalletStep.DownloadOptions
-                : WalletStep.Download,
-            ),
+          description: !compactModeEnabled
+            ? i18n.t('connect.walletconnect.description.full')
+            : i18n.t('connect.walletconnect.description.compact'),
+          label: i18n.t('connect.walletconnect.copy.label'),
+          onClick: () => {
+            if (qrCodeUri) {
+              navigator?.clipboard?.writeText(qrCodeUri);
+              setCopiedUri(true);
+            }
+          },
         }
-      : null;
+      : hasQrCode
+        ? {
+            description: i18n.t('connect.secondary_action.get.description', {
+              wallet: name,
+            }),
+            label: i18n.t('connect.secondary_action.get.label'),
+            onClick: () =>
+              changeWalletStep(
+                hasQrCodeAndExtension || hasQrCodeAndDesktop
+                  ? WalletStep.DownloadOptions
+                  : WalletStep.Download,
+              ),
+          }
+        : null;
 
   const { width: windowWidth } = useWindowSize();
   const smallWindow = windowWidth && windowWidth < 768;
@@ -405,11 +421,17 @@ export function ConnectDetail({
             <Text color="modalTextSecondary" size="14" weight="medium">
               {secondaryAction.description}
             </Text>
-            <ActionButton
-              label={secondaryAction.label}
-              onClick={secondaryAction.onClick}
-              type="secondary"
-            />
+            {copiedUri ? (
+              <Box color="modalTextSecondary" display="flex">
+                <CopiedIcon />
+              </Box>
+            ) : (
+              <ActionButton
+                label={secondaryAction.label}
+                onClick={secondaryAction.onClick}
+                type="secondary"
+              />
+            )}
           </>
         )}
       </Box>

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -262,7 +262,6 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
           changeWalletStep={changeWalletStep}
           compactModeEnabled={compactModeEnabled}
           connectionError={connectionError}
-          onClose={onClose}
           qrCodeUri={qrCodeUri}
           reconnect={connectToWallet}
           wallet={selectedWallet}

--- a/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
+++ b/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
@@ -41,7 +41,7 @@ export function ProfileDetails({
   const [copiedAddress, setCopiedAddress] = useState(false);
   const copyAddressAction = useCallback(() => {
     if (address) {
-      navigator.clipboard.writeText(address);
+      navigator?.clipboard?.writeText(address);
       setCopiedAddress(true);
     }
   }, [address]);

--- a/packages/rainbowkit/src/locales/en_US.json
+++ b/packages/rainbowkit/src/locales/en_US.json
@@ -79,11 +79,12 @@
     },
     "walletconnect": {
       "description": {
-        "full": "Need the official WalletConnect modal?",
-        "compact": "Need the WalletConnect modal?"
+        "full": "Need a pairing code to connect?",
+        "compact": "Need a pairing code?"
       },
-      "open": {
-        "label": "OPEN"
+      "copy": {
+        "label": "Copy",
+        "copied": "Copied!"
       }
     }
   },


### PR DESCRIPTION
## Summary
- replace WalletConnect modal open button with a copy URI button on desktop
- restore WalletConnect modal behavior on mobile
- update changeset description

## Testing
- `pnpm lint`
- `pnpm test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6840e04208f48325b47a0f1c78c6529f

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the desktop WalletConnect flow by introducing a "Copy URI" feature, improving user experience. It also refines clipboard interactions and updates wallet connection descriptions.

### Detailed summary
- Replaced the WalletConnect modal with a "Copy URI" button for desktop.
- Updated clipboard interaction to use optional chaining.
- Modified connection descriptions in `en_US.json`.
- Added a copied state and feedback in `ConnectDetail`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->