### PR TITLE
fix: improve Nova Wallet provider detection

### DIFF
--- a/.changeset/curvy-tips-beam.md
+++ b/.changeset/curvy-tips-beam.md
@@ -1,5 +1,5 @@
 ---
-"@rainbow-me/rainbowkit": major
+"@rainbow-me/rainbowkit": patch
 ---
 
 Improved detection for nova wallet provider

--- a/.changeset/curvy-tips-beam.md
+++ b/.changeset/curvy-tips-beam.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": major
+---
+
+Improved detection for nova wallet provider

--- a/packages/rainbowkit/src/wallets/walletConnectors/novaWallet/novaWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/novaWallet/novaWallet.ts
@@ -4,17 +4,23 @@ import {
 } from '../../getInjectedConnector';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
+import type { WindowProvider } from '../../../types/utils';
 
 export type NovaWalletOptions = DefaultWalletOptions;
+
+function isNovaWallet(ethereum?: WindowProvider['ethereum']): boolean {
+  if (ethereum?.isNovaWallet) return true;
+
+  return false;
+}
 
 export const novaWallet = ({
   projectId,
   walletConnectParameters,
 }: NovaWalletOptions): Wallet => {
-  const isNovaWalletInjected = hasInjectedProvider({
-    namespace: 'ethereum',
-    flag: 'isNovaWallet',
-  });
+  const isNovaWalletInjected =
+    typeof window !== 'undefined' ? isNovaWallet(window.ethereum) : false;
+
   const shouldUseWalletConnect = !isNovaWalletInjected;
 
   const getUriMobile = (uri: string) => {
@@ -73,7 +79,6 @@ export const novaWallet = ({
         })
       : getInjectedConnector({
           namespace: 'ethereum',
-          flag: 'isNovaWallet',
         }),
   };
 };


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the detection of the `novaWallet` provider by implementing a new function to check for its presence in the `window.ethereum` object.

### Detailed summary
- Added a new function `isNovaWallet` to check if `ethereum` has the `isNovaWallet` property.
- Updated the `isNovaWalletInjected` variable to use the new `isNovaWallet` function.
- Removed the previous method of checking for the `isNovaWallet` flag.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->