### PR TITLE
chore: upgrade cuer to 0.0.3

### DIFF
--- a/.changeset/upgrade-cuer-003.md
+++ b/.changeset/upgrade-cuer-003.md
@@ -1,4 +1,5 @@
 ---
 "@rainbow-me/rainbowkit": patch
 ---
-chore: upgrade cuer to 0.0.3
+
+Fixed unintended forwarding of the `errorCorrection` prop to SVG elements used by the QRCode component to prevent React warning.

--- a/.changeset/upgrade-cuer-003.md
+++ b/.changeset/upgrade-cuer-003.md
@@ -1,0 +1,4 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+chore: upgrade cuer to 0.0.3

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -69,7 +69,7 @@
     "@vanilla-extract/dynamic": "2.1.4",
     "@vanilla-extract/sprinkles": "1.6.4",
     "clsx": "2.1.1",
-    "cuer": "0.0.2",
+    "cuer": "0.0.3",
     "react-remove-scroll": "2.6.2",
     "ua-parser-js": "^1.0.37"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,8 +439,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       cuer:
-        specifier: 0.0.2
-        version: 0.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.5.4)
+        specifier: 0.0.3
+        version: 0.0.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.5.4)
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
@@ -5990,8 +5990,8 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
-  cuer@0.0.2:
-    resolution: {integrity: sha512-MG1BYnnSLqBnO0dOBS1Qm/TEc9DnFa9Sz2jMA24OF4hGzs8UuPjpKBMkRPF3lrpC+7b3EzULwooX9djcvsM8IA==}
+  cuer@0.0.3:
+    resolution: {integrity: sha512-f/UNxRMRCYtfLEGECAViByA3JNflZImOk11G9hwSd+44jvzrc99J35u5l+fbdQ2+ZG441GvOpaeGYBmWquZsbQ==}
     peerDependencies:
       react: ^19.1.0
       react-dom: ^19.1.0
@@ -19334,7 +19334,7 @@ snapshots:
 
   csstype@3.1.3: {}
 
-  cuer@0.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.5.4):
+  cuer@0.0.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.5.4):
     dependencies:
       qr: 0.4.2
       react: 19.1.0


### PR DESCRIPTION
## Summary
- upgrade cuer to 0.0.3
- add changeset for cuer upgrade

## Testing
- `pnpm format:fix`
- `pnpm lint` *(fails: packages/rainbowkit typecheck: Failed, site typecheck: Failed, packages/rainbowkit-siwe-next-auth typecheck: Failed, packages/rainbow-button typecheck: Failed)*
- `pnpm test:unit run`


------
https://chatgpt.com/codex/tasks/task_e_68addc50fdd08325b19784b1bdf11116

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on upgrading the `cuer` package from version `0.0.2` to `0.0.3`, along with a fix for the `errorCorrection` prop in the QRCode component to prevent React warnings.

### Detailed summary
- Updated `cuer` from `0.0.2` to `0.0.3` in `package.json` and `pnpm-lock.yaml`.
- Added a changeset documenting the fix for unintended forwarding of the `errorCorrection` prop in the QRCode component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->