### PR TITLE
fix: remove ci env overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on: [pull_request, push]
 
 env:
   pnpm: 10.17.0
-  RAINBOW_PROVIDER_API_KEY: ${{ secrets.RAINBOW_PROVIDER_API_KEY }}
-  WALLETCONNECT_PROJECT_ID: ${{ secrets.WALLETCONNECT_PROJECT_ID }}
 
 jobs:
   tests:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `.github/workflows/ci.yml` file by modifying environment variables for the CI workflow, specifically removing two secrets.

### Detailed summary
- Set `pnpm` version to `10.17.0`.
- Removed `RAINBOW_PROVIDER_API_KEY` from the environment variables.
- Removed `WALLETCONNECT_PROJECT_ID` from the environment variables.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `RAINBOW_PROVIDER_API_KEY` and `WALLETCONNECT_PROJECT_ID` from CI env and pins `pnpm` to 10.17.0.
> 
> - **CI Workflow (`.github/workflows/ci.yml`)**:
>   - Remove env secrets: `RAINBOW_PROVIDER_API_KEY`, `WALLETCONNECT_PROJECT_ID`.
>   - Pin `pnpm` version via `env.pnpm` to `10.17.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d998793782584362a994b957d66504bef4ce282. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->