### PR TITLE
feat: optimize regex performance in abbreviateETHBalance

### DIFF
--- a/packages/rainbowkit/src/components/ConnectButton/abbreviateETHBalance.ts
+++ b/packages/rainbowkit/src/components/ConnectButton/abbreviateETHBalance.ts
@@ -3,10 +3,20 @@
  */
 const units = ['k', 'm', 'b', 't'];
 
+// Cache for storing compiled regular expressions
+const precisionRegexCache = new Map<number, RegExp>();
+
 export function toPrecision(number: number, precision = 1) {
+  // Get or create regex for the current precision value
+  let regex = precisionRegexCache.get(precision);
+  if (!regex) {
+    regex = new RegExp(`(.+\\.\\d{${precision}})\\d+`);
+    precisionRegexCache.set(precision, regex);
+  }
+  
   return number
     .toString()
-    .replace(new RegExp(`(.+\\.\\d{${precision}})\\d+`), '$1')
+    .replace(regex, '$1')
     .replace(/(\.[1-9]*)0+$/, '$1')
     .replace(/\.$/, '');
 }


### PR DESCRIPTION
Add regex caching in toPrecision function to avoid recreating regular expressions on each call. This optimization improves performance when formatting ETH balances, especially when the function is called multiple times with the same precision values.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces caching for regular expressions in the `toPrecision` function, optimizing performance by avoiding the creation of new regex objects for the same precision value.

### Detailed summary
- Added a cache (`precisionRegexCache`) to store compiled regular expressions based on precision.
- Modified the `toPrecision` function to retrieve or create regex from the cache, enhancing efficiency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->