### PR TITLE
chore: upgrade pnpm to 10.21.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
   "name": "Node.js & TypeScript",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm",
-  "postCreateCommand": "npm i -g pnpm@10.17.0 && pnpm install"
+  "postCreateCommand": "npm i -g pnpm@10.21.0 && pnpm install"
 }

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,7 +13,7 @@ It's never a fun experience to have your pull request declined after investing a
 
 ## Prerequisites
 
-This project uses [`pnpm`](https://pnpm.io) as a package manager. The required `pnpm` version to get started is `^10.17.0`.
+This project uses [`pnpm`](https://pnpm.io) as a package manager. The required `pnpm` version to get started is `^10.21.0`.
 
 ## Development environment
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [pull_request, push]
 
 env:
-  pnpm: 10.17.0
+  pnpm: 10.21.0
 
 jobs:
   tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  pnpm: 10.17.0
+  pnpm: 10.21.0
   HUSKY: 0 # Avoid pre-commit hook tests
   RAINBOW_PROVIDER_API_KEY: RAINBOW_PROVIDER_API_KEY
 

--- a/package.json
+++ b/package.json
@@ -82,10 +82,11 @@
     "react-dom": "^19.1.0",
     "elliptic": "6.6.1"
   },
-  "packageManager": "pnpm@10.17.0",
+  "packageManager": "pnpm@10.21.0",
   "pnpm": {
     "ignoredBuiltDependencies": [
       "@biomejs/biome",
+      "@tailwindcss/oxide",
       "@vercel/speed-insights",
       "bufferutil",
       "contentlayer2",


### PR DESCRIPTION
Upgrades pnpm to 10.21.0 across the project.

## Changes
- Updated pnpm version in package.json (packageManager field)
- Updated pnpm version in CI workflows (.github/workflows/ci.yml and release.yml)
- Updated pnpm version in devcontainer config
- Updated pnpm version in CONTRIBUTING.md
- Updated pnpm-lock.yaml

## Stack
Built on top of #2566 (wagmi/viem upgrade)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps pnpm to 10.21.0 across configs (devcontainer, CI, release, docs) and updates package.json pnpm settings.
> 
> - **Tooling**:
>   - Upgrade `pnpm` from `10.17.0` to `10.21.0` in `package.json` (`packageManager`), `.github/workflows/ci.yml`, `.github/workflows/release.yml`, `.devcontainer/devcontainer.json`, and `.github/CONTRIBUTING.md`.
> - **Package config**:
>   - Add `@tailwindcss/oxide` to `pnpm.ignoredBuiltDependencies` in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6e464ab34528d077e3e0ee044b4717d0636b6e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `pnpm` from `10.17.0` to `10.21.0` across multiple configuration files to ensure consistency and take advantage of improvements in the newer version.

### Detailed summary
- Updated `pnpm` version in `.github/workflows/ci.yml` from `10.17.0` to `10.21.0`
- Updated `pnpm` version in `.github/workflows/release.yml` from `10.17.0` to `10.21.0`
- Updated `packageManager` in `package.json` from `pnpm@10.17.0` to `pnpm@10.21.0`
- Updated `postCreateCommand` in `.devcontainer/devcontainer.json` to use `pnpm@10.21.0`
- Updated prerequisite `pnpm` version in `.github/CONTRIBUTING.md` from `^10.17.0` to `^10.21.0`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->