### PR TITLE
feat: rainbow button connect hook

### DIFF
--- a/.changeset/improve-rainbow-button.md
+++ b/.changeset/improve-rainbow-button.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbow-button': patch
+---
+
+Expose `useRainbowConnectModal` hook for programmatic control of the connect modal. The hook returns `connect` and `connectModalOpen` properties

--- a/examples/with-next-rainbow-button/src/pages/index.tsx
+++ b/examples/with-next-rainbow-button/src/pages/index.tsx
@@ -1,10 +1,14 @@
 import type { NextPage } from 'next';
 import { useAccount, useDisconnect } from 'wagmi';
-import { RainbowButton } from '@rainbow-me/rainbow-button';
+import {
+  RainbowButton,
+  useRainbowConnectModal,
+} from '@rainbow-me/rainbow-button';
 
 const Home: NextPage = () => {
   const { isConnected } = useAccount();
   const { disconnect } = useDisconnect();
+  const { connect } = useRainbowConnectModal();
 
   return (
     <div
@@ -18,6 +22,7 @@ const Home: NextPage = () => {
       }}
     >
       <RainbowButton />
+      <button onClick={connect}>Custom Connect Button</button>
       {isConnected && <button onClick={() => disconnect()}>Disconnect</button>}
     </div>
   );

--- a/packages/rainbow-button/README.md
+++ b/packages/rainbow-button/README.md
@@ -25,7 +25,7 @@ Import Rainbow Button and wagmi.
 ```tsx
 import '@rainbow-me/rainbow-button/styles.css';
 import {
-  RainbowConnector,
+  rainbowConnector,
   RainbowButtonProvider,
 } from '@rainbow-me/rainbow-button';
 ...
@@ -34,13 +34,13 @@ import { createConfig, WagmiConfig } from 'wagmi';
 
 ### Adopt the connector
 
-The `RainbowConnector` supports connecting with Rainbow just like Wagmi's native `MetaMaskConnector` from `wagmi/connectors/metaMask`.
+The `rainbowConnector` supports connecting with Rainbow just like Wagmi's native `MetaMaskConnector` from `wagmi/connectors/metaMask`.
 
-Create an instance of the `RainbowConnector` and provide it in your wagmi config `connectors` list. Supply your `chains` list and your WalletConnect v2 `projectId`. You can obtain a `projectId` from [WalletConnect Cloud](https://cloud.reown.com/sign-in). This is absolutely free and only takes a few minutes.
+Create an instance of the `rainbowConnector` and provide it in your wagmi config `connectors` list. Supply your WalletConnect v2 `projectId` and your application name. You can obtain a `projectId` from [WalletConnect Cloud](https://cloud.reown.com/sign-in). This is absolutely free and only takes a few minutes.
 
 ```tsx
 const config = createConfig({
-  connectors: [new RainbowConnector({ chains, projectId })],
+  connectors: [rainbowConnector({ projectId, appName: 'Your App' })],
   publicClient
 });
 ```
@@ -72,6 +72,19 @@ import { RainbowButton } from '@rainbow-me/rainbow-button';
 
 export const YourApp = () => {
   return <RainbowButton/>;
+};
+```
+
+### Use the connect modal hook
+
+If you'd like to trigger the Rainbow connect modal from anywhere in your app, the `useRainbowConnectModal` hook provides a `connect` function that launches the same compact modal flow used by the `RainbowButton`.
+
+```tsx
+import { useRainbowConnectModal } from '@rainbow-me/rainbow-button';
+
+export const CustomConnect = () => {
+  const { connect } = useRainbowConnectModal();
+  return <button onClick={connect}>Connect Rainbow</button>;
 };
 ```
 

--- a/packages/rainbow-button/src/hooks/useRainbowConnectModal.test.ts
+++ b/packages/rainbow-button/src/hooks/useRainbowConnectModal.test.ts
@@ -1,0 +1,25 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useRainbowConnectModal } from './useRainbowConnectModal';
+
+const openConnectModal = vi.hoisted(() => vi.fn());
+
+vi.mock('@rainbow-me/rainbowkit', () => ({
+  useConnectModal: () => ({
+    connectModalOpen: false,
+    openConnectModal,
+  }),
+}));
+
+describe('useRainbowConnectModal', () => {
+  it('invokes connect modal when connect is called', () => {
+    const { result } = renderHook(() => useRainbowConnectModal());
+
+    act(() => {
+      result.current.connect();
+    });
+
+    expect(openConnectModal).toHaveBeenCalledTimes(1);
+    expect(result.current.connectModalOpen).toBe(false);
+  });
+});

--- a/packages/rainbow-button/src/hooks/useRainbowConnectModal.ts
+++ b/packages/rainbow-button/src/hooks/useRainbowConnectModal.ts
@@ -1,0 +1,15 @@
+import { useCallback } from 'react';
+import { useConnectModal } from '@rainbow-me/rainbowkit';
+
+export function useRainbowConnectModal() {
+  const { openConnectModal, connectModalOpen } = useConnectModal();
+
+  const connect = useCallback(() => {
+    openConnectModal?.();
+  }, [openConnectModal]);
+
+  return {
+    connect,
+    connectModalOpen,
+  } as const;
+}

--- a/packages/rainbow-button/src/index.ts
+++ b/packages/rainbow-button/src/index.ts
@@ -1,3 +1,4 @@
 export { RainbowButtonProvider } from './components/RainbowButton';
 export { rainbowConnector } from './connectors/rainbow';
 export { RainbowButton } from './components/RainbowButton';
+export { useRainbowConnectModal } from './hooks/useRainbowConnectModal';


### PR DESCRIPTION
## Summary
- revert the RainbowButton export to its original implementation so `.Custom` continues to work without relying on `Object.assign`
- expose a `useRainbowConnectModal` wrapper that forwards to RainbowKit's `useConnectModal` API and update the related unit test
- remove the rainbowkit package export changes and scope the changeset to the rainbow-button package only

## Testing
- `pnpm test`
- `pnpm lint` *(fails: `@rainbow-me/rainbowkit` typecheck reports WalletConnector typing error)*

------
https://chatgpt.com/codex/tasks/task_e_68ae99e532708325a0b3632d0f5e9bd5

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on exposing the `useRainbowConnectModal` hook, which allows for programmatic control of the connect modal in the `rainbow-button` package. It also updates the documentation and example usage to reflect this new functionality.

### Detailed summary
- Added `useRainbowConnectModal` hook in `packages/rainbow-button/src/hooks/useRainbowConnectModal.ts`.
- Updated `packages/rainbow-button/src/index.ts` to export the new hook.
- Modified example in `examples/with-next-rainbow-button/src/pages/index.tsx` to include a custom connect button using the hook.
- Added tests for `useRainbowConnectModal` in `packages/rainbow-button/src/hooks/useRainbowConnectModal.test.ts`.
- Updated README documentation to describe the new hook and its usage.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->