### PR TITLE
feat: extend MetaMask detection flags

### DIFF
--- a/.changeset/update-metamask-flags.md
+++ b/.changeset/update-metamask-flags.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Add additional wallet flags to `isMetaMask()` to detect impersonating providers.

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.test.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { metaMaskWallet } from './metaMaskWallet';
+
+const projectId = 'test-id';
+
+describe('isMetaMask', () => {
+  it('returns undefined for impersonating wallet flags', () => {
+    window.ethereum = { isMetaMask: true, isSafePal: true } as any;
+    const wallet = metaMaskWallet({ projectId });
+    expect(wallet.installed).toBeUndefined();
+  });
+});

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -26,6 +26,7 @@ function isMetaMask(ethereum?: WindowProvider['ethereum']): boolean {
   if (ethereum.isBifrost) return false;
   if (ethereum.isBitKeep) return false;
   if (ethereum.isBitski) return false;
+  if (ethereum.isBinance) return false;
   if (ethereum.isBlockWallet) return false;
   if (ethereum.isCoinbaseWallet) return false;
   if (ethereum.isDawn) return false;
@@ -44,7 +45,9 @@ function isMetaMask(ethereum?: WindowProvider['ethereum']): boolean {
     return false;
   if (ethereum.isOpera) return false;
   if (ethereum.isPhantom) return false;
+  if (ethereum.isZilPay) return false;
   if (ethereum.isPortal) return false;
+  if (ethereum.isxPortal) return false;
   if (ethereum.isRabby) return false;
   if (ethereum.isRainbow) return false;
   if (ethereum.isStatus) return false;
@@ -55,6 +58,11 @@ function isMetaMask(ethereum?: WindowProvider['ethereum']): boolean {
   if (ethereum.isTrust || ethereum.isTrustWallet) return false;
   if (ethereum.isXDEFI) return false;
   if (ethereum.isZeal) return false;
+  if (ethereum.isCoin98) return false;
+  if (ethereum.isMEWwallet) return false;
+  if (ethereum.isSafeheron) return false;
+  if (ethereum.isSafePal) return false;
+  if (ethereum.isWigwam) return false;
   if (ethereum.isZerion) return false;
   if (ethereum.__seif) return false;
   return true;


### PR DESCRIPTION
## Summary
- check additional impersonation flags in `isMetaMask`
- add regression test for MetaMask impersonation
- add changeset for `@rainbow-me/rainbowkit`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68700a9158bc8325a6c387cd990cfffb

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `isMetaMask()` function to better identify impersonating wallet providers by adding additional flags. It also includes a test to ensure that impersonating wallets return `undefined`.

### Detailed summary
- Updated `isMetaMask()` function to include checks for new wallet flags: `isBinance`, `isZilPay`, `isxPortal`, `isCoin98`, `isMEWwallet`, `isSafeheron`, `isSafePal`, and `isWigwam`.
- Added a test case in `metaMaskWallet.test.ts` to validate that impersonating wallet flags return `undefined`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->