### PR TITLE
feat: migrate to @walletconnect/wagmi-connector

### DIFF
--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -69,6 +69,7 @@
     "@vanilla-extract/css": "1.17.3",
     "@vanilla-extract/dynamic": "2.1.4",
     "@vanilla-extract/sprinkles": "1.6.4",
+    "@walletconnect/wagmi-connector": "^1.0.2",
     "clsx": "2.1.1",
     "cuer": "0.0.3",
     "react-remove-scroll": "2.6.2",

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -1,6 +1,6 @@
 import { createConnector } from 'wagmi';
 import type { CreateConnectorFn } from 'wagmi';
-import { type WalletConnectParameters, walletConnect } from 'wagmi/connectors';
+import { walletConnect, type WalletConnectParameters } from '@walletconnect/wagmi-connector';
 import type {
   CreateConnector,
   RainbowKitDetails,


### PR DESCRIPTION
Switch from wagmi/connectors to @walletconnect/wagmi-connector package for WalletConnect functionality. This change adds the @walletconnect/wagmi-connector dependency and updates the import in getWalletConnectConnector.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `package.json` for `rainbowkit` to include a new dependency and modifies the import statement in `getWalletConnectConnector.ts` to use the new package.

### Detailed summary
- Added `@walletconnect/wagmi-connector` dependency in `packages/rainbowkit/package.json`.
- Updated import in `packages/rainbowkit/src/wallets/getWalletConnectConnector.ts` to source `walletConnect` and `WalletConnectParameters` from `@walletconnect/wagmi-connector`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->