### PR TITLE
chore: update workflows to use Node.js v22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [lts/*]
+        node: [22]
 
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [lts/*]
+        node: [22]
 
     steps:
       - uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [lts/*]
+        node: [22]
 
     steps:
       - uses: actions/checkout@v4
@@ -89,7 +89,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [lts/*]
+        node: [22]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [lts/*]
+        node: [22]
 
     steps:
       - name: Use Node.js ${{ matrix.node }}
@@ -23,11 +23,11 @@ jobs:
       - name: Print dependency versions
         working-directory: generated-test-app
         run: |
-          echo "RainbowKit: $(node -p \"require('./node_modules/@rainbow-me/rainbowkit/package.json').version\")"
-          echo "Wagmi: $(node -p \"require('./node_modules/wagmi/package.json').version\")"
-          echo "Viem: $(node -p \"require('./node_modules/viem/package.json').version\")"
-          echo "Next.js: $(node -p \"require('./node_modules/next/package.json').version\")"
-          echo "React: $(node -p \"require('./node_modules/react/package.json').version\")"
+          echo "RainbowKit: $(node -p 'require("./node_modules/@rainbow-me/rainbowkit/package.json").version')"
+          echo "Wagmi: $(node -p 'require("./node_modules/wagmi/package.json").version')"
+          echo "Viem: $(node -p 'require("./node_modules/viem/package.json").version')"
+          echo "Next.js: $(node -p 'require("./node_modules/next/package.json").version')"
+          echo "React: $(node -p 'require("./node_modules/react/package.json").version')"
       - name: Typecheck generated project
         working-directory: generated-test-app
         run: yarn tsc --noEmit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [lts/*]
+        node: [22]
 
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Node.js version used in various GitHub workflow files from `lts/*` to `22`, ensuring compatibility with the latest features and improvements. Additionally, it modifies the echo commands in the `cli.yml` file to use double quotes consistently.

### Detailed summary
- Updated `node` version from `lts/*` to `22` in:
  - `.github/workflows/release.yml`
  - `.github/workflows/ci.yml`
  - `.github/workflows/cli.yml`
- Changed echo commands in `cli.yml` to use double quotes consistently.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->