### PR TITLE
chore: /icons preview page for debugging

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -9,6 +9,7 @@
     "@rainbow-me/rainbowkit": "workspace:*",
     "@rainbow-me/rainbowkit-siwe-next-auth": "workspace:*",
     "@tanstack/react-query": "^5.55.3",
+    "cuer": "^0.0.3",
     "next": "^15.3.6",
     "next-auth": "4.24.11",
     "react": "^19.1.2",

--- a/packages/example/src/pages/_app.tsx
+++ b/packages/example/src/pages/_app.tsx
@@ -181,7 +181,7 @@ function RainbowKitApp({
         >
           <Component {...pageProps} {...appContextProps} />
 
-          {isMounted && router.pathname !== '/providers' && (
+          {isMounted && router.pathname !== '/providers' && router.pathname !== '/icons' && (
             <>
               <div
                 style={{

--- a/packages/example/src/pages/_app.tsx
+++ b/packages/example/src/pages/_app.tsx
@@ -181,328 +181,343 @@ function RainbowKitApp({
         >
           <Component {...pageProps} {...appContextProps} />
 
-          {isMounted && router.pathname !== '/providers' && router.pathname !== '/icons' && (
-            <>
-              <div
-                style={{
-                  fontFamily: 'sans-serif',
-                }}
-              >
-                <h3>RainbowKitProvider props</h3>
-                <table cellSpacing={12}>
-                  <tbody>
-                    <tr>
-                      <td>
-                        <label
-                          htmlFor="authEnabled"
-                          style={{ userSelect: 'none' }}
-                        >
-                          authentication
-                        </label>
-                      </td>
-                      <td>
-                        <input
-                          checked={authEnabled}
-                          id="authEnabled"
-                          name="authEnabled"
-                          onChange={(e) => {
-                            setAuthEnabled(e.target.checked);
-
-                            // Reset connection and auth state when
-                            // toggling the authentication mode.
-                            // This better simulates the real dev experience
-                            // since they don't normally toggle between
-                            // these two modes at run time. Otherwise you
-                            // might experience weird behavior when toggling
-                            // in the middle of a session.
-                            signOut({ redirect: false });
-                            disconnect();
-                          }}
-                          type="checkbox"
-                        />
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <label
-                          htmlFor="showRecentTransactions"
-                          style={{ userSelect: 'none' }}
-                        >
-                          showRecentTransactions
-                        </label>
-                      </td>
-                      <td>
-                        <input
-                          checked={showRecentTransactions}
-                          id="showRecentTransactions"
-                          name="showRecentTransactions"
-                          onChange={(e) =>
-                            setShowRecentTransactions(e.target.checked)
-                          }
-                          type="checkbox"
-                        />
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <label
-                          htmlFor="coolModeEnabled"
-                          style={{ userSelect: 'none' }}
-                        >
-                          coolMode
-                        </label>
-                      </td>
-                      <td>
-                        <input
-                          checked={coolModeEnabled}
-                          id="coolModeEnabled"
-                          name="coolModeEnabled"
-                          onChange={(e) => setCoolModeEnabled(e.target.checked)}
-                          type="checkbox"
-                        />
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <label
-                          htmlFor="showDisclaimer"
-                          style={{ userSelect: 'none' }}
-                        >
-                          disclaimer
-                        </label>
-                      </td>
-                      <td>
-                        <input
-                          checked={showDisclaimer}
-                          id="showDisclaimer"
-                          name="showDisclaimer"
-                          onChange={(e) => setShowDisclaimer(e.target.checked)}
-                          type="checkbox"
-                        />
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <label
-                          htmlFor="customAvatar"
-                          style={{ userSelect: 'none' }}
-                        >
-                          avatar
-                        </label>
-                      </td>
-                      <td>
-                        <input
-                          checked={customAvatar}
-                          id="customAvatar"
-                          name="customAvatar"
-                          onChange={(e) => setCustomAvatar(e.target.checked)}
-                          type="checkbox"
-                        />
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>modalSize</td>
-                      <td>
-                        <select
-                          onChange={(e) =>
-                            setModalSize(e.target.value as ModalSize)
-                          }
-                          value={modalSize}
-                        >
-                          {modalSizes.map((size) => (
-                            <option key={size} value={size}>
-                              {size}
-                            </option>
-                          ))}
-                        </select>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>initialChain</td>
-                      <td>
-                        <select
-                          onChange={(e) =>
-                            setInitialChainId(
-                              e.target.value
-                                ? Number.parseInt(e.target.value, 10)
-                                : undefined,
-                            )
-                          }
-                          value={selectedInitialChainId ?? 'default'}
-                        >
-                          {[undefined, ...config.chains].map((chain) => (
-                            <option
-                              key={chain?.id ?? ''}
-                              value={chain?.id ?? ''}
-                            >
-                              {chain?.name ?? 'Default'}
-                            </option>
-                          ))}
-                        </select>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <label style={{ userSelect: 'none' }}>locale</label>
-                      </td>
-                      <td>
-                        <select
-                          onChange={(e) => {
-                            setLocale(e.target.value as Locale);
-                          }}
-                          value={locale}
-                        >
-                          {locales.map((locale) => (
-                            <option key={locale} value={locale}>
-                              {locale}
-                            </option>
-                          ))}
-                        </select>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
+          {isMounted &&
+            router.pathname !== '/providers' &&
+            router.pathname !== '/icons' && (
+              <>
                 <div
                   style={{
-                    display: 'flex',
-                    flexWrap: 'wrap',
-                    gap: 24,
+                    fontFamily: 'sans-serif',
                   }}
                 >
-                  <div>
-                    <h4>Theme</h4>
-                    <div
-                      style={{
-                        alignItems: 'flex-start',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: 12,
-                      }}
-                    >
-                      {themes.map(({ name: themeName }) => (
-                        <label key={themeName} style={{ userSelect: 'none' }}>
+                  <h3>RainbowKitProvider props</h3>
+                  <table cellSpacing={12}>
+                    <tbody>
+                      <tr>
+                        <td>
+                          <label
+                            htmlFor="authEnabled"
+                            style={{ userSelect: 'none' }}
+                          >
+                            authentication
+                          </label>
+                        </td>
+                        <td>
                           <input
-                            checked={themeName === selectedThemeName}
-                            name="theme"
+                            checked={authEnabled}
+                            id="authEnabled"
+                            name="authEnabled"
+                            onChange={(e) => {
+                              setAuthEnabled(e.target.checked);
+
+                              // Reset connection and auth state when
+                              // toggling the authentication mode.
+                              // This better simulates the real dev experience
+                              // since they don't normally toggle between
+                              // these two modes at run time. Otherwise you
+                              // might experience weird behavior when toggling
+                              // in the middle of a session.
+                              signOut({ redirect: false });
+                              disconnect();
+                            }}
+                            type="checkbox"
+                          />
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <label
+                            htmlFor="showRecentTransactions"
+                            style={{ userSelect: 'none' }}
+                          >
+                            showRecentTransactions
+                          </label>
+                        </td>
+                        <td>
+                          <input
+                            checked={showRecentTransactions}
+                            id="showRecentTransactions"
+                            name="showRecentTransactions"
                             onChange={(e) =>
-                              setThemeName(e.target.value as ThemeName)
+                              setShowRecentTransactions(e.target.checked)
                             }
-                            type="radio"
-                            value={themeName}
-                          />{' '}
-                          {themeName}
-                        </label>
-                      ))}
+                            type="checkbox"
+                          />
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <label
+                            htmlFor="coolModeEnabled"
+                            style={{ userSelect: 'none' }}
+                          >
+                            coolMode
+                          </label>
+                        </td>
+                        <td>
+                          <input
+                            checked={coolModeEnabled}
+                            id="coolModeEnabled"
+                            name="coolModeEnabled"
+                            onChange={(e) =>
+                              setCoolModeEnabled(e.target.checked)
+                            }
+                            type="checkbox"
+                          />
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <label
+                            htmlFor="showDisclaimer"
+                            style={{ userSelect: 'none' }}
+                          >
+                            disclaimer
+                          </label>
+                        </td>
+                        <td>
+                          <input
+                            checked={showDisclaimer}
+                            id="showDisclaimer"
+                            name="showDisclaimer"
+                            onChange={(e) =>
+                              setShowDisclaimer(e.target.checked)
+                            }
+                            type="checkbox"
+                          />
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <label
+                            htmlFor="customAvatar"
+                            style={{ userSelect: 'none' }}
+                          >
+                            avatar
+                          </label>
+                        </td>
+                        <td>
+                          <input
+                            checked={customAvatar}
+                            id="customAvatar"
+                            name="customAvatar"
+                            onChange={(e) => setCustomAvatar(e.target.checked)}
+                            type="checkbox"
+                          />
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>modalSize</td>
+                        <td>
+                          <select
+                            onChange={(e) =>
+                              setModalSize(e.target.value as ModalSize)
+                            }
+                            value={modalSize}
+                          >
+                            {modalSizes.map((size) => (
+                              <option key={size} value={size}>
+                                {size}
+                              </option>
+                            ))}
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>initialChain</td>
+                        <td>
+                          <select
+                            onChange={(e) =>
+                              setInitialChainId(
+                                e.target.value
+                                  ? Number.parseInt(e.target.value, 10)
+                                  : undefined,
+                              )
+                            }
+                            value={selectedInitialChainId ?? 'default'}
+                          >
+                            {[undefined, ...config.chains].map((chain) => (
+                              <option
+                                key={chain?.id ?? ''}
+                                value={chain?.id ?? ''}
+                              >
+                                {chain?.name ?? 'Default'}
+                              </option>
+                            ))}
+                          </select>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <label style={{ userSelect: 'none' }}>locale</label>
+                        </td>
+                        <td>
+                          <select
+                            onChange={(e) => {
+                              setLocale(e.target.value as Locale);
+                            }}
+                            value={locale}
+                          >
+                            {locales.map((locale) => (
+                              <option key={locale} value={locale}>
+                                {locale}
+                              </option>
+                            ))}
+                          </select>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexWrap: 'wrap',
+                      gap: 24,
+                    }}
+                  >
+                    <div>
+                      <h4>Theme</h4>
+                      <div
+                        style={{
+                          alignItems: 'flex-start',
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: 12,
+                        }}
+                      >
+                        {themes.map(({ name: themeName }) => (
+                          <label key={themeName} style={{ userSelect: 'none' }}>
+                            <input
+                              checked={themeName === selectedThemeName}
+                              name="theme"
+                              onChange={(e) =>
+                                setThemeName(e.target.value as ThemeName)
+                              }
+                              type="radio"
+                              value={themeName}
+                            />{' '}
+                            {themeName}
+                          </label>
+                        ))}
+                      </div>
                     </div>
-                  </div>
-                  <div>
-                    <h4>Font stack</h4>
-                    <div
-                      style={{
-                        alignItems: 'flex-start',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: 12,
-                      }}
-                    >
-                      {fontStacks.map((fontStack) => (
-                        <label key={fontStack} style={{ userSelect: 'none' }}>
-                          <input
-                            checked={fontStack === selectedFontStack}
-                            name="fontStack"
-                            onChange={(e) =>
-                              setFontStack(e.target.value as FontStack)
-                            }
-                            type="radio"
-                            value={fontStack}
-                          />{' '}
-                          {fontStack}
-                        </label>
-                      ))}
+                    <div>
+                      <h4>Font stack</h4>
+                      <div
+                        style={{
+                          alignItems: 'flex-start',
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: 12,
+                        }}
+                      >
+                        {fontStacks.map((fontStack) => (
+                          <label key={fontStack} style={{ userSelect: 'none' }}>
+                            <input
+                              checked={fontStack === selectedFontStack}
+                              name="fontStack"
+                              onChange={(e) =>
+                                setFontStack(e.target.value as FontStack)
+                              }
+                              type="radio"
+                              value={fontStack}
+                            />{' '}
+                            {fontStack}
+                          </label>
+                        ))}
+                      </div>
                     </div>
-                  </div>
-                  <div>
-                    <h4>Accent</h4>
-                    <div
-                      style={{
-                        alignItems: 'flex-start',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: 12,
-                      }}
-                    >
-                      {accentColors.map((accentColor) => (
-                        <label key={accentColor} style={{ userSelect: 'none' }}>
-                          <input
-                            checked={accentColor === selectedAccentColor}
-                            name="accentColor"
-                            onChange={(e) =>
-                              setAccentColor(e.target.value as AccentColor)
-                            }
-                            type="radio"
-                            value={accentColor}
-                          />{' '}
-                          {accentColor}
-                        </label>
-                      ))}
+                    <div>
+                      <h4>Accent</h4>
+                      <div
+                        style={{
+                          alignItems: 'flex-start',
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: 12,
+                        }}
+                      >
+                        {accentColors.map((accentColor) => (
+                          <label
+                            key={accentColor}
+                            style={{ userSelect: 'none' }}
+                          >
+                            <input
+                              checked={accentColor === selectedAccentColor}
+                              name="accentColor"
+                              onChange={(e) =>
+                                setAccentColor(e.target.value as AccentColor)
+                              }
+                              type="radio"
+                              value={accentColor}
+                            />{' '}
+                            {accentColor}
+                          </label>
+                        ))}
+                      </div>
                     </div>
-                  </div>
-                  <div>
-                    <h4>Border radius</h4>
-                    <div
-                      style={{
-                        alignItems: 'flex-start',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: 12,
-                      }}
-                    >
-                      {radiusScales.map((radiusScale) => (
-                        <label key={radiusScale} style={{ userSelect: 'none' }}>
-                          <input
-                            checked={radiusScale === selectedRadiusScale}
-                            name="radiusScale"
-                            onChange={(e) =>
-                              setRadiusScale(e.target.value as RadiusScale)
-                            }
-                            type="radio"
-                            value={radiusScale}
-                          />{' '}
-                          {radiusScale}
-                        </label>
-                      ))}
+                    <div>
+                      <h4>Border radius</h4>
+                      <div
+                        style={{
+                          alignItems: 'flex-start',
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: 12,
+                        }}
+                      >
+                        {radiusScales.map((radiusScale) => (
+                          <label
+                            key={radiusScale}
+                            style={{ userSelect: 'none' }}
+                          >
+                            <input
+                              checked={radiusScale === selectedRadiusScale}
+                              name="radiusScale"
+                              onChange={(e) =>
+                                setRadiusScale(e.target.value as RadiusScale)
+                              }
+                              type="radio"
+                              value={radiusScale}
+                            />{' '}
+                            {radiusScale}
+                          </label>
+                        ))}
+                      </div>
                     </div>
-                  </div>
-                  <div>
-                    <h4>Overlay blurs</h4>
-                    <div
-                      style={{
-                        alignItems: 'flex-start',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: 12,
-                      }}
-                    >
-                      {overlayBlurs.map((overlayBlur) => (
-                        <label key={overlayBlur} style={{ userSelect: 'none' }}>
-                          <input
-                            checked={overlayBlur === selectedOverlayBlur}
-                            name="overlayBlur"
-                            onChange={(e) =>
-                              setOverlayBlur(e.target.value as OverlayBlur)
-                            }
-                            type="radio"
-                            value={overlayBlur}
-                          />{' '}
-                          {overlayBlur}
-                        </label>
-                      ))}
+                    <div>
+                      <h4>Overlay blurs</h4>
+                      <div
+                        style={{
+                          alignItems: 'flex-start',
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: 12,
+                        }}
+                      >
+                        {overlayBlurs.map((overlayBlur) => (
+                          <label
+                            key={overlayBlur}
+                            style={{ userSelect: 'none' }}
+                          >
+                            <input
+                              checked={overlayBlur === selectedOverlayBlur}
+                              name="overlayBlur"
+                              onChange={(e) =>
+                                setOverlayBlur(e.target.value as OverlayBlur)
+                              }
+                              type="radio"
+                              value={overlayBlur}
+                            />{' '}
+                            {overlayBlur}
+                          </label>
+                        ))}
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </>
-          )}
+              </>
+            )}
         </div>
       </RainbowKitProvider>
     </RainbowKitSiweNextAuthProvider>

--- a/packages/example/src/pages/icons.tsx
+++ b/packages/example/src/pages/icons.tsx
@@ -18,7 +18,7 @@ export const getStaticProps: GetStaticProps<IconsProps> = async () => {
   try {
     const walletConnectorsPath = path.join(
       process.cwd(),
-      'node_modules/@rainbow-me/rainbowkit/dist/wallets/walletConnectors'
+      'node_modules/@rainbow-me/rainbowkit/dist/wallets/walletConnectors',
     );
 
     const files = fs.readdirSync(walletConnectorsPath);
@@ -89,7 +89,11 @@ export default function Icons({ wallets }: IconsProps) {
                   <div className="svg-box">
                     <div className="size-label">QR</div>
                     <div className="svg-display large">
-                      <Cuer.Root errorCorrection="medium" size={120} value="https://wevm.dev">
+                      <Cuer.Root
+                        errorCorrection="medium"
+                        size={120}
+                        value="https://wevm.dev"
+                      >
                         <Cuer.Cells radius={1} />
                         <Cuer.Finder radius={0.25} />
                         <Cuer.Arena>

--- a/packages/example/src/pages/icons.tsx
+++ b/packages/example/src/pages/icons.tsx
@@ -24,8 +24,8 @@ export const getStaticProps: GetStaticProps<IconsProps> = async () => {
     const files = fs.readdirSync(walletConnectorsPath);
 
     // Find hashed JS files (e.g., backpackWallet-QESORHY7.js)
-    const hashedJsFiles = files.filter(file =>
-      /^[a-zA-Z0-9]+(Wallet|Account)-[A-Z0-9]+\.js$/.test(file)
+    const hashedJsFiles = files.filter((file) =>
+      /^[a-zA-Z0-9]+(Wallet|Account)-[A-Z0-9]+\.js$/.test(file),
     );
 
     const seenWallets = new Set<string>();
@@ -36,7 +36,9 @@ export const getStaticProps: GetStaticProps<IconsProps> = async () => {
         const jsFilePath = path.join(walletConnectorsPath, jsFile);
         const jsContent = fs.readFileSync(jsFilePath, 'utf-8');
 
-        const svgDataUrlMatch = jsContent.match(/var \w+_default = "(data:image\/svg\+xml,[^"]+)";/);
+        const svgDataUrlMatch = jsContent.match(
+          /var \w+_default = "(data:image\/svg\+xml,[^"]+)";/,
+        );
 
         if (svgDataUrlMatch?.[1] && !seenWallets.has(walletName)) {
           seenWallets.add(walletName);
@@ -109,16 +111,42 @@ export default function Icons({ wallets }: IconsProps) {
                 <button
                   className="file-path"
                   onClick={() => {
-                    navigator.clipboard.writeText(`packages/rainbowkit/src/wallets/walletConnectors/${wallet.name}/${wallet.name}.svg`);
+                    navigator.clipboard.writeText(
+                      `packages/rainbowkit/src/wallets/walletConnectors/${wallet.name}/${wallet.name}.svg`,
+                    );
                   }}
                   aria-label="Copy file path"
                   title="Copy full path to clipboard"
                 >
-                  <span>src/wallets/walletConnectors/{wallet.name}/{wallet.name}.svg</span>
-                  <svg className="copy-icon" width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Copy to clipboard">
+                  <span>
+                    src/wallets/walletConnectors/{wallet.name}/{wallet.name}
+                    .svg
+                  </span>
+                  <svg
+                    className="copy-icon"
+                    width="14"
+                    height="14"
+                    viewBox="0 0 14 14"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    role="img"
+                    aria-label="Copy to clipboard"
+                  >
                     <title>Copy to clipboard</title>
-                    <path d="M9.5 1H2.5C1.94772 1 1.5 1.44772 1.5 2V9C1.5 9.55228 1.94772 10 2.5 10H9.5C10.0523 10 10.5 9.55228 10.5 9V2C10.5 1.44772 10.0523 1 9.5 1Z" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/>
-                    <path d="M3.5 10V11.5C3.5 12.0523 3.94772 12.5 4.5 12.5H11.5C12.0523 12.5 12.5 12.0523 12.5 11.5V4.5C12.5 3.94772 12.0523 3.5 11.5 3.5H10" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path
+                      d="M9.5 1H2.5C1.94772 1 1.5 1.44772 1.5 2V9C1.5 9.55228 1.94772 10 2.5 10H9.5C10.0523 10 10.5 9.55228 10.5 9V2C10.5 1.44772 10.0523 1 9.5 1Z"
+                      stroke="currentColor"
+                      strokeWidth="1.2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M3.5 10V11.5C3.5 12.0523 3.94772 12.5 4.5 12.5H11.5C12.0523 12.5 12.5 12.0523 12.5 11.5V4.5C12.5 3.94772 12.0523 3.5 11.5 3.5H10"
+                      stroke="currentColor"
+                      strokeWidth="1.2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
                   </svg>
                 </button>
               </div>
@@ -132,7 +160,9 @@ export default function Icons({ wallets }: IconsProps) {
             min-height: 100vh;
             background: #f5f5f5;
             padding: 40px 20px;
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            font-family: -apple-system, BlinkMacSystemFont,
+              'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+              sans-serif;
         }
 
         .container {
@@ -142,7 +172,10 @@ export default function Icons({ wallets }: IconsProps) {
 
         .grid {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(550px, 1fr));
+            grid-template-columns: repeat(
+              auto-fill,
+              minmax(550px, 1fr)
+            );
             gap: 24px;
         }
 

--- a/packages/example/src/pages/icons.tsx
+++ b/packages/example/src/pages/icons.tsx
@@ -1,0 +1,279 @@
+import type { GetStaticProps } from 'next';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Cuer } from 'cuer';
+
+interface Wallet {
+  name: string;
+  svgDataUrl: string;
+}
+
+interface IconsProps {
+  wallets: Wallet[];
+}
+
+export const getStaticProps: GetStaticProps<IconsProps> = async () => {
+  const wallets: Wallet[] = [];
+
+  try {
+    const walletConnectorsPath = path.join(
+      process.cwd(),
+      'node_modules/@rainbow-me/rainbowkit/dist/wallets/walletConnectors'
+    );
+
+    const files = fs.readdirSync(walletConnectorsPath);
+
+    // Find hashed JS files (e.g., backpackWallet-QESORHY7.js)
+    const hashedJsFiles = files.filter(file =>
+      /^[a-zA-Z0-9]+(Wallet|Account)-[A-Z0-9]+\.js$/.test(file)
+    );
+
+    const seenWallets = new Set<string>();
+
+    for (const jsFile of hashedJsFiles) {
+      try {
+        const walletName = jsFile.split('-')[0];
+        const jsFilePath = path.join(walletConnectorsPath, jsFile);
+        const jsContent = fs.readFileSync(jsFilePath, 'utf-8');
+
+        const svgDataUrlMatch = jsContent.match(/var \w+_default = "(data:image\/svg\+xml,[^"]+)";/);
+
+        if (svgDataUrlMatch?.[1] && !seenWallets.has(walletName)) {
+          seenWallets.add(walletName);
+          wallets.push({
+            name: walletName,
+            svgDataUrl: svgDataUrlMatch[1],
+          });
+        }
+      } catch (error) {
+        console.error(`Error processing ${jsFile}:`, error);
+      }
+    }
+
+    wallets.sort((a, b) => a.name.localeCompare(b.name));
+  } catch (error) {
+    console.error('Error reading wallet connectors:', error);
+  }
+
+  return {
+    props: {
+      wallets,
+    },
+  };
+};
+
+export default function Icons({ wallets }: IconsProps) {
+  return (
+    <>
+      <div className="page-wrapper">
+        <div className="container">
+          <div className="grid">
+            {wallets.map((wallet) => (
+              <div className="card" key={wallet.name}>
+                <div className="wallet-name">{wallet.name}</div>
+                <div className="svg-container">
+                  <div className="svg-box">
+                    <div className="size-label">28×28</div>
+                    <div className="svg-display small">
+                      <img src={wallet.svgDataUrl} alt={wallet.name} />
+                    </div>
+                  </div>
+                  <div className="svg-box">
+                    <div className="size-label">120×120</div>
+                    <div className="svg-display large">
+                      <img src={wallet.svgDataUrl} alt={wallet.name} />
+                    </div>
+                  </div>
+                  <div className="svg-box">
+                    <div className="size-label">QR</div>
+                    <div className="svg-display large">
+                      <Cuer.Root errorCorrection="medium" size={120} value="https://wevm.dev">
+                        <Cuer.Cells radius={1} />
+                        <Cuer.Finder radius={0.25} />
+                        <Cuer.Arena>
+                          <img
+                            alt={wallet.name}
+                            src={wallet.svgDataUrl}
+                            style={{
+                              objectFit: 'cover',
+                              height: '88%',
+                              width: '88%',
+                              borderRadius: '22.5%',
+                            }}
+                          />
+                        </Cuer.Arena>
+                      </Cuer.Root>
+                    </div>
+                  </div>
+                </div>
+                <button
+                  className="file-path"
+                  onClick={() => {
+                    navigator.clipboard.writeText(`packages/rainbowkit/src/wallets/walletConnectors/${wallet.name}/${wallet.name}.svg`);
+                  }}
+                  aria-label="Copy file path"
+                  title="Copy full path to clipboard"
+                >
+                  <span>src/wallets/walletConnectors/{wallet.name}/{wallet.name}.svg</span>
+                  <svg className="copy-icon" width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Copy to clipboard">
+                    <title>Copy to clipboard</title>
+                    <path d="M9.5 1H2.5C1.94772 1 1.5 1.44772 1.5 2V9C1.5 9.55228 1.94772 10 2.5 10H9.5C10.0523 10 10.5 9.55228 10.5 9V2C10.5 1.44772 10.0523 1 9.5 1Z" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path d="M3.5 10V11.5C3.5 12.0523 3.94772 12.5 4.5 12.5H11.5C12.0523 12.5 12.5 12.0523 12.5 11.5V4.5C12.5 3.94772 12.0523 3.5 11.5 3.5H10" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/>
+                  </svg>
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <style jsx>{`
+        .page-wrapper {
+            min-height: 100vh;
+            background: #f5f5f5;
+            padding: 40px 20px;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+        }
+
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(550px, 1fr));
+            gap: 24px;
+        }
+
+        .card {
+            background: white;
+            border-radius: 12px;
+            padding: 24px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+
+        .card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+        }
+
+        .wallet-name {
+            font-size: 20px;
+            font-weight: 600;
+            color: #333;
+            margin-bottom: 16px;
+        }
+
+        .svg-container {
+            display: flex;
+            gap: 24px;
+            align-items: center;
+            margin-bottom: 16px;
+            flex-wrap: wrap;
+        }
+
+        .svg-box {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .size-label {
+            font-size: 12px;
+            font-weight: 600;
+            color: #666;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .svg-display {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #f0f0f0;
+            border: 2px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 8px;
+        }
+
+        .svg-display.small {
+            width: 44px;
+            height: 44px;
+        }
+
+        .svg-display.large {
+            width: 136px;
+            height: 136px;
+        }
+
+        .svg-box:last-child .svg-display {
+            background: white;
+        }
+
+        .svg-display.small img {
+            width: 28px;
+            height: 28px;
+            border-radius: 6px;
+        }
+
+        .svg-display.large img {
+            width: 120px;
+            height: 120px;
+            border-radius: 25.71px;
+        }
+
+        .file-path {
+            position: relative;
+            width: 100%;
+            font-size: 11px;
+            color: #999;
+            font-family: 'Monaco', 'Menlo', monospace;
+            word-break: break-all;
+            padding: 8px 32px 8px 8px;
+            background: #f9f9f9;
+            border-radius: 4px;
+            border: 1px solid #e0e0e0;
+            display: flex;
+            align-items: center;
+            cursor: pointer;
+            transition: all 0.2s;
+            text-align: left;
+        }
+
+        .file-path:hover {
+            background: #f0f0f0;
+            border-color: #ccc;
+        }
+
+        .file-path:active {
+            background: #e8e8e8;
+        }
+
+        .file-path span {
+            flex: 1;
+        }
+
+        .copy-icon {
+            position: absolute;
+            right: 8px;
+            top: 50%;
+            transform: translateY(-50%);
+        }
+
+        @media (max-width: 768px) {
+            .grid {
+                grid-template-columns: 1fr;
+            }
+
+            .svg-container {
+                flex-direction: column;
+                gap: 16px;
+            }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.55.3
         version: 5.59.0(react@19.2.1)
+      cuer:
+        specifier: ^0.0.3
+        version: 0.0.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.5.4)
       mipd:
         specifier: ^0.0.7
         version: 0.0.7(typescript@5.5.4)
@@ -13946,7 +13949,7 @@ snapshots:
   '@commitlint/is-ignored@19.2.2':
     dependencies:
       '@commitlint/types': 19.0.3
-      semver: 7.7.2
+      semver: 7.7.3
 
   '@commitlint/lint@19.4.1':
     dependencies:
@@ -15482,7 +15485,7 @@ snapshots:
       '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
-      semver: 7.7.2
+      semver: 7.7.3
 
   '@opentelemetry/semantic-conventions@1.28.0': {}
 


### PR DESCRIPTION
# Add Wallet Icons Gallery Page

### TL;DR

Added a new `/icons` page to the example app that displays all wallet icons in the RainbowKit library with their file paths.

### What changed?

- Created a new `/icons` page that dynamically loads and displays all wallet icons from the RainbowKit package
- Added the `cuer` package as a dependency to demonstrate QR code integration with wallet icons
- Updated the app layout to hide navigation elements on the icons page
- Implemented a copy-to-clipboard feature for wallet icon file paths

### How to test?

1. Navigate to `/icons` in the example app
2. Verify that all wallet icons are displayed in both small (28×28) and large (120×120) sizes
3. Check that the QR code integration works correctly
4. Test the copy-to-clipboard functionality for file paths

### Why make this change?

This page serves as a visual reference for all wallet icons available in RainbowKit, making it easier for developers to:
- See all supported wallets at a glance
- Find the correct file paths for specific wallet icons
- Visualize how icons appear at different sizes
- Test QR code integration with wallet icons

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `Icons` page that dynamically loads wallet icons from the `rainbowkit` package and enhances the `_app.tsx` file by modifying the UI for provider props. It also updates package dependencies.

### Detailed summary
- Added `cuer` dependency to `package.json`.
- Implemented `getStaticProps` in `Icons` to read wallet icons from the `rainbowkit` package.
- Created `Icons` component to display wallet icons with SVGs and QR codes.
- Updated `_app.tsx` to modify provider props UI, removing some previous settings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->