### PR TITLE
fix: use icon instead of icons in gemini wallet AppMetadata

### DIFF
--- a/.changeset/fix-gemini-wallet-icon.md
+++ b/.changeset/fix-gemini-wallet-icon.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fix Gemini wallet connector to use `icon` instead of `icons` in `appMetadata`

--- a/packages/rainbowkit/src/wallets/walletConnectors/geminiWallet/geminiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/geminiWallet/geminiWallet.ts
@@ -76,7 +76,7 @@ export const geminiWallet = ({
       const connector: CreateConnectorFn = gemini({
         appMetadata: {
           name: appName,
-          icons: appIcon ? [appIcon] : undefined,
+          icon: appIcon,
         },
       });
 


### PR DESCRIPTION
The gemini connector's AppMetadata type expects 'icon' (singular string)
instead of 'icons' (plural array) to match wagmi v2 API.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the Gemini wallet connector by updating the property used for the wallet icon in the `appMetadata` object.

### Detailed summary
- Changed the property from `icons` to `icon` in the `appMetadata` of the `geminiWallet` file.
- Updated the assignment to directly use `appIcon` instead of wrapping it in an array.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch Gemini wallet connector `appMetadata` from `icons` array to `icon` string and add patch changeset.
> 
> - **Wallet connectors**:
>   - **Gemini**: In `packages/rainbowkit/src/wallets/walletConnectors/geminiWallet/geminiWallet.ts`, change `appMetadata` from `icons` to `icon` and pass `appIcon` directly.
> - **Release**:
>   - Add patch changeset in `.changeset/fix-gemini-wallet-icon.md` for `@rainbow-me/rainbowkit`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71da57128bf9da82a3b3ba35a2dd973d0b2cd96e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->