### PR TITLE
docs: fix custom-avatars zh repeat copy

### DIFF
--- a/site/data/zh-CN/docs/custom-avatars.mdx
+++ b/site/data/zh-CN/docs/custom-avatars.mdx
@@ -7,7 +7,7 @@ description: 定制您的应用程序的用户头像
 
 ## 定制您的应用程序的用户头像
 
-默认情况下，我们为用户提供一个头像，以防他们的ENS图像未设置，但您可以通过提供自己的头像组件来自定义这个头像。 如果使用TypeScript，你可以导入`AvatarComponent`类型： 如果使用TypeScript，你可以导入`AvatarComponent`类型：
+默认情况下，我们为用户提供一个头像，以防他们的ENS图像未设置，但您可以通过提供自己的头像组件来自定义这个头像。 如果使用TypeScript，你可以导入`AvatarComponent`类型：
 
 ```tsx
 import {

--- a/site/data/zh-HK/docs/custom-avatars.mdx
+++ b/site/data/zh-HK/docs/custom-avatars.mdx
@@ -7,7 +7,7 @@ description: 自定義應用程式的用戶頭像
 
 ## 自定義應用程式的用戶頭像
 
-默認情況下，我們會為用戶提供頭像，以防他們的 ENS 圖像未設置，但您可以通過提供自己的頭像元件來自定義這一點。 如果使用 TypeScript，您可以匯入 `AvatarComponent` 類型： 如果使用 TypeScript，您可以匯入 `AvatarComponent` 類型：
+默認情況下，我們會為用戶提供頭像，以防他們的 ENS 圖像未設置，但您可以通過提供自己的頭像元件來自定義這一點。 如果使用 TypeScript，您可以匯入 `AvatarComponent` 類型：
 
 ```tsx
 import {

--- a/site/data/zh-TW/docs/custom-avatars.mdx
+++ b/site/data/zh-TW/docs/custom-avatars.mdx
@@ -7,7 +7,7 @@ description: 自定義應用程式的用戶頭像
 
 ## 自定義應用程式的用戶頭像
 
-預設情況下，我們會提供給用戶一個頭像，以防止他們的ENS圖像未設置，但你可以通過提供自己的頭像組件來自定義這一點。 如果使用TypeScript，你可以匯入`AvatarComponent`類型： 如果使用TypeScript，你可以匯入`AvatarComponent`類型：
+預設情況下，我們會提供給用戶一個頭像，以防止他們的ENS圖像未設置，但你可以通過提供自己的頭像組件來自定義這一點。 如果使用TypeScript，你可以匯入`AvatarComponent`類型：
 
 ```tsx
 import {


### PR DESCRIPTION
- fix the conflict in custom avatar documents

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for custom user avatars in three language versions: Chinese (Simplified), Chinese (Traditional), and Chinese (Hong Kong). The changes ensure consistency in the text across these versions.

### Detailed summary
- In `zh-CN/docs/custom-avatars.mdx`, updated text for clarity.
- In `zh-TW/docs/custom-avatars.mdx`, updated text for consistency.
- In `zh-HK/docs/custom-avatars.mdx`, updated text for uniformity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->