### PR TITLE
Reorganize novaWallet placement in example wallet groups

### DIFF
--- a/packages/example/src/wagmi.ts
+++ b/packages/example/src/wagmi.ts
@@ -188,7 +188,6 @@ export const config = getDefaultConfig({
         baseAccount,
         metaMaskWallet,
         walletConnectWallet,
-        novaWallet,
       ],
     },
     {
@@ -226,6 +225,7 @@ export const config = getDefaultConfig({
         magicEdenWallet,
         mewWallet,
         nestWallet,
+        novaWallet,
         oktoWallet,
         okxWallet,
         omniWallet,


### PR DESCRIPTION
Remove novaWallet from the first wallet group and add it to the second group.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the `novaWallet` to the configuration in the `wagmi.ts` file, enhancing wallet support.

### Detailed summary
- Added `novaWallet` to the list of wallets in the `config` object in `wagmi.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->