### PR TITLE
feat: index.ts: export EmojiAvatar and emojiAvatarForAddress (#2491)

### DIFF
--- a/.changeset/slimy-geckos-give.md
+++ b/.changeset/slimy-geckos-give.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": minor
+---
+
+Export EmojiAvatar and emojiAvatarForAddress

--- a/packages/rainbowkit/src/index.ts
+++ b/packages/rainbowkit/src/index.ts
@@ -35,4 +35,6 @@ export { darkTheme } from './themes/darkTheme';
 export { midnightTheme } from './themes/midnightTheme';
 export { cssStringFromTheme } from './css/cssStringFromTheme';
 export { cssObjectFromTheme } from './css/cssObjectFromTheme';
+export { EmojiAvatar } from './components/Avatar/EmojiAvatar';
+export { emojiAvatarForAddress } from './components/Avatar/emojiAvatarForAddress';
 export { __private__ } from './__private__';


### PR DESCRIPTION
Aspirational PR assuming this feature seems reasonable: https://github.com/rainbow-me/rainbowkit/discussions/2491

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on exporting two new components, `EmojiAvatar` and `emojiAvatarForAddress`, from the `rainbowkit` package, enhancing its functionality.

### Detailed summary
- Updated the version of `@rainbow-me/rainbowkit` to minor.
- Exported `EmojiAvatar` from `./components/Avatar/EmojiAvatar`.
- Exported `emojiAvatarForAddress` from `./components/Avatar/emojiAvatarForAddress`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->