### PR TITLE
fix: disable telemetry in Base Account connector

### DIFF
--- a/.changeset/disable-base-account-telemetry.md
+++ b/.changeset/disable-base-account-telemetry.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Disable telemetry by default in Base Account wallet connector to respect user privacy.

--- a/packages/rainbowkit/src/wallets/walletConnectors/baseAccount/baseAccount.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/baseAccount/baseAccount.ts
@@ -41,6 +41,10 @@ export const baseAccount: BaseAccount = ({ appName, appIcon }) => {
         appName,
         appLogoUrl: appIcon,
         ...optionalConfig,
+        preference: {
+          ...((optionalConfig as any)?.preference || {}),
+          telemetry: false,
+        },
       });
 
       return createConnector((config) => ({

--- a/packages/rainbowkit/src/wallets/walletConnectors/baseAccount/baseAccount.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/baseAccount/baseAccount.ts
@@ -42,8 +42,8 @@ export const baseAccount: BaseAccount = ({ appName, appIcon }) => {
         appLogoUrl: appIcon,
         ...optionalConfig,
         preference: {
-          ...((optionalConfig as any)?.preference || {}),
           telemetry: false,
+          ...((optionalConfig as any)?.preference || {}),
         },
       });
 


### PR DESCRIPTION
## Summary

This PR disables telemetry by default in the Base Account wallet connector.

## Background

Base Account SDK uses an opt-out telemetry model that collects anonymous usage data unless explicitly disabled via the `preference.telemetry` configuration option (see [Base Account telemetry docs](https://docs.base.org/base-account/more/telemetry)).

As mentioned in [this comment](https://github.com/coinbase/coinbase-wallet-sdk/issues/1808#issuecomment-3498783603), telemetry was introduced in Base Account SDK (the successor to Coinbase Wallet SDK), and the suggested solution is to reference the Base Account SDK's telemetry documentation for control options.

Currently, RainbowKit does not expose telemetry configuration to users - the `baseAccount` connector only accepts `appName` and `appIcon` parameters. This means users have no way to opt out of telemetry collection when using Base Account through RainbowKit.

## Changes

- Added `preference: { telemetry: false }` to the Base Account connector configuration
- This change respects user privacy by disabling telemetry collection by default

## Related Issues

Partially addresses #2560

## Testing

The change preserves all existing functionality while adding the telemetry opt-out preference to the connector configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing user privacy by disabling telemetry by default in the `Base Account` wallet connector.

### Detailed summary
- Updated `baseAccount.ts` to include a `preference` object.
- Set `telemetry` to `false` by default in the `preference` object.
- Merged any existing `preference` settings from `optionalConfig`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables Base Account connector telemetry by default via `preference.telemetry = false`, and adds a patch changeset.
> 
> - **Wallets**
>   - `packages/rainbowkit/src/wallets/walletConnectors/baseAccount/baseAccount.ts`: Pass `preference: { telemetry: false, ... }` to `baseAccountConnector`, defaulting telemetry off while allowing overrides from `optionalConfig`.
> - **Release**
>   - `.changeset/disable-base-account-telemetry.md`: Patch bump for `@rainbow-me/rainbowkit`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a4d75f770489e56bc3c7e21224ea80b5befc8ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->