### PR TITLE
fix: /providers 1193 extension providers[] visibility

### DIFF
--- a/packages/example/src/pages/providers.tsx
+++ b/packages/example/src/pages/providers.tsx
@@ -135,37 +135,34 @@ export default function EthereumProviders() {
         ) : (
           <p>No window.ethereum detected</p>
         )}
-        {providerFlags.length > 0 && (
-          <>
-            <h2>eip-1193 providers[]</h2>
-            <table style={tableStyle}>
-              <thead>
-                <tr>
-                  <th style={cellStyle}>#</th>
-                  <th style={cellStyle}>flag</th>
-                  <th style={cellStyle}>value</th>
-                </tr>
-              </thead>
-              <tbody>
-                {providerFlags.map((flags, idx) =>
-                  Object.entries(flags).map(([key, value], i) => (
-                    <tr key={`${idx}-${key}`}>
-                      {i === 0 && (
-                        <td
-                          style={cellStyle}
-                          rowSpan={Object.keys(flags).length}
-                        >
-                          {idx}
-                        </td>
-                      )}
-                      <td style={cellStyle}>{key}</td>
-                      <td style={cellStyle}>{String(value)}</td>
-                    </tr>
-                  )),
-                )}
-              </tbody>
-            </table>
-          </>
+        <h2>eip-1193 providers[]</h2>
+        {providerFlags.length > 0 ? (
+          <table style={tableStyle}>
+            <thead>
+              <tr>
+                <th style={cellStyle}>#</th>
+                <th style={cellStyle}>flag</th>
+                <th style={cellStyle}>value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {providerFlags.map((flags, idx) =>
+                Object.entries(flags).map(([key, value], i) => (
+                  <tr key={`${idx}-${key}`}>
+                    {i === 0 && (
+                      <td style={cellStyle} rowSpan={Object.keys(flags).length}>
+                        {idx}
+                      </td>
+                    )}
+                    <td style={cellStyle}>{key}</td>
+                    <td style={cellStyle}>{String(value)}</td>
+                  </tr>
+                )),
+              )}
+            </tbody>
+          </table>
+        ) : (
+          <p>No providers detected</p>
         )}
       </section>
       <section>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies the rendering logic of the providers section in the `providers.tsx` file. It updates the conditional rendering to display a message when no providers are detected and refines the structure of the JSX for better readability.

### Detailed summary
- Changed conditional rendering to show `<p>No providers detected</p>` when `providerFlags.length` is 0.
- Adjusted the structure of the JSX, moving the `h2` heading above the conditional logic.
- Ensured consistent formatting and indentation for better readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->