### PR TITLE
fix: coin98, other wallet mobile visibility

### DIFF
--- a/.changeset/fix-mobile-wallet-visibility.md
+++ b/.changeset/fix-mobile-wallet-visibility.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fix Coin98, CLV, SafePal, Frontier, and BeraSig wallets not appearing on mobile. These wallets now properly display on mobile devices with WalletConnect support when the browser extension is not installed.

--- a/.changeset/fix-mobile-wallet-visibility.md
+++ b/.changeset/fix-mobile-wallet-visibility.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Fix Coin98, CLV, SafePal, Frontier, and BeraSig wallets not appearing on mobile. These wallets now properly display on mobile devices with WalletConnect support when the browser extension is not installed.
+Fix mobile visibility for Coin98, CLV, SafePal, Frontier, and BeraSig wallets.

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
       "core-js",
       "core-js-pure",
       "keccak",
+      "msw",
       "protobufjs",
       "sharp",
       "utf-8-validate"

--- a/packages/rainbowkit/src/wallets/walletConnectors/berasigWallet/berasigWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/berasigWallet/berasigWallet.ts
@@ -22,7 +22,7 @@ export const berasigWallet = ({
     rdns: 'app.berasig',
     iconUrl: async () => (await import('./berasigWallet.svg')).default,
     iconBackground: '#ffffff',
-    installed: isBerasigWalletInjected,
+    installed: !shouldUseWalletConnect ? isBerasigWalletInjected : undefined,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=io.berasig.ios',
       ios: 'https://apps.apple.com/us/app/berasig-wallet-on-berachain/id6502052535',

--- a/packages/rainbowkit/src/wallets/walletConnectors/clvWallet/clvWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/clvWallet/clvWallet.ts
@@ -20,7 +20,7 @@ export const clvWallet = ({
     iconUrl: async () => (await import('./clvWallet.svg')).default,
     iconBackground: '#fff',
     iconAccent: '#BDFDE2',
-    installed: isCLVInjected,
+    installed: !shouldUseWalletConnect ? isCLVInjected : undefined,
     downloadUrls: {
       chrome:
         'https://chrome.google.com/webstore/detail/clv-wallet/nhnkbkgjikgcigadomkphalanndcapjk',

--- a/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
@@ -21,10 +21,10 @@ export const coin98Wallet = ({
     id: 'coin98',
     name: 'Coin98 Wallet',
     iconUrl: async () => (await import('./coin98Wallet.svg')).default,
-    installed: isCoin98WalletInjected,
+    installed: !shouldUseWalletConnect ? isCoin98WalletInjected : undefined,
     iconAccent: '#CDA349',
     iconBackground: '#fff',
-    rdns: 'coin98.com',
+    rdns: 'com.coin98',
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=coin98.crypto.finance.media',

--- a/packages/rainbowkit/src/wallets/walletConnectors/frontierWallet/frontierWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/frontierWallet/frontierWallet.ts
@@ -22,7 +22,7 @@ export const frontierWallet = ({
     id: 'frontier',
     name: 'Frontier Wallet',
     rdns: 'xyz.frontier.wallet',
-    installed: isFrontierInjected,
+    installed: !shouldUseWalletConnect ? isFrontierInjected : undefined,
     iconUrl: async () => (await import('./frontierWallet.svg')).default,
     iconBackground: '#CC703C',
     downloadUrls: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/safepalWallet/safepalWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safepalWallet/safepalWallet.ts
@@ -91,7 +91,7 @@ export const safepalWallet = ({
     // Note that we never resolve `installed` to `false` because the
     // SafePal Wallet provider falls back to other connection methods if
     // the injected connector isn't available
-    installed: isSafePalWalletInjected,
+    installed: !shouldUseWalletConnect ? isSafePalWalletInjected : undefined,
     iconAccent: '#3375BB',
     iconBackground: '#fff',
     downloadUrls: {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the visibility of several mobile wallets in the `rainbowkit` package by adjusting the `installed` property based on the `shouldUseWalletConnect` condition and updating the `rdns` for `Coin98 Wallet`.

### Detailed summary
- Added `msw` dependency in `package.json`.
- Updated visibility logic for the following wallets:
  - `CLV Wallet`: Changed `installed` to `!shouldUseWalletConnect ? isCLVInjected : undefined`.
  - `Frontier Wallet`: Changed `installed` to `!shouldUseWalletConnect ? isFrontierInjected : undefined`.
  - `SafePal Wallet`: Changed `installed` to `!shouldUseWalletConnect ? isSafePalWalletInjected : undefined`.
  - `BeraSig Wallet`: Changed `installed` to `!shouldUseWalletConnect ? isBerasigWalletInjected : undefined`.
  - `Coin98 Wallet`: Changed `installed` to `!shouldUseWalletConnect ? isCoin98WalletInjected : undefined` and updated `rdns` to `com.coin98`.
- Added a changelog entry in `.changeset/fix-mobile-wallet-visibility.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->