### PR TITLE
fix: disable WalletConnect analytics by default for GDPR compliance

### DIFF
--- a/.changeset/disable-walletconnect-analytics.md
+++ b/.changeset/disable-walletconnect-analytics.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Disable WalletConnect Pulse analytics by default for GDPR compliance. Analytics tracking now requires explicit opt-in by setting `walletConnectParameters: { disableProviderPing: false }`.

--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -41,6 +41,7 @@ const getOrCreateWalletConnectInstance = ({
   typeof walletConnect
 > => {
   let config: WalletConnectParameters = {
+    disableProviderPing: true, // Disable analytics by default for GDPR compliance
     ...(walletConnectParameters ? walletConnectParameters : {}),
     projectId,
     showQrModal: false, // Required. Otherwise WalletConnect modal (Web3Modal) will popup during time of connection for a wallet


### PR DESCRIPTION
## Description

This PR disables WalletConnect Pulse analytics by default to address GDPR compliance concerns where analytics tracking was occurring on initialization without user consent.

## Changes

- Sets `disableProviderPing: true` by default in WalletConnect configuration
- Adds changeset documenting the change
- Developers can still explicitly enable analytics by passing `walletConnectParameters: { disableProviderPing: false }`

## Related Issues

Partially fixes #2560

## Context

Previously, WalletConnect would send analytics data to `pulse.walletconnect.org` immediately on initialization, before any user interaction or consent. This violates GDPR requirements which mandate opt-in consent for tracking.

With this change, analytics are disabled by default and require explicit opt-in, making RainbowKit GDPR-compliant out of the box.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing GDPR compliance by disabling WalletConnect Pulse analytics by default. It introduces a requirement for explicit user consent to enable analytics tracking.

### Detailed summary
- Updated `getWalletConnectConnector.ts` to set `disableProviderPing` to `true` by default.
- Added a note about requiring explicit opt-in for analytics tracking via `walletConnectParameters: { disableProviderPing: false }`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->