### PR TITLE
Update link to root.tsx

### DIFF
--- a/examples/with-remix/app/root.tsx
+++ b/examples/with-remix/app/root.tsx
@@ -53,7 +53,7 @@ export const links: LinksFunction = () => [
 ];
 
 // Note: These environment variables are hard coded for demonstration purposes.
-// See: https://remix.run/docs/en/v1/guides/envvars#browser-environment-variables
+// See: https://remix.run/docs/en/guides/envvars#browser-environment-variables
 export const loader: LoaderFunction = () => {
   const data: LoaderData = {
     ENV: {
@@ -72,7 +72,7 @@ export default function App() {
   // Remix modules cannot have side effects so the initialization of `wagmi`
   // client happens during render, but the result is cached via `useState`
   // and a lazy initialization function.
-  // See: https://remix.run/docs/en/v1/guides/constraints#no-module-side-effects
+  // See: https://remix.run/docs/en/guides/constraints#no-module-side-effects
   const [{ config, chains }] = useState(() => {
     const testChains = ENV.PUBLIC_ENABLE_TESTNETS === 'true' ? [sepolia] : [];
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates documentation links in the `examples/with-remix/app/root.tsx` file to reflect the correct versioning of the Remix documentation.

### Detailed summary
- Updated the link for browser environment variables from `https://remix.run/docs/en/v1/guides/envvars#browser-environment-variables` to `https://remix.run/docs/en/guides/envvars#browser-environment-variables`.
- Updated the link for no module side effects from `https://remix.run/docs/en/v1/guides/constraints#no-module-side-effects` to `https://remix.run/docs/en/guides/constraints#no-module-side-effects`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->