### PR TITLE
fix: remove deprecated legacyBehavior

### DIFF
--- a/.changeset/remove-legacy-link-site.md
+++ b/.changeset/remove-legacy-link-site.md
@@ -2,4 +2,5 @@
 "site": patch
 ---
 
-Remove deprecated `legacyBehavior` from Next.js Link components.
+Remove deprecated `legacyBehavior` from Next.js Link components. Updated the
+custom Link component to use Next.js' new API and preserve existing styling.

--- a/.changeset/remove-legacy-link-site.md
+++ b/.changeset/remove-legacy-link-site.md
@@ -1,0 +1,5 @@
+---
+"site": patch
+---
+
+Remove deprecated `legacyBehavior` from Next.js Link components.

--- a/site/components/DocsLayout/DocsLayout.tsx
+++ b/site/components/DocsLayout/DocsLayout.tsx
@@ -17,7 +17,6 @@ import { Wrapper } from 'components/Wrapper/Wrapper';
 import { vars } from 'css/vars.css';
 import { allDocsRoutes, docsRoutes } from 'lib/docsRoutes';
 import { useCoolMode } from 'lib/useCoolMode';
-import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import React, { type Ref, useCallback, useEffect } from 'react';
 import { useAccount } from 'wagmi';
@@ -142,25 +141,25 @@ export function DocsLayout({ children }: { children: React.ReactNode }) {
               >
                 {previous && (
                   <Text weight="semibold">
-                    <NextLink
+                    <Link
                       className={paginationItem}
                       href={`/docs/${previous.slug}`}
                     >
                       <PreviousIcon />
                       {previous.title}
-                    </NextLink>
+                    </Link>
                   </Text>
                 )}
                 <span aria-hidden />
                 {next && (
                   <Text weight="semibold">
-                    <NextLink
+                    <Link
                       className={paginationItem}
                       href={`/docs/${next.slug}`}
                     >
                       {next.title}
                       <NextIcon />
-                    </NextLink>
+                    </Link>
                   </Text>
                 )}
               </Box>

--- a/site/components/DocsLayout/DocsLayout.tsx
+++ b/site/components/DocsLayout/DocsLayout.tsx
@@ -142,11 +142,7 @@ export function DocsLayout({ children }: { children: React.ReactNode }) {
               >
                 {previous && (
                   <Text weight="semibold">
-                    <NextLink
-                      href={`/docs/${previous.slug}`}
-                      legacyBehavior
-                      passHref
-                    >
+                    <NextLink href={`/docs/${previous.slug}`} passHref>
                       <Link className={paginationItem}>
                         <PreviousIcon />
                         {previous.title}
@@ -157,11 +153,7 @@ export function DocsLayout({ children }: { children: React.ReactNode }) {
                 <span aria-hidden />
                 {next && (
                   <Text weight="semibold">
-                    <NextLink
-                      href={`/docs/${next.slug}`}
-                      legacyBehavior
-                      passHref
-                    >
+                    <NextLink href={`/docs/${next.slug}`} passHref>
                       <Link className={paginationItem}>
                         {next.title}
                         <NextIcon />

--- a/site/components/DocsLayout/DocsLayout.tsx
+++ b/site/components/DocsLayout/DocsLayout.tsx
@@ -142,22 +142,24 @@ export function DocsLayout({ children }: { children: React.ReactNode }) {
               >
                 {previous && (
                   <Text weight="semibold">
-                    <NextLink href={`/docs/${previous.slug}`} passHref>
-                      <Link className={paginationItem}>
-                        <PreviousIcon />
-                        {previous.title}
-                      </Link>
+                    <NextLink
+                      className={paginationItem}
+                      href={`/docs/${previous.slug}`}
+                    >
+                      <PreviousIcon />
+                      {previous.title}
                     </NextLink>
                   </Text>
                 )}
                 <span aria-hidden />
                 {next && (
                   <Text weight="semibold">
-                    <NextLink href={`/docs/${next.slug}`} passHref>
-                      <Link className={paginationItem}>
-                        {next.title}
-                        <NextIcon />
-                      </Link>
+                    <NextLink
+                      className={paginationItem}
+                      href={`/docs/${next.slug}`}
+                    >
+                      {next.title}
+                      <NextIcon />
                     </NextLink>
                   </Text>
                 )}

--- a/site/components/Header/Header.tsx
+++ b/site/components/Header/Header.tsx
@@ -9,7 +9,7 @@ import { Badge } from 'components/Badge/Badge';
 import { Box } from 'components/Box/Box';
 import { Text } from 'components/Text/Text';
 import { vars } from 'css/vars.css';
-import NextLink from 'next/link';
+import { Link } from 'components/Link/Link';
 import { useRouter } from 'next/router';
 import type React from 'react';
 import pckg from '../../../packages/rainbowkit/package.json';
@@ -31,7 +31,7 @@ export function Header({
   return (
     <Box className={sticky ? header : undefined} {...props}>
       <Box className={row}>
-        <NextLink href="/">
+        <Link href="/">
           <Box
             alt="Rainbow logo"
             as="img"
@@ -46,7 +46,7 @@ export function Header({
             transitionProperty="transform"
             transitionTimingFunction="ease"
           />
-        </NextLink>
+        </Link>
 
         <Box
           alignItems={{ xs: 'flex-start', sm: 'center' }}

--- a/site/components/Header/Header.tsx
+++ b/site/components/Header/Header.tsx
@@ -31,7 +31,7 @@ export function Header({
   return (
     <Box className={sticky ? header : undefined} {...props}>
       <Box className={row}>
-        <NextLink href="/" legacyBehavior>
+        <NextLink href="/">
           <Box
             alt="Rainbow logo"
             as="img"

--- a/site/components/Link/Link.tsx
+++ b/site/components/Link/Link.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { Box, type BoxProps } from 'components/Box/Box';
-import type { LinkProps as NextLinkProps } from 'next/link';
-import React from 'react';
+import NextLink, { type LinkProps as NextLinkProps } from 'next/link';
+import React, { type JSX } from 'react';
 import * as styles from './Link.css';
 
 type Props = {
@@ -42,7 +42,7 @@ export const Link = React.forwardRef(
   ) => {
     return (
       <Box
-        as="a"
+        as={NextLink}
         className={clsx(
           styles.variants({
             variant,

--- a/site/components/Link/Link.tsx
+++ b/site/components/Link/Link.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { Box, type BoxProps } from 'components/Box/Box';
+import NextLink, { type LinkProps as NextLinkProps } from 'next/link';
 import React, { type JSX } from 'react';
 import * as styles from './Link.css';
 
@@ -15,8 +16,9 @@ type Props = {
   marginX?: BoxProps['marginX'];
   display?: BoxProps['display'];
   style?: React.CSSProperties;
-} & Pick<JSX.IntrinsicElements['a'], 'href' | 'className'> &
-  styles.Variants;
+} & Omit<BoxProps, 'as'> &
+  Omit<NextLinkProps, 'className' | 'legacyBehavior' | 'children'> &
+  styles.Variants & { className?: string };
 
 export const Link = React.forwardRef(
   (
@@ -40,7 +42,7 @@ export const Link = React.forwardRef(
   ) => {
     return (
       <Box
-        as="a"
+        as={NextLink}
         className={clsx(
           styles.variants({
             variant,

--- a/site/components/Link/Link.tsx
+++ b/site/components/Link/Link.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { Box, type BoxProps } from 'components/Box/Box';
-import NextLink, { type LinkProps as NextLinkProps } from 'next/link';
-import React, { type JSX } from 'react';
+import type { LinkProps as NextLinkProps } from 'next/link';
+import React from 'react';
 import * as styles from './Link.css';
 
 type Props = {
@@ -42,7 +42,7 @@ export const Link = React.forwardRef(
   ) => {
     return (
       <Box
-        as={NextLink}
+        as="a"
         className={clsx(
           styles.variants({
             variant,

--- a/site/components/Sidebar/Sidebar.tsx
+++ b/site/components/Sidebar/Sidebar.tsx
@@ -106,7 +106,7 @@ function Link({ children, slug }: { children: React.ReactNode; slug: string }) {
   const router = useRouter();
 
   return (
-    <NextLink passHref href={`/docs/${slug}`} legacyBehavior>
+    <NextLink passHref href={`/docs/${slug}`}>
       <Box as="a" className={link({ active: router.query.slug === slug })}>
         {children}
       </Box>

--- a/site/components/Sidebar/Sidebar.tsx
+++ b/site/components/Sidebar/Sidebar.tsx
@@ -106,10 +106,11 @@ function Link({ children, slug }: { children: React.ReactNode; slug: string }) {
   const router = useRouter();
 
   return (
-    <NextLink passHref href={`/docs/${slug}`}>
-      <Box as="a" className={link({ active: router.query.slug === slug })}>
-        {children}
-      </Box>
+    <NextLink
+      className={link({ active: router.query.slug === slug })}
+      href={`/docs/${slug}`}
+    >
+      {children}
     </NextLink>
   );
 }

--- a/site/components/Sidebar/Sidebar.tsx
+++ b/site/components/Sidebar/Sidebar.tsx
@@ -3,7 +3,7 @@ import { SearchIcon } from 'components/Icons/Search';
 import { SearchButton } from 'components/Search/Search';
 import { Text } from 'components/Text/Text';
 import { useTranslations } from 'next-intl';
-import NextLink from 'next/link';
+import { Link as DocsLink } from 'components/Link/Link';
 import { useRouter } from 'next/router';
 import type React from 'react';
 import { link } from './Sidebar.css';
@@ -106,11 +106,11 @@ function Link({ children, slug }: { children: React.ReactNode; slug: string }) {
   const router = useRouter();
 
   return (
-    <NextLink
+    <DocsLink
       className={link({ active: router.query.slug === slug })}
       href={`/docs/${slug}`}
     >
       {children}
-    </NextLink>
+    </DocsLink>
   );
 }

--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -82,8 +82,8 @@ export default function Home() {
             <InstallScript />
           </Box>
           <Box marginBottom={{ xs: '0', md: '11' }}>
-            <NextLink href="/docs" passHref>
-              <Button as="a" size="xl" variant="purpleGradient">
+            <NextLink href="/docs">
+              <Button size="xl" variant="purpleGradient">
                 {t('cta')}
               </Button>
             </NextLink>
@@ -174,9 +174,8 @@ export default function Home() {
               marginTop={{ xs: '5', md: '11' }}
               textAlign={{ xs: 'left', md: 'center' }}
             >
-              <NextLink href="/docs" passHref>
+              <NextLink href="/docs">
                 <Button
-                  as="a"
                   size="xl"
                   style={{ alignSelf: 'flex-start' }}
                   variant="purpleGradient"

--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -16,7 +16,6 @@ import { vars } from 'css/vars.css';
 import { useCoolMode } from 'lib/useCoolMode';
 import { useTranslations } from 'next-intl';
 import NextImage from 'next/legacy/image';
-import NextLink from 'next/link';
 import React, { type Ref, useState } from 'react';
 import { useAccount } from 'wagmi';
 
@@ -82,11 +81,11 @@ export default function Home() {
             <InstallScript />
           </Box>
           <Box marginBottom={{ xs: '0', md: '11' }}>
-            <NextLink href="/docs">
+            <Link href="/docs">
               <Button size="xl" variant="purpleGradient">
                 {t('cta')}
               </Button>
-            </NextLink>
+            </Link>
           </Box>
         </Box>
       </Wrapper>
@@ -174,7 +173,7 @@ export default function Home() {
               marginTop={{ xs: '5', md: '11' }}
               textAlign={{ xs: 'left', md: 'center' }}
             >
-              <NextLink href="/docs">
+              <Link href="/docs">
                 <Button
                   size="xl"
                   style={{ alignSelf: 'flex-start' }}
@@ -182,7 +181,7 @@ export default function Home() {
                 >
                   {t('cta')}
                 </Button>
-              </NextLink>
+              </Link>
             </Box>
           </Box>
         </Wrapper>

--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -82,7 +82,7 @@ export default function Home() {
             <InstallScript />
           </Box>
           <Box marginBottom={{ xs: '0', md: '11' }}>
-            <NextLink href="/docs" legacyBehavior passHref>
+            <NextLink href="/docs" passHref>
               <Button as="a" size="xl" variant="purpleGradient">
                 {t('cta')}
               </Button>
@@ -174,7 +174,7 @@ export default function Home() {
               marginTop={{ xs: '5', md: '11' }}
               textAlign={{ xs: 'left', md: 'center' }}
             >
-              <NextLink href="/docs" legacyBehavior passHref>
+              <NextLink href="/docs" passHref>
                 <Button
                   as="a"
                   size="xl"


### PR DESCRIPTION
## Summary
- remove `legacyBehavior` from Next.js Link components in the site project
- add a changeset for the site package

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6849bd498a1c83259720e79e792cfa73

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the deprecated `legacyBehavior` from Next.js `Link` components and updating the custom `Link` component to utilize Next.js' new API while maintaining existing styles.

### Detailed summary
- Removed `legacyBehavior` from `NextLink` in `Header`, `Sidebar`, `Home`, and `DocsLayout` components.
- Updated `Header` and `Sidebar` to use the custom `Link` component.
- Modified `Link` component to accept props from `NextLink` and ensure proper styling.
- Ensured existing functionality and styles are preserved with the new API.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->