### PR TITLE
fix: add missing rdns metadata

### DIFF
--- a/.changeset/flat-suns-pump.md
+++ b/.changeset/flat-suns-pump.md
@@ -1,0 +1,4 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+Add rdns metadata from the wallet registry to BeraSig, Bifrost, Bitski, and Wigwam connectors.

--- a/.changeset/flat-suns-pump.md
+++ b/.changeset/flat-suns-pump.md
@@ -1,4 +1,4 @@
 ---
 "@rainbow-me/rainbowkit": patch
 ---
-Add rdns metadata from the wallet registry to BeraSig, Bifrost, Bitski, and Wigwam connectors.
+Added missing `rdns` metadata for wallet connectors that now support EIP-6963.

--- a/packages/rainbowkit/src/wallets/walletConnectors/berasigWallet/berasigWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/berasigWallet/berasigWallet.ts
@@ -19,6 +19,7 @@ export const berasigWallet = ({
   return {
     id: 'berasig',
     name: 'BeraSig',
+    rdns: 'app.berasig',
     iconUrl: async () => (await import('./berasigWallet.svg')).default,
     iconBackground: '#ffffff',
     installed: isBerasigWalletInjected,

--- a/packages/rainbowkit/src/wallets/walletConnectors/bifrostWallet/bifrostWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bifrostWallet/bifrostWallet.ts
@@ -26,6 +26,7 @@ export const bifrostWallet = ({
   return {
     id: 'bifrostWallet',
     name: 'Bifrost Wallet',
+    rdns: 'com.bifrostwallet',
     iconUrl: async () => (await import('./bifrostWallet.svg')).default,
     iconBackground: '#fff',
     installed: !shouldUseWalletConnect ? isBifrostInjected : undefined,

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
@@ -7,7 +7,6 @@ import {
 export const bitskiWallet = (): Wallet => ({
   id: 'bitski',
   name: 'Bitski',
-  rdns: 'com.brave.wallet',
   installed: hasInjectedProvider({ flag: 'isBitski' }),
   iconUrl: async () => (await import('./bitskiWallet.svg')).default,
   iconBackground: '#fff',

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
@@ -7,6 +7,7 @@ import {
 export const bitskiWallet = (): Wallet => ({
   id: 'bitski',
   name: 'Bitski',
+  rdns: 'com.brave.wallet',
   installed: hasInjectedProvider({ flag: 'isBitski' }),
   iconUrl: async () => (await import('./bitskiWallet.svg')).default,
   iconBackground: '#fff',

--- a/packages/rainbowkit/src/wallets/walletConnectors/wigwamWallet/wigwamWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/wigwamWallet/wigwamWallet.ts
@@ -8,6 +8,7 @@ export const wigwamWallet = (): Wallet => {
   return {
     id: 'wigwam',
     name: 'Wigwam',
+    rdns: 'com.wigwam.wallet',
     iconBackground: '#80EF6E',
     iconUrl: async () => (await import('./wigwamWallet.svg')).default,
     downloadUrls: {


### PR DESCRIPTION
## Summary
- add `rdns` fields for BeraSig, Bifrost, Bitski and Wigwam wallets
- create changeset

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684b1220e69883259ef049ae7acb09e2

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds missing `rdns` metadata for several wallet connectors in the `rainbowkit` package, ensuring they comply with EIP-6963 standards.

### Detailed summary
- Added `rdns` entry for `wigwam` wallet: `com.wigwam.wallet`
- Added `rdns` entry for `berasig` wallet: `app.berasig`
- Added `rdns` entry for `bifrostWallet`: `com.bifrostwallet`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->