### PR TITLE
fix: isolate walletconnect storages

### DIFF
--- a/.changeset/custom-storage-prefix.md
+++ b/.changeset/custom-storage-prefix.md
@@ -1,0 +1,4 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+Add separate customStoragePrefix for WalletConnect modal and wallet connectors.

--- a/.changeset/custom-storage-prefix.md
+++ b/.changeset/custom-storage-prefix.md
@@ -1,4 +1,5 @@
 ---
 "@rainbow-me/rainbowkit": patch
 ---
-Add separate customStoragePrefix for WalletConnect modal and wallet connectors.
+
+Mitigated `WalletConnect Core is already initialized` warnings that began appearing with recent distributions of Wagmi and WalletConnect.

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -23,6 +23,7 @@ interface GetOrCreateWalletConnectInstanceParams {
   projectId: string;
   walletConnectParameters?: RainbowKitWalletConnectParameters;
   rkDetailsShowQrModal?: RainbowKitDetails['showQrModal'];
+  rkDetailsIsWalletConnectModalConnector?: RainbowKitDetails['isWalletConnectModalConnector'];
 }
 
 const walletConnectInstances = new Map<
@@ -35,6 +36,7 @@ const getOrCreateWalletConnectInstance = ({
   projectId,
   walletConnectParameters,
   rkDetailsShowQrModal,
+  rkDetailsIsWalletConnectModalConnector,
 }: GetOrCreateWalletConnectInstanceParams): ReturnType<
   typeof walletConnect
 > => {
@@ -47,6 +49,16 @@ const getOrCreateWalletConnectInstance = ({
   // `rkDetailsShowQrModal` should always be `true`
   if (rkDetailsShowQrModal) {
     config = { ...config, showQrModal: true };
+  }
+
+  // Assign unique storage prefix depending on connector type
+  if (!('customStoragePrefix' in config)) {
+    config = {
+      ...config,
+      customStoragePrefix: rkDetailsIsWalletConnectModalConnector
+        ? 'clientOne'
+        : 'clientTwo',
+    };
   }
 
   const serializedConfig = JSON.stringify(config);
@@ -79,6 +91,8 @@ function createWalletConnectConnector({
       // Used in `connectorsForWallets` to add another
       // walletConnect wallet into rainbowkit with modal popup option
       rkDetailsShowQrModal: walletDetails.rkDetails.showQrModal,
+      rkDetailsIsWalletConnectModalConnector:
+        walletDetails.rkDetails.isWalletConnectModalConnector,
     })(config),
     ...walletDetails,
   }));


### PR DESCRIPTION
## Summary
- isolate walletconnect modal and wallet storages
- document change in changeset

## Testing
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684ba4df1f8c8325b9ef059afbacd168

<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses the issue of `WalletConnect Core is already initialized` warnings by introducing a unique storage prefix based on the connector type in the `getOrCreateWalletConnectInstance` function.

### Detailed summary
- Added `rkDetailsIsWalletConnectModalConnector` to parameters in `getOrCreateWalletConnectInstance`.
- Implemented logic to assign a `customStoragePrefix` based on the connector type.
- Updated the `createWalletConnectConnector` function to include the new parameter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->