### PR TITLE
refactor: replace disableProviderPing with telemetryEnabled

### DIFF
--- a/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
+++ b/packages/rainbowkit/src/wallets/getWalletConnectConnector.ts
@@ -41,7 +41,7 @@ const getOrCreateWalletConnectInstance = ({
   typeof walletConnect
 > => {
   let config: WalletConnectParameters = {
-    disableProviderPing: true, // Disable analytics by default for GDPR compliance
+    telemetryEnabled: false, // Disable analytics by default
     ...(walletConnectParameters ? walletConnectParameters : {}),
     projectId,
     showQrModal: false, // Required. Otherwise WalletConnect modal (Web3Modal) will popup during time of connection for a wallet


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the configuration for the `WalletConnect` connector by modifying the analytics settings for GDPR compliance.

### Detailed summary
- Changed `disableProviderPing: true` to `telemetryEnabled: false` to disable analytics by default.
- Maintained the existing properties while ensuring GDPR compliance in the `WalletConnectParameters`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->