### PR TITLE
fix: inherited qr code colors in dark mode

### DIFF
--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.css.ts
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.css.ts
@@ -1,8 +1,10 @@
 import { style } from '@vanilla-extract/css';
 import { sprinkles } from '../../css/sprinkles.css';
+
 export const QRCodeBackgroundClassName = style([
   {
     background: 'white',
+    color: 'black',
   },
 ]);
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new CSS style to the `QRCodeBackgroundClassName` in the `DesktopOptions.css.ts` file, specifically defining the text color for the QR code background.

### Detailed summary
- Added `color: 'black'` to the `QRCodeBackgroundClassName` style definition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->