### PR TITLE
docs: combine changesets and add opt-in examples

### DIFF
--- a/.changeset/disable-base-account-telemetry.md
+++ b/.changeset/disable-base-account-telemetry.md
@@ -1,5 +1,0 @@
----
-"@rainbow-me/rainbowkit": patch
----
-
-Disable telemetry by default in Base Account wallet connector to respect user privacy.

--- a/.changeset/disable-connector-telemetry.md
+++ b/.changeset/disable-connector-telemetry.md
@@ -1,0 +1,40 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Disable third-party connector telemetry by default for user privacy.
+
+**To opt-in to WalletConnect analytics:**
+
+With `getDefaultConfig`:
+```ts
+const config = getDefaultConfig({
+  appName: 'My App',
+  projectId: 'YOUR_PROJECT_ID',
+  chains: [mainnet],
+  walletConnectParameters: {
+    telemetryEnabled: true
+  }
+});
+```
+
+With `connectorsForWallets`:
+```ts
+const connectors = connectorsForWallets(
+  [{ groupName: 'Popular', wallets: [rainbowWallet] }],
+  {
+    appName: 'My App',
+    projectId: 'YOUR_PROJECT_ID',
+    walletConnectParameters: {
+      telemetryEnabled: true
+    }
+  }
+);
+```
+
+**To opt-in to Base Account telemetry:**
+```ts
+baseAccount.preference = {
+  telemetry: true
+};
+```

--- a/.changeset/disable-walletconnect-analytics.md
+++ b/.changeset/disable-walletconnect-analytics.md
@@ -1,5 +1,0 @@
----
-"@rainbow-me/rainbowkit": patch
----
-
-Disable WalletConnect Pulse analytics by default for GDPR compliance. Analytics tracking now requires explicit opt-in by setting `walletConnectParameters: { disableProviderPing: false }`.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing user privacy by disabling third-party connector telemetry by default. It provides instructions for developers to opt-in to telemetry for `WalletConnect` and `Base Account`.

### Detailed summary
- Deleted files: `.changeset/disable-base-account-telemetry.md`, `.changeset/disable-walletconnect-analytics.md`
- Added documentation on disabling telemetry by default.
- Provided code snippets for opting-in to telemetry for `WalletConnect` and `Base Account`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->