### PR TITLE
Opportunity to reuse and extend AvatarComponent used for RainbowKitProvider.

### DIFF
--- a/packages/rainbowkit/src/components/RainbowKitProvider/AvatarContext.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/AvatarContext.ts
@@ -7,7 +7,9 @@ export type AvatarComponentProps = {
   ensImage?: string | null;
   size: number;
 };
-export type AvatarComponent = React.FunctionComponent<AvatarComponentProps>;
+export type AvatarComponent<
+  P extends AvatarComponentProps = AvatarComponentProps,
+> = React.FunctionComponent<P>;
 
 export const defaultAvatar = EmojiAvatar;
 

--- a/packages/rainbowkit/src/index.ts
+++ b/packages/rainbowkit/src/index.ts
@@ -28,7 +28,10 @@ export type {
 } from './components/RainbowKitProvider/AuthenticationContext';
 export type { Locale } from './locales/';
 export type { DisclaimerComponent } from './components/RainbowKitProvider/AppContext';
-export type { AvatarComponent } from './components/RainbowKitProvider/AvatarContext';
+export type {
+  AvatarComponent,
+  AvatarComponentProps,
+} from './components/RainbowKitProvider/AvatarContext';
 export type { RainbowKitChain as Chain } from './components/RainbowKitProvider/RainbowKitChainContext';
 export { lightTheme } from './themes/lightTheme';
 export { darkTheme } from './themes/darkTheme';


### PR DESCRIPTION
Now AvatarComponentProps is not exported from packages/rainbowkit/src/index.ts. I want to do something like:

```typescript
interface CustomAvatarProps extends AvatarComponentProps {
    onLoad?: () => void;
}

const MyCustomAvatar: AvatarComponent<CustomAvatarProps> = ({address, ensImage, size, onLoad}) => {
    ....
}
``` 
<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `AvatarComponent` type definition in `AvatarContext.ts` to allow for generic props, improving flexibility. It also updates the exports in `index.ts` to include `AvatarComponentProps`.

### Detailed summary
- Updated `AvatarComponent` type to accept generic props in `AvatarContext.ts`.
- Changed export statements in `index.ts` to include `AvatarComponentProps` along with `AvatarComponent`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->