### PR TITLE
chore: update GitHub actions in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         node: [lts/*]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub Actions workflows by upgrading the `actions/checkout` version from `v4` to `v5` in both `.github/workflows/ci.yml` and `.github/workflows/release.yml`. It also ensures that the `WALLETCONNECT_PROJECT_ID` environment variable is defined correctly.

### Detailed summary
- Updated `actions/checkout` from `v4` to `v5` in `.github/workflows/ci.yml`.
- Updated `actions/checkout` from `v4` to `v5` in `.github/workflows/release.yml`.
- Ensured `WALLETCONNECT_PROJECT_ID` is correctly defined in the environment variables.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->