### PR TITLE
feat: filter docsearch by locale

### DIFF
--- a/.changeset/dcc4c036-docsearch-language.md
+++ b/.changeset/dcc4c036-docsearch-language.md
@@ -1,0 +1,5 @@
+---
+"site": patch
+---
+
+Add language facet filter to DocSearch.

--- a/site/components/Search/Search.tsx
+++ b/site/components/Search/Search.tsx
@@ -72,6 +72,7 @@ export function SearchProvider({ children }: { children: React.ReactNode }) {
             }}
             onClose={onClose}
             placeholder="Search documentation"
+            searchParameters={{ facetFilters: [`language:${router.locale}`] }}
             transformItems={(items) => {
               return items.map((item, index) => {
                 const a = document.createElement('a');

--- a/site/components/Search/Search.tsx
+++ b/site/components/Search/Search.tsx
@@ -72,7 +72,7 @@ export function SearchProvider({ children }: { children: React.ReactNode }) {
             }}
             onClose={onClose}
             placeholder="Search documentation"
-            searchParameters={{ facetFilters: [`language:${router.locale}`] }}
+            searchParameters={{ facetFilters: [`lang:${router.locale}`] }}
             transformItems={(items) => {
               return items.map((item, index) => {
                 const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- filter DocSearch results by language using facetFilters
- add changeset for site

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684a35649354832593e14f26a913889c

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a language facet filter to the `DocSearch` component, enhancing search functionality by allowing users to filter results based on their selected language.

### Detailed summary
- Updated `.changeset/dcc4c036-docsearch-language.md` to document the addition of the language facet filter.
- Modified `site/components/Search/Search.tsx` to include `facetFilters` in `searchParameters`, specifically using the current `router.locale`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->