### PR TITLE
revert: package node engine minimum bump

### DIFF
--- a/examples/with-next-app-i18n/package.json
+++ b/examples/with-next-app-i18n/package.json
@@ -23,6 +23,6 @@
     "typescript": "5.5.4"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20"
   }
 }

--- a/examples/with-next-app/package.json
+++ b/examples/with-next-app/package.json
@@ -22,6 +22,6 @@
     "typescript": "5.5.4"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20"
   }
 }

--- a/examples/with-remix/package.json
+++ b/examples/with-remix/package.json
@@ -26,6 +26,6 @@
     "typescript": "5.5.4"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20"
   }
 }

--- a/packages/rainbow-button/package.json
+++ b/packages/rainbow-button/package.json
@@ -24,7 +24,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "engines": {
-    "node": ">=20"
+    "node": ">=12.4"
   },
   "scripts": {
     "build": "node build.js",

--- a/packages/rainbowkit-siwe-next-auth/package.json
+++ b/packages/rainbowkit-siwe-next-auth/package.json
@@ -13,7 +13,7 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "engines": {
-    "node": ">=20"
+    "node": ">=12.4"
   },
   "scripts": {
     "build": "node build.js",

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -19,7 +19,7 @@
     "src/css/reset.css.ts"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=12.4"
   },
   "scripts": {
     "build": "node build.js",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `node` engine version requirements in several `package.json` files, lowering the minimum version from `>=20.0.0` to `>=20` for some packages and from `>=20` to `>=12.4` for others.

### Detailed summary
- Updated `node` engine version to `>=20` in:
  - `examples/with-remix/package.json`
  - `examples/with-next-app/package.json`
  - `examples/with-next-app-i18n/package.json`
- Updated `node` engine version to `>=12.4` in:
  - `packages/rainbowkit/package.json`
  - `packages/rainbow-button/package.json`
  - `packages/rainbowkit-siwe-next-auth/package.json`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->