### PR TITLE
fix: cli workflow caching

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: yarn
       - name: Scaffold new project with published CLI
         run: yarn create @rainbow-me/rainbowkit generated-test-app --skip-git
       - name: Print dependency versions


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the GitHub Actions workflow configuration in the `.github/workflows/cli.yml` file, specifically modifying the steps for scaffolding a new project and printing dependency versions.

### Detailed summary
- Removed the `-cache: yarn` line.
- Changed the step name from `Scaffold new project with published CLI` to `Print dependency versions`.
- Updated the `run` command to scaffold a new project using `yarn create @rainbow-me/rainbowkit generated-test-app --skip-git`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->