### PR TITLE
feat: allow promises for createMessage in createAuthenticationAdapter

### DIFF
--- a/packages/rainbowkit/src/components/RainbowKitProvider/AuthenticationContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/AuthenticationContext.tsx
@@ -20,7 +20,13 @@ export interface AuthenticationAdapter<Message> {
     nonce: string;
     address: Address;
     chainId: number;
-  }) => Message;
+  }) =>
+    | Message
+    | ((args: {
+        nonce: string;
+        address: Address;
+        chainId: number;
+      }) => Promise<Message>);
   verify: (args: { message: Message; signature: string }) => Promise<boolean>;
   signOut: () => Promise<void>;
 }

--- a/packages/rainbowkit/src/components/SignIn/SignIn.tsx
+++ b/packages/rainbowkit/src/components/SignIn/SignIn.tsx
@@ -72,7 +72,11 @@ export function SignIn({
         status: 'signing',
       }));
 
-      const message = authAdapter.createMessage({ address, chainId, nonce });
+      const message = await authAdapter.createMessage({
+        address,
+        chainId,
+        nonce,
+      });
       let signature: string;
 
       try {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `createMessage` function in the `SignIn` component to handle asynchronous operations and modifying the type definitions in the `AuthenticationContext` to reflect these changes.

### Detailed summary
- In `SignIn.tsx`, `createMessage` is changed to an `await` call with a new object format for parameters.
- In `AuthenticationContext.tsx`, the return type of a function is changed to a Promise, and the parameter structure is updated to include `nonce`, `address`, and `chainId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->