### PR TITLE
Fix broken link to rainbowWallet connector example in Russian RainbowKit v2 guide

### DIFF
--- a/site/data/ru/guides/rainbowkit-wagmi-v2.mdx
+++ b/site/data/ru/guides/rainbowkit-wagmi-v2.mdx
@@ -195,7 +195,7 @@ const config = getDefaultConfig({
 
 **5. Пользовательские кошельки**
 
-Коннекторы кошельков RainbowKit претерпели значительные изменения для поддержки Wagmi v2. Ссылка на [обновленную документацию](https://www.rainbowkit.com/docs/custom-wallets) и [пример коннектора](packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts) для обновления любых Пользовательских Коннекторов Кошельков в вашем dApp.
+Коннекторы кошельков RainbowKit претерпели значительные изменения для поддержки Wagmi v2. Ссылка на [обновленную документацию](https://www.rainbowkit.com/docs/custom-wallets) и [пример коннектора](../../../../../../packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts) для обновления любых Пользовательских Коннекторов Кошельков в вашем dApp.
 
 Коннекторы кошельков теперь также поддерживают стандарт EIP-6963 с помощью свойства `rdns`. Убедитесь, что это свойство заполнено, чтобы избежать дублирования ссылок на кошельки, поддерживающие EIP-6963, в списке ваших кошельков.
 


### PR DESCRIPTION
Updated the outdated relative path to the rainbowWallet.ts connector example in the Russian RainbowKit v2 migration guide. The link now correctly points to the actual file location within the repository. This resolves a "Cannot find file" error for users following the documentation.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for `RainbowKit` connectors to reflect changes for supporting `Wagmi v2` and corrects the link path for the example connector.

### Detailed summary
- Updated the link path for the example connector in the `rainbowkit-wagmi-v2.mdx` file from a relative path to a more accurate one.
- Added information about support for the `EIP-6963` standard with the `rdns` property.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->