### PR TITLE
feat: Binance wallet chrome extension download url

### DIFF
--- a/.changeset/metal-taxes-bet.md
+++ b/.changeset/metal-taxes-bet.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': patch
+---
+
+Add binance wallet chrome extension download url

--- a/packages/rainbowkit/src/locales/en_US.json
+++ b/packages/rainbowkit/src/locales/en_US.json
@@ -423,6 +423,20 @@
           "description": "After you scan, a connection prompt will appear for you to connect your wallet.",
           "title": "Tap the WalletConnect button"
         }
+      },
+      "extension": {
+        "step1": {
+          "title": "Install the Binance Wallet extension",
+          "description": "We recommend pinning Binance Wallet to your taskbar for quicker access to your wallet."
+        },
+        "step2": {
+          "title": "Create or Import a Wallet",
+          "description": "Be sure to back up your wallet using a secure method. Never share your secret phrase with anyone."
+        },
+        "step3": {
+          "title": "Refresh your browser",
+          "description": "Once you set up your wallet, click below to refresh the browser and load up the extension."
+        }
       }
     },
 

--- a/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
@@ -1,6 +1,9 @@
 import { isAndroid } from '../../../utils/isMobile';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
-import { getInjectedConnector } from '../../getInjectedConnector';
+import {
+  getInjectedConnector,
+  hasInjectedProvider,
+} from '../../getInjectedConnector';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export type BinanceWalletOptions = DefaultWalletOptions;
@@ -9,7 +12,11 @@ export const binanceWallet = ({
   projectId,
   walletConnectParameters,
 }: BinanceWalletOptions): Wallet => {
-  const isBinanceInjected = (window as any)?.binancew3w?.isExtension === true;
+  const isBinanceInjected =
+    (window as any)?.binancew3w?.isExtension === true ||
+    hasInjectedProvider({
+      flag: 'isBinance',
+    });
   const shouldUseWalletConnect = !isBinanceInjected;
 
   return {

--- a/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
@@ -12,11 +12,10 @@ export const binanceWallet = ({
   projectId,
   walletConnectParameters,
 }: BinanceWalletOptions): Wallet => {
-  const isBinanceInjected =
-    (window as any)?.binancew3w?.isExtension === true ||
-    hasInjectedProvider({
-      flag: 'isBinance',
-    });
+  const isBinanceInjected = hasInjectedProvider({
+    namespace: 'binancew3w.isExtension',
+    flag: 'isBinance',
+  });
   const shouldUseWalletConnect = !isBinanceInjected;
 
   return {

--- a/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
@@ -1,9 +1,6 @@
 import { isAndroid } from '../../../utils/isMobile';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
-import {
-  getInjectedConnector,
-  hasInjectedProvider,
-} from '../../getInjectedConnector';
+import { getInjectedConnector } from '../../getInjectedConnector';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export type BinanceWalletOptions = DefaultWalletOptions;
@@ -12,9 +9,7 @@ export const binanceWallet = ({
   projectId,
   walletConnectParameters,
 }: BinanceWalletOptions): Wallet => {
-  const isBinanceInjected = hasInjectedProvider({
-    flag: 'isBinance',
-  });
+  const isBinanceInjected = (window as any)?.binancew3w?.isExtension === true;
   const shouldUseWalletConnect = !isBinanceInjected;
 
   return {
@@ -29,6 +24,8 @@ export const binanceWallet = ({
       ios: 'https://apps.apple.com/us/app/id1436799971',
       mobile: 'https://www.binance.com/en/download',
       qrCode: 'https://www.binance.com/en/web3wallet',
+      chrome:
+        'https://chromewebstore.google.com/detail/cadiboklkpojfamcoggejbbdjcoiljjk',
     },
     mobile: shouldUseWalletConnect
       ? {


### PR DESCRIPTION
Add Binance wallet chrome extension download url

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for the Binance Wallet by including a Chrome extension download URL and detailed installation steps in the `rainbowkit` package.

### Detailed summary
- Added Chrome extension download URL for Binance Wallet in `binanceWallet.ts`.
- Introduced installation steps for the Binance Wallet in `en_US.json`, including:
  - Step 1: Install the Binance Wallet extension.
  - Step 2: Create or Import a Wallet.
  - Step 3: Refresh your browser.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->