### PR TITLE
refactor: adopt WalletFactory pattern for type-safe wallet IDs

### DIFF
--- a/packages/example/src/pages/index.tsx
+++ b/packages/example/src/pages/index.tsx
@@ -241,9 +241,11 @@ const Example = ({ authEnabled }: AppContextProps) => {
             gap: '20px',
           }}
         >
-          {['rainbow', 'metamask', 'baseAccount'].map((connector) => {
-            return <WalletButton key={connector} wallet={connector} />;
-          })}
+          {(['rainbow', 'metaMask', 'baseAccount'] as const).map(
+            (connector) => {
+              return <WalletButton key={connector} wallet={connector} />;
+            },
+          )}
         </div>
       </div>
 

--- a/packages/rainbowkit/src/components/WalletButton/WalletButton.tsx
+++ b/packages/rainbowkit/src/components/WalletButton/WalletButton.tsx
@@ -5,9 +5,13 @@ import { Box } from '../Box/Box';
 import { SpinnerIcon } from '../Icons/Spinner';
 import { I18nContext } from '../RainbowKitProvider/I18nContext';
 import * as styles from './WalletButton.css';
-import { WalletButtonRenderer } from './WalletButtonRenderer';
+import { WalletButtonRenderer, type WalletId } from './WalletButtonRenderer';
 
-export const WalletButton = ({ wallet }: { wallet?: string }) => {
+export interface WalletButtonProps {
+  wallet?: WalletId;
+}
+
+export const WalletButton = ({ wallet }: WalletButtonProps) => {
   return (
     <WalletButtonRenderer wallet={wallet}>
       {({ ready, connect, connected, mounted, connector, loading }) => {

--- a/packages/rainbowkit/src/components/WalletButton/WalletButtonRenderer.tsx
+++ b/packages/rainbowkit/src/components/WalletButton/WalletButtonRenderer.tsx
@@ -23,9 +23,13 @@ import {
   useModalState,
 } from '../RainbowKitProvider/ModalContext';
 import { WalletButtonContext } from '../RainbowKitProvider/WalletButtonContext';
+import type * as walletConnectors from '../../wallets/walletConnectors';
+
+type WalletFactories = typeof walletConnectors;
+export type WalletId = ReturnType<WalletFactories[keyof WalletFactories]>['id'];
 
 export interface WalletButtonRendererProps {
-  wallet?: string;
+  wallet?: WalletId;
   children: (renderProps: {
     error: boolean;
     loading: boolean;

--- a/packages/rainbowkit/src/wallets/walletConnectors/ZilPayWallet/zilPayWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ZilPayWallet/zilPayWallet.ts
@@ -10,12 +10,12 @@ export type ZilPayWalletOptions = DefaultWalletOptions;
 export const zilPayWallet = ({
   projectId,
   walletConnectParameters,
-}: ZilPayWalletOptions): Wallet => {
+}: ZilPayWalletOptions) => {
   const isZilPayInjected = hasInjectedProvider({ flag: 'isZilPay' });
   const shouldUseWalletConnect = !isZilPayInjected;
 
   return {
-    id: 'zilpay',
+    id: 'zilpay' as const,
     name: 'ZilPay',
     rdns: 'io.zilpay',
     iconUrl: async () => (await import('./zilPayWallet.svg')).default,
@@ -69,5 +69,5 @@ export const zilPayWallet = ({
       : getInjectedConnector({
           flag: 'isZilPay',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/argentWallet/argentWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/argentWallet/argentWallet.ts
@@ -9,11 +9,11 @@ export type ArgentWalletOptions = ReadyWalletOptions;
 /**
  * @deprecated Use {@link readyWallet} instead.
  */
-export const argentWallet = (options: ArgentWalletOptions): Wallet => {
+export const argentWallet = (options: ArgentWalletOptions) => {
   const wallet = readyWallet(options);
 
   return {
     ...wallet,
-    id: 'argent',
-  };
+    id: 'argent' as const,
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/backpackWallet/backpackWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/backpackWallet/backpackWallet.ts
@@ -4,9 +4,9 @@ import {
 } from '../../getInjectedConnector';
 import type { Wallet } from '../../Wallet';
 
-export const backpackWallet = (): Wallet => {
+export const backpackWallet = () => {
   return {
-    id: 'backpack',
+    id: 'backpack' as const,
     name: 'Backpack',
     rdns: 'app.backpack.mobile',
     iconUrl: async () => (await import('./backpackWallet.svg')).default,
@@ -48,5 +48,5 @@ export const backpackWallet = (): Wallet => {
       },
     },
     createConnector: getInjectedConnector({ namespace: 'backpack.ethereum' }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/baseAccount/baseAccount.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/baseAccount/baseAccount.ts
@@ -3,33 +3,23 @@ import {
   type BaseAccountParameters,
   baseAccount as baseAccountConnector,
 } from 'wagmi/connectors';
-import type { Wallet, WalletDetailsParams } from '../../Wallet';
+import type { Wallet, WalletDetailsParams, WalletFactory } from '../../Wallet';
 
-export interface BaseAccountOptions {
+// supports preference, paymasterUrls, subAccounts
+export interface BaseAccountOptions
+  extends Omit<BaseAccountParameters, 'appName' | 'appLogoUrl'> {
   appName: string;
   appIcon?: string;
 }
 
-// supports preference, paymasterUrls, subAccounts
-type AcceptedBaseAccountParameters = Omit<
-  BaseAccountParameters,
-  'appName' | 'appLogoUrl'
->;
-
-interface BaseAccount extends AcceptedBaseAccountParameters {
-  (params: BaseAccountOptions): Wallet;
-}
-
-export const baseAccount: BaseAccount = ({
+export const baseAccount: WalletFactory<BaseAccountOptions, 'baseAccount'> = ({
   appName,
   appIcon,
-}: BaseAccountOptions): Wallet => {
-  // Extract all AcceptedBaseAccountParameters from baseAccount
-  // This approach avoids type errors for properties not yet in upstream connector
-  const { preference, ...optionalConfig } = baseAccount;
-
+  preference,
+  ...optionalConfig
+}) => {
   return {
-    id: 'baseAccount',
+    id: 'baseAccount' as const,
     name: 'Base Account',
     shortName: 'Base Account',
     rdns: 'app.base.account',
@@ -54,5 +44,5 @@ export const baseAccount: BaseAccount = ({
         ...walletDetails,
       }));
     },
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/berasigWallet/berasigWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/berasigWallet/berasigWallet.ts
@@ -10,14 +10,14 @@ export type BerasigWalletOptions = DefaultWalletOptions;
 export const berasigWallet = ({
   projectId,
   walletConnectParameters,
-}: BerasigWalletOptions): Wallet => {
+}: BerasigWalletOptions) => {
   const isBerasigWalletInjected = hasInjectedProvider({
     namespace: 'berasig.ethereum',
   });
 
   const shouldUseWalletConnect = !isBerasigWalletInjected;
   return {
-    id: 'berasig',
+    id: 'berasig' as const,
     name: 'BeraSig',
     rdns: 'app.berasig',
     iconUrl: async () => (await import('./berasigWallet.svg')).default,
@@ -64,5 +64,5 @@ export const berasigWallet = ({
       : getInjectedConnector({
           namespace: 'berasig.ethereum',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/bestWallet/bestWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bestWallet/bestWallet.ts
@@ -7,49 +7,50 @@ export type BestWalletOptions = DefaultWalletOptions;
 export const bestWallet = ({
   projectId,
   walletConnectParameters,
-}: BestWalletOptions): Wallet => ({
-  id: 'bestWallet',
-  name: 'Best Wallet',
-  iconUrl: async () => (await import('./bestWallet.svg')).default,
-  iconBackground: '#5961FF',
-  downloadUrls: {
-    android: 'https://best.sng.link/Dnio2/rto7?_smtype=3',
-    ios: 'https://best.sng.link/Dnio2/rto7?_smtype=3',
-    mobile: 'https://best.sng.link/Dnio2/rto7?_smtype=3',
-    qrCode: 'https://best.sng.link/Dnio2/rto7?_smtype=3',
-  },
-
-  mobile: {
-    getUri: (uri: string) => {
-      return `bw://connect/wc?uri=${encodeURIComponent(uri)}`;
+}: BestWalletOptions) =>
+  ({
+    id: 'bestWallet' as const,
+    name: 'Best Wallet',
+    iconUrl: async () => (await import('./bestWallet.svg')).default,
+    iconBackground: '#5961FF',
+    downloadUrls: {
+      android: 'https://best.sng.link/Dnio2/rto7?_smtype=3',
+      ios: 'https://best.sng.link/Dnio2/rto7?_smtype=3',
+      mobile: 'https://best.sng.link/Dnio2/rto7?_smtype=3',
+      qrCode: 'https://best.sng.link/Dnio2/rto7?_smtype=3',
     },
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl: 'https://best.sng.link/Dnio2/rto7?_smtype=3',
-      steps: [
-        {
-          description: 'wallet_connectors.best.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.best.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.best.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.best.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.best.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.best.qr_code.step3.title',
-        },
-      ],
-    },
-  },
 
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    mobile: {
+      getUri: (uri: string) => {
+        return `bw://connect/wc?uri=${encodeURIComponent(uri)}`;
+      },
+    },
+    qrCode: {
+      getUri: (uri: string) => uri,
+      instructions: {
+        learnMoreUrl: 'https://best.sng.link/Dnio2/rto7?_smtype=3',
+        steps: [
+          {
+            description: 'wallet_connectors.best.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.best.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.best.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.best.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.best.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.best.qr_code.step3.title',
+          },
+        ],
+      },
+    },
+
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/bifrostWallet/bifrostWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bifrostWallet/bifrostWallet.ts
@@ -12,7 +12,7 @@ export type BifrostWalletOptions = DefaultWalletOptions;
 export const bifrostWallet = ({
   projectId,
   walletConnectParameters,
-}: BifrostWalletOptions): Wallet => {
+}: BifrostWalletOptions) => {
   const isBifrostInjected = hasInjectedProvider({ flag: 'isBifrost' });
 
   const shouldUseWalletConnect = !isBifrostInjected;
@@ -24,7 +24,7 @@ export const bifrostWallet = ({
   };
 
   return {
-    id: 'bifrostWallet',
+    id: 'bifrostWallet' as const,
     name: 'Bifrost Wallet',
     rdns: 'com.bifrostwallet',
     iconUrl: async () => (await import('./bifrostWallet.svg')).default,
@@ -77,5 +77,5 @@ export const bifrostWallet = ({
       : getInjectedConnector({
           flag: 'isBifrost',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
@@ -11,7 +11,7 @@ export type BinanceWalletOptions = DefaultWalletOptions;
 export const binanceWallet = ({
   projectId,
   walletConnectParameters,
-}: BinanceWalletOptions): Wallet => {
+}: BinanceWalletOptions) => {
   const isBinanceInjected = hasInjectedProvider({
     namespace: 'binancew3w.isExtension',
     flag: 'isBinance',
@@ -19,7 +19,7 @@ export const binanceWallet = ({
   const shouldUseWalletConnect = !isBinanceInjected;
 
   return {
-    id: 'binance',
+    id: 'binance' as const,
     name: 'Binance Wallet',
     rdns: 'com.binance.wallet',
     iconUrl: async () => (await import('./binanceWallet.svg')).default,
@@ -80,5 +80,5 @@ export const binanceWallet = ({
       : getInjectedConnector({
           flag: 'isBinance',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitgetWallet/bitgetWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitgetWallet/bitgetWallet.ts
@@ -11,7 +11,7 @@ export type BitgetWalletOptions = DefaultWalletOptions;
 export const bitgetWallet = ({
   projectId,
   walletConnectParameters,
-}: BitgetWalletOptions): Wallet => {
+}: BitgetWalletOptions) => {
   const isBitKeepInjected = hasInjectedProvider({
     namespace: 'bitkeep.ethereum',
     flag: 'isBitKeep',
@@ -19,7 +19,7 @@ export const bitgetWallet = ({
   const shouldUseWalletConnect = !isBitKeepInjected;
 
   return {
-    id: 'bitget',
+    id: 'bitget' as const,
     name: 'Bitget Wallet',
     rdns: 'com.bitget.web3',
     iconUrl: async () => (await import('./bitgetWallet.svg')).default,
@@ -106,5 +106,5 @@ export const bitgetWallet = ({
           namespace: 'bitkeep.ethereum',
           flag: 'isBitKeep',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
@@ -4,39 +4,40 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const bitskiWallet = (): Wallet => ({
-  id: 'bitski',
-  name: 'Bitski',
-  installed: hasInjectedProvider({ flag: 'isBitski' }),
-  iconUrl: async () => (await import('./bitskiWallet.svg')).default,
-  iconBackground: '#fff',
-  downloadUrls: {
-    chrome:
-      'https://chrome.google.com/webstore/detail/bitski/feejiigddaafeojfddjjlmfkabimkell',
-    browserExtension: 'https://bitski.com',
-  },
-  extension: {
-    instructions: {
-      learnMoreUrl:
-        'https://bitski.zendesk.com/hc/articles/12803972818836-How-to-install-the-Bitski-browser-extension',
-      steps: [
-        {
-          description: 'wallet_connectors.bitski.extension.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.bitski.extension.step1.title',
-        },
-        {
-          description: 'wallet_connectors.bitski.extension.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.bitski.extension.step2.title',
-        },
-        {
-          description: 'wallet_connectors.bitski.extension.step3.description',
-          step: 'refresh',
-          title: 'wallet_connectors.bitski.extension.step3.title',
-        },
-      ],
+export const bitskiWallet = () =>
+  ({
+    id: 'bitski' as const,
+    name: 'Bitski',
+    installed: hasInjectedProvider({ flag: 'isBitski' }),
+    iconUrl: async () => (await import('./bitskiWallet.svg')).default,
+    iconBackground: '#fff',
+    downloadUrls: {
+      chrome:
+        'https://chrome.google.com/webstore/detail/bitski/feejiigddaafeojfddjjlmfkabimkell',
+      browserExtension: 'https://bitski.com',
     },
-  },
-  createConnector: getInjectedConnector({ flag: 'isBitski' }),
-});
+    extension: {
+      instructions: {
+        learnMoreUrl:
+          'https://bitski.zendesk.com/hc/articles/12803972818836-How-to-install-the-Bitski-browser-extension',
+        steps: [
+          {
+            description: 'wallet_connectors.bitski.extension.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.bitski.extension.step1.title',
+          },
+          {
+            description: 'wallet_connectors.bitski.extension.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.bitski.extension.step2.title',
+          },
+          {
+            description: 'wallet_connectors.bitski.extension.step3.description',
+            step: 'refresh',
+            title: 'wallet_connectors.bitski.extension.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getInjectedConnector({ flag: 'isBitski' }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitverseWallet/bitverseWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitverseWallet/bitverseWallet.ts
@@ -6,46 +6,47 @@ export type BitverseWalletOptions = DefaultWalletOptions;
 export const bitverseWallet = ({
   projectId,
   walletConnectParameters,
-}: BitverseWalletOptions): Wallet => ({
-  id: 'bitverse',
-  name: 'Bitverse Wallet',
-  iconUrl: async () => (await import('./bitverseWallet.svg')).default,
-  iconBackground: '#171728',
-  downloadUrls: {
-    android:
-      'https://play.google.com/store/apps/details?id=com.bitverse.app&pli=1',
-    ios: 'https://apps.apple.com/us/app/bitverse-discover-web3-wealth/id1645515614',
-    qrCode: 'https://www.bitverse.zone/download',
-  },
-  mobile: {
-    getUri: (uri: string) =>
-      `bitverseapp://open/wallet/wc?uri=${encodeURIComponent(uri)}`,
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl: 'https://www.bitverse.zone',
-      steps: [
-        {
-          description: 'wallet_connectors.bitverse.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.bitverse.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.bitverse.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.bitverse.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.bitverse.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.bitverse.qr_code.step3.title',
-        },
-      ],
+}: BitverseWalletOptions) =>
+  ({
+    id: 'bitverse' as const,
+    name: 'Bitverse Wallet',
+    iconUrl: async () => (await import('./bitverseWallet.svg')).default,
+    iconBackground: '#171728',
+    downloadUrls: {
+      android:
+        'https://play.google.com/store/apps/details?id=com.bitverse.app&pli=1',
+      ios: 'https://apps.apple.com/us/app/bitverse-discover-web3-wealth/id1645515614',
+      qrCode: 'https://www.bitverse.zone/download',
     },
-  },
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    mobile: {
+      getUri: (uri: string) =>
+        `bitverseapp://open/wallet/wc?uri=${encodeURIComponent(uri)}`,
+    },
+    qrCode: {
+      getUri: (uri: string) => uri,
+      instructions: {
+        learnMoreUrl: 'https://www.bitverse.zone',
+        steps: [
+          {
+            description: 'wallet_connectors.bitverse.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.bitverse.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.bitverse.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.bitverse.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.bitverse.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.bitverse.qr_code.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/bloomWallet/bloomWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bloomWallet/bloomWallet.ts
@@ -4,41 +4,42 @@ import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 export const bloomWallet = ({
   projectId,
   walletConnectParameters,
-}: DefaultWalletOptions): Wallet => ({
-  id: 'bloom',
-  name: 'Bloom Wallet',
-  iconBackground: '#000',
-  iconAccent: '#000',
-  iconUrl: async () => (await import('./bloomWallet.svg')).default,
-  downloadUrls: {
-    desktop: 'https://bloomwallet.io/',
-  },
-  desktop: {
-    getUri: (uri: string) =>
-      `bloom://wallet-connect/wc?uri=${encodeURIComponent(uri)}`,
-    instructions: {
-      learnMoreUrl: 'https://bloomwallet.io/',
-      steps: [
-        {
-          description: 'wallet_connectors.bloom.desktop.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.bloom.desktop.step1.title',
-        },
-        {
-          description: 'wallet_connectors.bloom.desktop.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.bloom.desktop.step2.title',
-        },
-        {
-          description: 'wallet_connectors.bloom.desktop.step3.description',
-          step: 'refresh',
-          title: 'wallet_connectors.bloom.desktop.step3.title',
-        },
-      ],
+}: DefaultWalletOptions) =>
+  ({
+    id: 'bloom' as const,
+    name: 'Bloom Wallet',
+    iconBackground: '#000',
+    iconAccent: '#000',
+    iconUrl: async () => (await import('./bloomWallet.svg')).default,
+    downloadUrls: {
+      desktop: 'https://bloomwallet.io/',
     },
-  },
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    desktop: {
+      getUri: (uri: string) =>
+        `bloom://wallet-connect/wc?uri=${encodeURIComponent(uri)}`,
+      instructions: {
+        learnMoreUrl: 'https://bloomwallet.io/',
+        steps: [
+          {
+            description: 'wallet_connectors.bloom.desktop.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.bloom.desktop.step1.title',
+          },
+          {
+            description: 'wallet_connectors.bloom.desktop.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.bloom.desktop.step2.title',
+          },
+          {
+            description: 'wallet_connectors.bloom.desktop.step3.description',
+            step: 'refresh',
+            title: 'wallet_connectors.bloom.desktop.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
@@ -4,18 +4,19 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const braveWallet = (): Wallet => ({
-  id: 'brave',
-  name: 'Brave Wallet',
-  rdns: 'com.brave.wallet',
-  iconUrl: async () => (await import('./braveWallet.svg')).default,
-  iconBackground: '#fff',
-  installed: hasInjectedProvider({ flag: 'isBraveWallet' }),
-  downloadUrls: {
-    // We're opting not to provide a download prompt if Brave isn't the current
-    // browser since it's unlikely to be a desired behavior for users. It's
-    // more of a convenience for users who are already using Brave rather than
-    // an explicit wallet choice for users coming from other browsers.
-  },
-  createConnector: getInjectedConnector({ flag: 'isBraveWallet' }),
-});
+export const braveWallet = () =>
+  ({
+    id: 'brave' as const,
+    name: 'Brave Wallet',
+    rdns: 'com.brave.wallet',
+    iconUrl: async () => (await import('./braveWallet.svg')).default,
+    iconBackground: '#fff',
+    installed: hasInjectedProvider({ flag: 'isBraveWallet' }),
+    downloadUrls: {
+      // We're opting not to provide a download prompt if Brave isn't the current
+      // browser since it's unlikely to be a desired behavior for users. It's
+      // more of a convenience for users who are already using Brave rather than
+      // an explicit wallet choice for users coming from other browsers.
+    },
+    createConnector: getInjectedConnector({ flag: 'isBraveWallet' }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/bybitWallet/bybitWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bybitWallet/bybitWallet.ts
@@ -10,7 +10,7 @@ export type BifrostWalletOptions = DefaultWalletOptions;
 export const bybitWallet = ({
   projectId,
   walletConnectParameters,
-}: BifrostWalletOptions): Wallet => {
+}: BifrostWalletOptions) => {
   const isBybitInjected = hasInjectedProvider({
     namespace: 'bybitWallet',
   });
@@ -24,7 +24,7 @@ export const bybitWallet = ({
   };
 
   return {
-    id: 'bybit',
+    id: 'bybit' as const,
     name: 'Bybit Wallet',
     rdns: 'com.bybit',
     iconUrl: async () => (await import('./bybitWallet.svg')).default,
@@ -100,5 +100,5 @@ export const bybitWallet = ({
       : getInjectedConnector({
           namespace: 'bybitWallet',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/clvWallet/clvWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/clvWallet/clvWallet.ts
@@ -10,12 +10,12 @@ export type CLVWalletOptions = DefaultWalletOptions;
 export const clvWallet = ({
   projectId,
   walletConnectParameters,
-}: CLVWalletOptions): Wallet => {
+}: CLVWalletOptions) => {
   const isCLVInjected = hasInjectedProvider({ namespace: 'clover' });
   const shouldUseWalletConnect = !isCLVInjected;
 
   return {
-    id: 'clv',
+    id: 'clv' as const,
     name: 'CLV',
     iconUrl: async () => (await import('./clvWallet.svg')).default,
     iconBackground: '#fff',
@@ -84,5 +84,5 @@ export const clvWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({ namespace: 'clover' }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
@@ -10,7 +10,7 @@ export type Coin98WalletOptions = DefaultWalletOptions;
 export const coin98Wallet = ({
   projectId,
   walletConnectParameters,
-}: Coin98WalletOptions): Wallet => {
+}: Coin98WalletOptions) => {
   const isCoin98WalletInjected = hasInjectedProvider({
     namespace: 'coin98.provider',
     flag: 'isCoin98',
@@ -18,7 +18,7 @@ export const coin98Wallet = ({
 
   const shouldUseWalletConnect = !isCoin98WalletInjected;
   return {
-    id: 'coin98',
+    id: 'coin98' as const,
     name: 'Coin98 Wallet',
     iconUrl: async () => (await import('./coin98Wallet.svg')).default,
     installed: !shouldUseWalletConnect ? isCoin98WalletInjected : undefined,
@@ -97,5 +97,5 @@ export const coin98Wallet = ({
           namespace: 'coin98Wallet',
           flag: 'isCoin98',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
@@ -4,39 +4,30 @@ import {
   coinbaseWallet as coinbaseConnector,
 } from 'wagmi/connectors';
 import { isIOS } from '../../../utils/isMobile';
-import type { Wallet, WalletDetailsParams } from '../../Wallet';
-
-export interface CoinbaseWalletOptions {
-  appName: string;
-  appIcon?: string;
-}
+import type { Wallet, WalletDetailsParams, WalletFactory } from '../../Wallet';
 
 // supports preference, paymasterUrls, subAccounts
-type AcceptedCoinbaseWalletParameters = Omit<
-  CoinbaseWalletParameters<'4'>,
-  'headlessMode' | 'version' | 'appName' | 'appLogoUrl'
->;
-
-interface CoinbaseWallet extends AcceptedCoinbaseWalletParameters {
-  (params: CoinbaseWalletOptions): Wallet;
+export interface CoinbaseWalletOptions
+  extends Omit<
+    CoinbaseWalletParameters<'4'>,
+    'headlessMode' | 'version' | 'appName' | 'appLogoUrl'
+  > {
+  appName: string;
+  appIcon?: string;
 }
 
 /**
  * @deprecated Use `baseAccount` instead. This wallet connector will be removed in a future version.
  */
-export const coinbaseWallet: CoinbaseWallet = ({
-  appName,
-  appIcon,
-}: CoinbaseWalletOptions): Wallet => {
-  // Extract all AcceptedCoinbaseWalletParameters from coinbaseWallet
-  // This approach avoids type errors for properties not yet in upstream connector
-  const { preference, ...optionalConfig } = coinbaseWallet;
-
+export const coinbaseWallet: WalletFactory<
+  CoinbaseWalletOptions,
+  'coinbase'
+> = ({ appName, appIcon, preference, ...optionalConfig }) => {
   const getUri = (uri: string) => uri;
   const ios = isIOS();
 
   return {
-    id: 'coinbase',
+    id: 'coinbase' as const,
     name: 'Coinbase Wallet',
     shortName: 'Coinbase',
     rdns: 'com.coinbase.wallet',
@@ -132,5 +123,5 @@ export const coinbaseWallet: CoinbaseWallet = ({
         ...walletDetails,
       }));
     },
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/compassWallet/compassWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/compassWallet/compassWallet.ts
@@ -4,11 +4,11 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const compassWallet = (): Wallet => {
+export const compassWallet = () => {
   const isCompassInjected = hasInjectedProvider({ namespace: 'compassEvm' });
 
   return {
-    id: 'compass',
+    id: 'compass' as const,
     name: 'Compass Wallet',
     installed: isCompassInjected,
     rdns: 'io.leapwallet.CompassWallet',
@@ -45,5 +45,5 @@ export const compassWallet = (): Wallet => {
       },
     },
     createConnector: getInjectedConnector({ namespace: 'compassEvm' }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/coreWallet/coreWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coreWallet/coreWallet.ts
@@ -10,14 +10,14 @@ export type CoreWalletOptions = DefaultWalletOptions;
 export const coreWallet = ({
   projectId,
   walletConnectParameters,
-}: CoreWalletOptions): Wallet => {
+}: CoreWalletOptions) => {
   const isCoreInjected = hasInjectedProvider({
     namespace: 'avalanche',
     flag: 'isAvalanche',
   });
   const shouldUseWalletConnect = !isCoreInjected;
   return {
-    id: 'core',
+    id: 'core' as const,
     name: 'Core',
     rdns: 'app.core.extension',
     iconUrl: async () => (await import('./coreWallet.svg')).default,
@@ -92,5 +92,5 @@ export const coreWallet = ({
           namespace: 'avalanche',
           flag: 'isAvalanche',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/ctrlWallet/ctrlWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ctrlWallet/ctrlWallet.ts
@@ -4,9 +4,9 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const ctrlWallet = (): Wallet => {
-  return {
-    id: 'ctrl',
+export const ctrlWallet = () =>
+  ({
+    id: 'ctrl' as const,
     name: 'CTRL Wallet',
     rdns: 'xyz.ctrl',
     installed: hasInjectedProvider({ namespace: 'ctrl.ethereum' }),
@@ -39,9 +39,8 @@ export const ctrlWallet = (): Wallet => {
         ],
       },
     },
-    createConnector: getInjectedConnector({ namespace: 'xfi.ethereum' }),
-  };
-};
+    createConnector: getInjectedConnector({ namespace: 'ctrl.ethereum' }),
+  }) satisfies Wallet;
 
 /**
  * @deprecated Use `ctrlWallet` instead. This wallet connector will be removed in a future version.

--- a/packages/rainbowkit/src/wallets/walletConnectors/dawnWallet/dawnWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/dawnWallet/dawnWallet.ts
@@ -5,16 +5,17 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const dawnWallet = (): Wallet => ({
-  id: 'dawn',
-  name: 'Dawn',
-  iconUrl: async () => (await import('./dawnWallet.svg')).default,
-  iconBackground: '#000000',
-  installed: hasInjectedProvider({ flag: 'isDawn' }),
-  hidden: () => !isIOS(),
-  downloadUrls: {
-    ios: 'https://apps.apple.com/us/app/dawn-ethereum-wallet/id1673143782',
-    mobile: 'https://dawnwallet.xyz',
-  },
-  createConnector: getInjectedConnector({ flag: 'isDawn' }),
-});
+export const dawnWallet = () =>
+  ({
+    id: 'dawn' as const,
+    name: 'Dawn',
+    iconUrl: async () => (await import('./dawnWallet.svg')).default,
+    iconBackground: '#000000',
+    installed: hasInjectedProvider({ flag: 'isDawn' }),
+    hidden: () => !isIOS(),
+    downloadUrls: {
+      ios: 'https://apps.apple.com/us/app/dawn-ethereum-wallet/id1673143782',
+      mobile: 'https://dawnwallet.xyz',
+    },
+    createConnector: getInjectedConnector({ flag: 'isDawn' }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/desigWallet/desigWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/desigWallet/desigWallet.ts
@@ -4,9 +4,9 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const desigWallet = (): Wallet => {
+export const desigWallet = () => {
   return {
-    id: 'desig',
+    id: 'desig' as const,
     name: 'Desig Wallet',
     iconUrl: async () => (await import('./desigWallet.svg')).default,
     iconBackground: '#ffffff',
@@ -44,5 +44,5 @@ export const desigWallet = (): Wallet => {
     createConnector: getInjectedConnector({
       namespace: 'desig.ethereum',
     }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/enkryptWallet/enkryptWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/enkryptWallet/enkryptWallet.ts
@@ -4,9 +4,9 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const enkryptWallet = (): Wallet => {
+export const enkryptWallet = () => {
   return {
-    id: 'enkrypt',
+    id: 'enkrypt' as const,
     name: 'Enkrypt Wallet',
     rdns: 'com.enkrypt',
     installed: hasInjectedProvider({ namespace: 'enkrypt.providers.ethereum' }),
@@ -50,5 +50,5 @@ export const enkryptWallet = (): Wallet => {
     createConnector: getInjectedConnector({
       namespace: 'enkrypt.providers.ethereum',
     }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/foxWallet/foxWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/foxWallet/foxWallet.ts
@@ -10,14 +10,14 @@ export type FoxWalletOptions = DefaultWalletOptions;
 export const foxWallet = ({
   projectId,
   walletConnectParameters,
-}: FoxWalletOptions): Wallet => {
+}: FoxWalletOptions) => {
   const isFoxInjected = hasInjectedProvider({
     namespace: 'foxwallet.ethereum',
   });
   const shouldUseWalletConnect = !isFoxInjected;
 
   return {
-    id: 'foxwallet',
+    id: 'foxwallet' as const,
     name: 'FoxWallet',
     iconUrl: async () => (await import('./foxWallet.svg')).default,
     iconBackground: '#fff',
@@ -66,5 +66,5 @@ export const foxWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({ namespace: 'foxwallet.ethereum' }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/frameWallet/frameWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/frameWallet/frameWallet.ts
@@ -4,38 +4,39 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const frameWallet = (): Wallet => ({
-  id: 'frame',
-  name: 'Frame',
-  rdns: 'sh.frame',
-  installed: hasInjectedProvider({ flag: 'isFrame' }),
-  iconUrl: async () => (await import('./frameWallet.svg')).default,
-  iconBackground: '#121C20',
-  downloadUrls: {
-    browserExtension: 'https://frame.sh/',
-  },
-  extension: {
-    instructions: {
-      learnMoreUrl:
-        'https://docs.frame.sh/docs/Getting%20Started/Installation/',
-      steps: [
-        {
-          description: 'wallet_connectors.frame.extension.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.frame.extension.step1.title',
-        },
-        {
-          description: 'wallet_connectors.frame.extension.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.frame.extension.step2.title',
-        },
-        {
-          description: 'wallet_connectors.frame.extension.step3.description',
-          step: 'refresh',
-          title: 'wallet_connectors.frame.extension.step3.title',
-        },
-      ],
+export const frameWallet = () =>
+  ({
+    id: 'frame' as const,
+    name: 'Frame',
+    rdns: 'sh.frame',
+    installed: hasInjectedProvider({ flag: 'isFrame' }),
+    iconUrl: async () => (await import('./frameWallet.svg')).default,
+    iconBackground: '#121C20',
+    downloadUrls: {
+      browserExtension: 'https://frame.sh/',
     },
-  },
-  createConnector: getInjectedConnector({ flag: 'isFrame' }),
-});
+    extension: {
+      instructions: {
+        learnMoreUrl:
+          'https://docs.frame.sh/docs/Getting%20Started/Installation/',
+        steps: [
+          {
+            description: 'wallet_connectors.frame.extension.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.frame.extension.step1.title',
+          },
+          {
+            description: 'wallet_connectors.frame.extension.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.frame.extension.step2.title',
+          },
+          {
+            description: 'wallet_connectors.frame.extension.step3.description',
+            step: 'refresh',
+            title: 'wallet_connectors.frame.extension.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getInjectedConnector({ flag: 'isFrame' }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/frontierWallet/frontierWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/frontierWallet/frontierWallet.ts
@@ -12,14 +12,14 @@ export type FrontierWalletOptions = DefaultWalletOptions;
 export const frontierWallet = ({
   projectId,
   walletConnectParameters,
-}: FrontierWalletOptions): Wallet => {
+}: FrontierWalletOptions) => {
   const isFrontierInjected = hasInjectedProvider({
     namespace: 'frontier.ethereum',
     flag: 'isFrontier',
   });
   const shouldUseWalletConnect = !isFrontierInjected;
   return {
-    id: 'frontier',
+    id: 'frontier' as const,
     name: 'Frontier Wallet',
     rdns: 'xyz.frontier.wallet',
     installed: !shouldUseWalletConnect ? isFrontierInjected : undefined,
@@ -108,5 +108,5 @@ export const frontierWallet = ({
           namespace: 'frontier.ethereum',
           flag: 'isFrontier',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/gateWallet/gateWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/gateWallet/gateWallet.ts
@@ -11,12 +11,12 @@ export type GateWalletOptions = DefaultWalletOptions;
 export const gateWallet = ({
   projectId,
   walletConnectParameters,
-}: GateWalletOptions): Wallet => {
+}: GateWalletOptions) => {
   const isGateInjected = hasInjectedProvider({ namespace: 'gatewallet' });
   const shouldUseWalletConnect = !isGateInjected;
 
   return {
-    id: 'gate',
+    id: 'gate' as const,
     name: 'Gate Wallet',
     rdns: 'io.gate.wallet',
     iconUrl: async () => (await import('./gateWallet.svg')).default,
@@ -95,5 +95,5 @@ export const gateWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({ namespace: 'gatewallet' }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/geminiWallet/geminiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/geminiWallet/geminiWallet.ts
@@ -1,18 +1,21 @@
 import { type CreateConnectorFn, createConnector } from 'wagmi';
-import { gemini } from 'wagmi/connectors';
-import type { Wallet, WalletDetailsParams } from '../../Wallet';
+import { gemini, type GeminiParameters } from 'wagmi/connectors';
+import type { Wallet, WalletDetailsParams, WalletFactory } from '../../Wallet';
 
-export interface GeminiWalletOptions {
+type AcceptedGeminiParameters = Omit<GeminiParameters, 'appMetadata'>;
+
+export interface GeminiWalletOptions extends AcceptedGeminiParameters {
   appName: string;
   appIcon?: string;
 }
 
-export const geminiWallet = ({
+export const geminiWallet: WalletFactory<GeminiWalletOptions, 'gemini'> = ({
   appName,
   appIcon,
-}: GeminiWalletOptions): Wallet => {
+  ...optionalConfig
+}) => {
   return {
-    id: 'gemini',
+    id: 'gemini' as const,
     name: 'Gemini Wallet',
     shortName: 'Gemini',
     rdns: 'com.gemini.wallet',
@@ -78,6 +81,7 @@ export const geminiWallet = ({
           name: appName,
           icon: appIcon,
         },
+        ...optionalConfig,
       });
 
       return createConnector((config) => ({
@@ -85,5 +89,5 @@ export const geminiWallet = ({
         ...walletDetails,
       }));
     },
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/imTokenWallet/imTokenWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/imTokenWallet/imTokenWallet.ts
@@ -6,51 +6,52 @@ export type ImTokenWalletOptions = DefaultWalletOptions;
 export const imTokenWallet = ({
   projectId,
   walletConnectParameters,
-}: ImTokenWalletOptions): Wallet => ({
-  id: 'imToken',
-  name: 'imToken',
-  iconUrl: async () => (await import('./imTokenWallet.svg')).default,
-  iconBackground: '#098de6',
-  downloadUrls: {
-    android: 'https://play.google.com/store/apps/details?id=im.token.app',
-    ios: 'https://itunes.apple.com/us/app/imtoken2/id1384798940',
-    mobile: 'https://token.im/download',
-    qrCode: 'https://token.im/download',
-  },
-  mobile: {
-    getUri: (uri: string) => {
-      return `imtokenv2://wc?uri=${encodeURIComponent(uri)}`;
+}: ImTokenWalletOptions) =>
+  ({
+    id: 'imToken' as const,
+    name: 'imToken',
+    iconUrl: async () => (await import('./imTokenWallet.svg')).default,
+    iconBackground: '#098de6',
+    downloadUrls: {
+      android: 'https://play.google.com/store/apps/details?id=im.token.app',
+      ios: 'https://itunes.apple.com/us/app/imtoken2/id1384798940',
+      mobile: 'https://token.im/download',
+      qrCode: 'https://token.im/download',
     },
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl:
-        typeof window !== 'undefined' &&
-        window.navigator.language.includes('zh')
-          ? 'https://support.token.im/hc/zh-cn/categories/360000925393'
-          : 'https://support.token.im/hc/en-us/categories/360000925393',
-      steps: [
-        {
-          description: 'wallet_connectors.im_token.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.im_token.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.im_token.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.im_token.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.im_token.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.im_token.qr_code.step3.title',
-        },
-      ],
+    mobile: {
+      getUri: (uri: string) => {
+        return `imtokenv2://wc?uri=${encodeURIComponent(uri)}`;
+      },
     },
-  },
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    qrCode: {
+      getUri: (uri: string) => uri,
+      instructions: {
+        learnMoreUrl:
+          typeof window !== 'undefined' &&
+          window.navigator.language.includes('zh')
+            ? 'https://support.token.im/hc/zh-cn/categories/360000925393'
+            : 'https://support.token.im/hc/en-us/categories/360000925393',
+        steps: [
+          {
+            description: 'wallet_connectors.im_token.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.im_token.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.im_token.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.im_token.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.im_token.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.im_token.qr_code.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
@@ -1,10 +1,11 @@
 import type { Wallet } from '../../Wallet';
 import { getInjectedConnector } from '../../getInjectedConnector';
 
-export const injectedWallet = (): Wallet => ({
-  id: 'injected',
-  name: 'Browser Wallet',
-  iconUrl: async () => (await import('./injectedWallet.svg')).default,
-  iconBackground: '#fff',
-  createConnector: getInjectedConnector({}),
-});
+export const injectedWallet = () =>
+  ({
+    id: 'injected' as const,
+    name: 'Browser Wallet',
+    iconUrl: async () => (await import('./injectedWallet.svg')).default,
+    iconBackground: '#fff',
+    createConnector: getInjectedConnector({}),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/iopayWallet/iopayWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/iopayWallet/iopayWallet.ts
@@ -17,50 +17,51 @@ function isIoPayMobile(): boolean {
 export const iopayWallet = ({
   projectId,
   walletConnectParameters,
-}: IoPayWalletOptions): Wallet => ({
-  id: 'iopay',
-  name: 'ioPay Wallet',
-  iconUrl: async () => (await import('./iopayWallet.svg')).default,
-  iconBackground: '#fff',
-  downloadUrls: {
-    android:
-      'https://play.google.com/store/apps/details?id=io.iotex.iopay.gp&pli=1',
-    ios: 'https://apps.apple.com/us/app/iopay-multichain-crypto-wallet/id1478086371',
-    qrCode: 'https://iopay.me/',
-    browserExtension: 'https://iopay.me/',
-  },
-  mobile: {
-    getUri: (uri: string) => {
-      return isAndroid() ? uri : `iopay://wc?uri=${encodeURIComponent(uri)}`;
+}: IoPayWalletOptions) =>
+  ({
+    id: 'iopay' as const,
+    name: 'ioPay Wallet',
+    iconUrl: async () => (await import('./iopayWallet.svg')).default,
+    iconBackground: '#fff',
+    downloadUrls: {
+      android:
+        'https://play.google.com/store/apps/details?id=io.iotex.iopay.gp&pli=1',
+      ios: 'https://apps.apple.com/us/app/iopay-multichain-crypto-wallet/id1478086371',
+      qrCode: 'https://iopay.me/',
+      browserExtension: 'https://iopay.me/',
     },
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl: 'https://iopay.me/',
-      steps: [
-        {
-          description: 'wallet_connectors.iopay.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.iopay.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.iopay.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.iopay.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.iopay.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.iopay.qr_code.step3.title',
-        },
-      ],
+    mobile: {
+      getUri: (uri: string) => {
+        return isAndroid() ? uri : `iopay://wc?uri=${encodeURIComponent(uri)}`;
+      },
     },
-  },
-  createConnector: isIoPayMobile()
-    ? getInjectedConnector({})
-    : getWalletConnectConnector({
-        projectId,
-        walletConnectParameters,
-      }),
-});
+    qrCode: {
+      getUri: (uri: string) => uri,
+      instructions: {
+        learnMoreUrl: 'https://iopay.me/',
+        steps: [
+          {
+            description: 'wallet_connectors.iopay.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.iopay.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.iopay.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.iopay.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.iopay.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.iopay.qr_code.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: isIoPayMobile()
+      ? getInjectedConnector({})
+      : getWalletConnectConnector({
+          projectId,
+          walletConnectParameters,
+        }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/kaiaWallet/kaiaWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kaiaWallet/kaiaWallet.ts
@@ -10,7 +10,7 @@ export type KaiaWalletOptions = DefaultWalletOptions;
 export const kaiaWallet = ({
   projectId,
   walletConnectParameters,
-}: KaiaWalletOptions): Wallet => {
+}: KaiaWalletOptions) => {
   const isKaiaWalletInjected = hasInjectedProvider({
     namespace: 'klaytn',
   });
@@ -22,7 +22,7 @@ export const kaiaWallet = ({
   };
 
   return {
-    id: 'kaia',
+    id: 'kaia' as const,
     name: 'Kaia Wallet',
     iconUrl: async () => (await import('./kaiaWallet.svg')).default,
     installed: isKaiaWalletInjected || undefined,
@@ -92,5 +92,5 @@ export const kaiaWallet = ({
       : getInjectedConnector({
           namespace: 'klaytn',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
@@ -10,7 +10,7 @@ export type KaikasWalletOptions = DefaultWalletOptions;
 export const kaikasWallet = ({
   projectId,
   walletConnectParameters,
-}: KaikasWalletOptions): Wallet => {
+}: KaikasWalletOptions) => {
   const isKaikasWalletInjected = hasInjectedProvider({
     namespace: 'klaytn',
   });
@@ -22,7 +22,7 @@ export const kaikasWallet = ({
   };
 
   return {
-    id: 'kaikas',
+    id: 'kaikas' as const,
     name: 'Kaikas Wallet',
     iconUrl: async () => (await import('./kaikasWallet.svg')).default,
     installed: isKaikasWalletInjected || undefined,
@@ -95,5 +95,5 @@ export const kaikasWallet = ({
       : getInjectedConnector({
           namespace: 'klaytn',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/krakenWallet/krakenWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/krakenWallet/krakenWallet.ts
@@ -7,48 +7,49 @@ export type KrakenWalletOptions = DefaultWalletOptions;
 export const krakenWallet = ({
   projectId,
   walletConnectParameters,
-}: KrakenWalletOptions): Wallet => ({
-  id: 'kraken',
-  name: 'Kraken Wallet',
-  iconUrl: async () => (await import('./krakenWallet.svg')).default,
-  iconBackground: '#FFD8EA',
-  downloadUrls: {
-    ios: 'https://apps.apple.com/us/app/kraken-wallet/id1626327149',
-    mobile: 'https://kraken.com/wallet',
-    qrCode: 'https://kraken.com/wallet',
-  },
-
-  mobile: {
-    getUri: (uri: string) => {
-      return `krakenwallet://wc?uri=${encodeURIComponent(uri)}`;
+}: KrakenWalletOptions) =>
+  ({
+    id: 'kraken' as const,
+    name: 'Kraken Wallet',
+    iconUrl: async () => (await import('./krakenWallet.svg')).default,
+    iconBackground: '#FFD8EA',
+    downloadUrls: {
+      ios: 'https://apps.apple.com/us/app/kraken-wallet/id1626327149',
+      mobile: 'https://kraken.com/wallet',
+      qrCode: 'https://kraken.com/wallet',
     },
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl: 'https://kraken.com/wallet',
-      steps: [
-        {
-          description: 'wallet_connectors.kraken.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.kraken.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.kraken.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.kraken.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.kraken.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.kraken.qr_code.step3.title',
-        },
-      ],
-    },
-  },
 
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    mobile: {
+      getUri: (uri: string) => {
+        return `krakenwallet://wc?uri=${encodeURIComponent(uri)}`;
+      },
+    },
+    qrCode: {
+      getUri: (uri: string) => uri,
+      instructions: {
+        learnMoreUrl: 'https://kraken.com/wallet',
+        steps: [
+          {
+            description: 'wallet_connectors.kraken.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.kraken.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.kraken.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.kraken.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.kraken.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.kraken.qr_code.step3.title',
+          },
+        ],
+      },
+    },
+
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/kresusWallet/kresusWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kresusWallet/kresusWallet.ts
@@ -6,46 +6,47 @@ export type KresusWalletOptions = DefaultWalletOptions;
 export const kresusWallet = ({
   projectId,
   walletConnectParameters,
-}: KresusWalletOptions): Wallet => ({
-  id: 'kresus-wallet',
-  name: 'Kresus Wallet',
-  iconUrl: async () => (await import('./kresusWallet.svg')).default,
-  iconBackground: '#fff',
-  downloadUrls: {
-    android:
-      'https://play.google.com/store/apps/details?id=com.kresus.superapp',
-    ios: 'https://apps.apple.com/us/app/kresus-crypto-nft-superapp/id6444355152',
-    qrCode: 'https://kresusconnect.kresus.com/download',
-  },
-  mobile: {
-    getUri: (uri: string) =>
-      `com.kresus.superapp://wc?uri=${encodeURIComponent(uri)}`,
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl: 'https://kresus.com/',
-      steps: [
-        {
-          description: 'wallet_connectors.kresus.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.kresus.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.kresus.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.kresus.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.kresus.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.kresus.qr_code.step3.title',
-        },
-      ],
+}: KresusWalletOptions) =>
+  ({
+    id: 'kresus-wallet' as const,
+    name: 'Kresus Wallet',
+    iconUrl: async () => (await import('./kresusWallet.svg')).default,
+    iconBackground: '#fff',
+    downloadUrls: {
+      android:
+        'https://play.google.com/store/apps/details?id=com.kresus.superapp',
+      ios: 'https://apps.apple.com/us/app/kresus-crypto-nft-superapp/id6444355152',
+      qrCode: 'https://kresusconnect.kresus.com/download',
     },
-  },
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    mobile: {
+      getUri: (uri: string) =>
+        `com.kresus.superapp://wc?uri=${encodeURIComponent(uri)}`,
+    },
+    qrCode: {
+      getUri: (uri: string) => uri,
+      instructions: {
+        learnMoreUrl: 'https://kresus.com/',
+        steps: [
+          {
+            description: 'wallet_connectors.kresus.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.kresus.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.kresus.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.kresus.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.kresus.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.kresus.qr_code.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
@@ -7,83 +7,84 @@ export type LedgerWalletOptions = DefaultWalletOptions;
 export const ledgerWallet = ({
   projectId,
   walletConnectParameters,
-}: LedgerWalletOptions): Wallet => ({
-  id: 'ledger',
-  iconBackground: '#000',
-  iconAccent: '#000',
-  name: 'Ledger',
-  iconUrl: async () => (await import('./ledgerWallet.svg')).default,
-  downloadUrls: {
-    android: 'https://play.google.com/store/apps/details?id=com.ledger.live',
-    ios: 'https://apps.apple.com/us/app/ledger-live-web3-wallet/id1361671700',
-    mobile: 'https://www.ledger.com/ledger-live',
-    qrCode: 'https://r354.adj.st/?adj_t=t2esmlk',
-    windows: 'https://www.ledger.com/ledger-live/download',
-    macos: 'https://www.ledger.com/ledger-live/download',
-    linux: 'https://www.ledger.com/ledger-live/download',
-    desktop: 'https://www.ledger.com/ledger-live',
-  },
-  mobile: {
-    getUri: (uri: string) => {
-      return isAndroid()
-        ? uri
-        : `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+}: LedgerWalletOptions) =>
+  ({
+    id: 'ledger' as const,
+    iconBackground: '#000',
+    iconAccent: '#000',
+    name: 'Ledger',
+    iconUrl: async () => (await import('./ledgerWallet.svg')).default,
+    downloadUrls: {
+      android: 'https://play.google.com/store/apps/details?id=com.ledger.live',
+      ios: 'https://apps.apple.com/us/app/ledger-live-web3-wallet/id1361671700',
+      mobile: 'https://www.ledger.com/ledger-live',
+      qrCode: 'https://r354.adj.st/?adj_t=t2esmlk',
+      windows: 'https://www.ledger.com/ledger-live/download',
+      macos: 'https://www.ledger.com/ledger-live/download',
+      linux: 'https://www.ledger.com/ledger-live/download',
+      desktop: 'https://www.ledger.com/ledger-live',
     },
-  },
-  desktop: {
-    getUri: (uri: string) => {
-      return `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+    mobile: {
+      getUri: (uri: string) => {
+        return isAndroid()
+          ? uri
+          : `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+      },
     },
-    instructions: {
-      learnMoreUrl:
-        'https://support.ledger.com/hc/en-us/articles/4404389503889-Getting-started-with-Ledger-Live',
-      steps: [
-        {
-          description: 'wallet_connectors.ledger.desktop.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.ledger.desktop.step1.title',
-        },
-        {
-          description: 'wallet_connectors.ledger.desktop.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.ledger.desktop.step2.title',
-        },
-        {
-          description: 'wallet_connectors.ledger.desktop.step3.description',
-          step: 'connect',
-          title: 'wallet_connectors.ledger.desktop.step3.title',
-        },
-      ],
+    desktop: {
+      getUri: (uri: string) => {
+        return `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+      },
+      instructions: {
+        learnMoreUrl:
+          'https://support.ledger.com/hc/en-us/articles/4404389503889-Getting-started-with-Ledger-Live',
+        steps: [
+          {
+            description: 'wallet_connectors.ledger.desktop.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.ledger.desktop.step1.title',
+          },
+          {
+            description: 'wallet_connectors.ledger.desktop.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.ledger.desktop.step2.title',
+          },
+          {
+            description: 'wallet_connectors.ledger.desktop.step3.description',
+            step: 'connect',
+            title: 'wallet_connectors.ledger.desktop.step3.title',
+          },
+        ],
+      },
     },
-  },
-  qrCode: {
-    getUri: (uri: string) => {
-      return `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+    qrCode: {
+      getUri: (uri: string) => {
+        return `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
+      },
+      instructions: {
+        learnMoreUrl:
+          'https://support.ledger.com/hc/en-us/articles/4404389503889-Getting-started-with-Ledger-Live',
+        steps: [
+          {
+            description: 'wallet_connectors.ledger.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.ledger.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.ledger.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.ledger.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.ledger.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.ledger.qr_code.step3.title',
+          },
+        ],
+      },
     },
-    instructions: {
-      learnMoreUrl:
-        'https://support.ledger.com/hc/en-us/articles/4404389503889-Getting-started-with-Ledger-Live',
-      steps: [
-        {
-          description: 'wallet_connectors.ledger.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.ledger.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.ledger.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.ledger.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.ledger.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.ledger.qr_code.step3.title',
-        },
-      ],
-    },
-  },
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/magicEdenWallet/magicEdenWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/magicEdenWallet/magicEdenWallet.ts
@@ -4,9 +4,9 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const magicEdenWallet = (): Wallet => {
+export const magicEdenWallet = () => {
   return {
-    id: 'magicEden',
+    id: 'magicEden' as const,
     name: 'Magic Eden Wallet',
     rdns: 'io.magiceden.wallet',
     iconUrl: async () => (await import('./magicEden.svg')).default,
@@ -45,5 +45,5 @@ export const magicEdenWallet = (): Wallet => {
     createConnector: getInjectedConnector({
       namespace: 'magicEden.ethereum',
     }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -4,6 +4,7 @@ import type {
   DefaultWalletOptions,
   Wallet,
   WalletDetailsParams,
+  WalletFactory,
 } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import { isMobile } from '../../../utils/isMobile';
@@ -19,10 +20,6 @@ type AcceptedMetaMaskParameters = Omit<
   | 'headless'
   | 'preferDesktop'
 >;
-
-interface MetaMaskWallet extends AcceptedMetaMaskParameters {
-  (params: MetaMaskWalletOptions): Wallet;
-}
 
 function isMetaMask(ethereum?: WindowProvider['ethereum']): boolean {
   // Logic borrowed from wagmi's legacy MetaMaskConnector
@@ -80,14 +77,10 @@ function isMetaMask(ethereum?: WindowProvider['ethereum']): boolean {
   return true;
 }
 
-export const metaMaskWallet: MetaMaskWallet = ({
-  projectId,
-  walletConnectParameters,
-}: MetaMaskWalletOptions): Wallet => {
-  // Extract all AcceptedMetaMaskParameters from metaMaskWallet
-  // This approach avoids type errors for properties not yet in upstream connector
-  const { ...optionalConfig } = metaMaskWallet;
-
+export const metaMaskWallet: WalletFactory<
+  MetaMaskWalletOptions,
+  'metaMask'
+> = ({ projectId, walletConnectParameters, ...optionalConfig }) => {
   // Custom logic to explicitly detect MetaMask
   // Whereas hasInjectedProvider only checks for impersonated `isMetaMask`
   // We need this because MetaMask SDK hangs on impersonated wallets
@@ -100,7 +93,7 @@ export const metaMaskWallet: MetaMaskWallet = ({
   const shouldUseMetaMaskConnector = isMetaMaskInjected || isMobile();
 
   return {
-    id: 'metaMask',
+    id: 'metaMask' as const,
     name: 'MetaMask',
     rdns: 'io.metamask',
     iconUrl: async () => (await import('./metaMaskWallet.svg')).default,
@@ -217,5 +210,5 @@ export const metaMaskWallet: MetaMaskWallet = ({
             };
           });
         },
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -10,8 +10,6 @@ import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import { isMobile } from '../../../utils/isMobile';
 import type { WindowProvider } from '../../../types/utils';
 
-export type MetaMaskWalletOptions = DefaultWalletOptions;
-
 type AcceptedMetaMaskParameters = Omit<
   MetaMaskParameters,
   | 'checkInstallationImmediately'
@@ -20,6 +18,9 @@ type AcceptedMetaMaskParameters = Omit<
   | 'headless'
   | 'preferDesktop'
 >;
+
+export type MetaMaskWalletOptions = DefaultWalletOptions &
+  AcceptedMetaMaskParameters;
 
 function isMetaMask(ethereum?: WindowProvider['ethereum']): boolean {
   // Logic borrowed from wagmi's legacy MetaMaskConnector

--- a/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
@@ -10,7 +10,7 @@ export type MEWWalletOptions = DefaultWalletOptions;
 export const mewWallet = ({
   projectId,
   walletConnectParameters,
-}: MEWWalletOptions): Wallet => {
+}: MEWWalletOptions) => {
   const isMEWInjected = hasInjectedProvider({ flag: 'isMEWwallet' });
   const shouldUseWalletConnect = !isMEWInjected;
 
@@ -20,7 +20,7 @@ export const mewWallet = ({
   };
 
   return {
-    id: 'mew',
+    id: 'mew' as const,
     name: 'MEW wallet',
     iconUrl: async () => (await import('./mewWallet.svg')).default,
     iconBackground: '#fff',
@@ -65,5 +65,5 @@ export const mewWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({ flag: 'isMEWwallet' }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/nestWallet/nestWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/nestWallet/nestWallet.ts
@@ -4,40 +4,41 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const nestWallet = (): Wallet => ({
-  id: 'nest',
-  name: 'Nest',
-  rdns: 'xyz.nestwallet',
-  iconUrl: async () => (await import('./nestWallet.svg')).default,
-  iconBackground: '#fff0',
-  installed: hasInjectedProvider({ flag: 'isNestWallet' }),
-  downloadUrls: {
-    browserExtension: 'https://nestwallet.xyz',
-  },
-  extension: {
-    instructions: {
-      learnMoreUrl: 'https://nestwallet.xyz',
-      steps: [
-        {
-          description:
-            'wallet_connectors.nestwallet.extension.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.nestwallet.extension.step1.title',
-        },
-        {
-          description:
-            'wallet_connectors.nestwallet.extension.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.nestwallet.extension.step2.title',
-        },
-        {
-          description:
-            'wallet_connectors.nestwallet.extension.step3.description',
-          step: 'refresh',
-          title: 'wallet_connectors.nestwallet.extension.step3.title',
-        },
-      ],
+export const nestWallet = () =>
+  ({
+    id: 'nest' as const,
+    name: 'Nest',
+    rdns: 'xyz.nestwallet',
+    iconUrl: async () => (await import('./nestWallet.svg')).default,
+    iconBackground: '#fff0',
+    installed: hasInjectedProvider({ flag: 'isNestWallet' }),
+    downloadUrls: {
+      browserExtension: 'https://nestwallet.xyz',
     },
-  },
-  createConnector: getInjectedConnector({ flag: 'isNestWallet' }),
-});
+    extension: {
+      instructions: {
+        learnMoreUrl: 'https://nestwallet.xyz',
+        steps: [
+          {
+            description:
+              'wallet_connectors.nestwallet.extension.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.nestwallet.extension.step1.title',
+          },
+          {
+            description:
+              'wallet_connectors.nestwallet.extension.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.nestwallet.extension.step2.title',
+          },
+          {
+            description:
+              'wallet_connectors.nestwallet.extension.step3.description',
+            step: 'refresh',
+            title: 'wallet_connectors.nestwallet.extension.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getInjectedConnector({ flag: 'isNestWallet' }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/novaWallet/novaWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/novaWallet/novaWallet.ts
@@ -17,7 +17,7 @@ function isNovaWallet(ethereum?: WindowProvider['ethereum']): boolean {
 export const novaWallet = ({
   projectId,
   walletConnectParameters,
-}: NovaWalletOptions): Wallet => {
+}: NovaWalletOptions) => {
   const isNovaWalletInjected =
     typeof window !== 'undefined' ? isNovaWallet(window.ethereum) : false;
 
@@ -32,7 +32,7 @@ export const novaWallet = ({
   };
 
   return {
-    id: 'nova',
+    id: 'nova' as const,
     name: 'Nova Wallet',
     rdns: 'io.novawallet',
     iconUrl: async () => (await import('./novaWallet.svg')).default,
@@ -80,5 +80,5 @@ export const novaWallet = ({
       : getInjectedConnector({
           namespace: 'ethereum',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/oktoWallet/oktoWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/oktoWallet/oktoWallet.ts
@@ -7,48 +7,49 @@ export type OktoWalletOptions = DefaultWalletOptions;
 export const oktoWallet = ({
   projectId,
   walletConnectParameters,
-}: OktoWalletOptions): Wallet => ({
-  id: 'Okto',
-  name: 'Okto',
-  iconUrl: async () => (await import('./oktoWallet.svg')).default,
-  iconBackground: '#fff',
-  downloadUrls: {
-    android:
-      'https://play.google.com/store/apps/details?id=im.okto.contractwalletclient',
-    ios: 'https://apps.apple.com/in/app/okto-wallet/id6450688229',
-    mobile: 'https://okto.tech/',
-    qrCode: 'https://okto.tech/',
-  },
-  mobile: {
-    getUri: (uri: string) => {
-      return isAndroid() ? uri : `okto://wc?uri=${encodeURIComponent(uri)}`;
+}: OktoWalletOptions) =>
+  ({
+    id: 'Okto' as const,
+    name: 'Okto',
+    iconUrl: async () => (await import('./oktoWallet.svg')).default,
+    iconBackground: '#fff',
+    downloadUrls: {
+      android:
+        'https://play.google.com/store/apps/details?id=im.okto.contractwalletclient',
+      ios: 'https://apps.apple.com/in/app/okto-wallet/id6450688229',
+      mobile: 'https://okto.tech/',
+      qrCode: 'https://okto.tech/',
     },
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl: 'https://okto.tech/',
-      steps: [
-        {
-          description: 'wallet_connectors.okto.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.okto.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.okto.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.okto.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.okto.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.okto.qr_code.step3.title',
-        },
-      ],
+    mobile: {
+      getUri: (uri: string) => {
+        return isAndroid() ? uri : `okto://wc?uri=${encodeURIComponent(uri)}`;
+      },
     },
-  },
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    qrCode: {
+      getUri: (uri: string) => uri,
+      instructions: {
+        learnMoreUrl: 'https://okto.tech/',
+        steps: [
+          {
+            description: 'wallet_connectors.okto.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.okto.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.okto.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.okto.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.okto.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.okto.qr_code.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
@@ -11,12 +11,12 @@ export type OKXWalletOptions = DefaultWalletOptions;
 export const okxWallet = ({
   projectId,
   walletConnectParameters,
-}: OKXWalletOptions): Wallet => {
+}: OKXWalletOptions) => {
   const isOKXInjected = hasInjectedProvider({ namespace: 'okxwallet' });
   const shouldUseWalletConnect = !isOKXInjected;
 
   return {
-    id: 'okx',
+    id: 'okx' as const,
     name: 'OKX Wallet',
     rdns: 'com.okex.wallet',
     iconUrl: async () => (await import('./okxWallet.svg')).default,
@@ -97,5 +97,5 @@ export const okxWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({ namespace: 'okxwallet' }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/omniWallet/omniWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/omniWallet/omniWallet.ts
@@ -7,47 +7,49 @@ export type OmniWalletOptions = DefaultWalletOptions;
 export const omniWallet = ({
   projectId,
   walletConnectParameters,
-}: OmniWalletOptions): Wallet => ({
-  id: 'omni',
-  name: 'Omni',
-  iconUrl: async () => (await import('./omniWallet.svg')).default,
-  iconBackground: '#000',
-  downloadUrls: {
-    android: 'https://play.google.com/store/apps/details?id=fi.steakwallet.app',
-    ios: 'https://itunes.apple.com/us/app/id1569375204',
-    mobile: 'https://omniwallet.app.link',
-    qrCode: 'https://omniwallet.app.link',
-  },
-  mobile: {
-    getUri: (uri: string) => {
-      return isAndroid() ? uri : `omni://wc?uri=${encodeURIComponent(uri)}`;
+}: OmniWalletOptions) =>
+  ({
+    id: 'omni' as const,
+    name: 'Omni',
+    iconUrl: async () => (await import('./omniWallet.svg')).default,
+    iconBackground: '#000',
+    downloadUrls: {
+      android:
+        'https://play.google.com/store/apps/details?id=fi.steakwallet.app',
+      ios: 'https://itunes.apple.com/us/app/id1569375204',
+      mobile: 'https://omniwallet.app.link',
+      qrCode: 'https://omniwallet.app.link',
     },
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl: 'https://omni.app/support',
-      steps: [
-        {
-          description: 'wallet_connectors.omni.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.omni.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.omni.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.omni.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.omni.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.omni.qr_code.step3.title',
-        },
-      ],
+    mobile: {
+      getUri: (uri: string) => {
+        return isAndroid() ? uri : `omni://wc?uri=${encodeURIComponent(uri)}`;
+      },
     },
-  },
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    qrCode: {
+      getUri: (uri: string) => uri,
+      instructions: {
+        learnMoreUrl: 'https://omni.app/support',
+        steps: [
+          {
+            description: 'wallet_connectors.omni.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.omni.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.omni.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.omni.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.omni.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.omni.qr_code.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/oneInchWallet/oneInchWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/oneInchWallet/oneInchWallet.ts
@@ -6,45 +6,47 @@ export type OneInchWalletOptions = DefaultWalletOptions;
 export const oneInchWallet = ({
   projectId,
   walletConnectParameters,
-}: OneInchWalletOptions): Wallet => ({
-  id: '1inch',
-  name: '1inch Wallet',
-  iconUrl: async () => (await import('./oneInchWallet.svg')).default,
-  iconBackground: '#fff',
-  downloadUrls: {
-    android: 'https://play.google.com/store/apps/details?id=io.oneinch.android',
-    ios: 'https://apps.apple.com/us/app/1inch-crypto-defi-wallet/id1546049391',
-    mobile: 'https://1inch.io/wallet',
-    qrCode: 'https://1inch.io/wallet',
-  },
-  mobile: {
-    getUri: (uri: string) => `oneinch://wc?uri=${encodeURIComponent(uri)}`,
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl: 'https://1inch.io/wallet',
-      steps: [
-        {
-          description: 'wallet_connectors.1inch.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.1inch.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.1inch.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.1inch.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.1inch.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.1inch.qr_code.step3.title',
-        },
-      ],
+}: OneInchWalletOptions) =>
+  ({
+    id: '1inch' as const,
+    name: '1inch Wallet',
+    iconUrl: async () => (await import('./oneInchWallet.svg')).default,
+    iconBackground: '#fff',
+    downloadUrls: {
+      android:
+        'https://play.google.com/store/apps/details?id=io.oneinch.android',
+      ios: 'https://apps.apple.com/us/app/1inch-crypto-defi-wallet/id1546049391',
+      mobile: 'https://1inch.io/wallet',
+      qrCode: 'https://1inch.io/wallet',
     },
-  },
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    mobile: {
+      getUri: (uri: string) => `oneinch://wc?uri=${encodeURIComponent(uri)}`,
+    },
+    qrCode: {
+      getUri: (uri: string) => uri,
+      instructions: {
+        learnMoreUrl: 'https://1inch.io/wallet',
+        steps: [
+          {
+            description: 'wallet_connectors.1inch.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.1inch.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.1inch.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.1inch.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.1inch.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.1inch.qr_code.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/oneKeyWallet/oneKeyWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/oneKeyWallet/oneKeyWallet.ts
@@ -4,9 +4,9 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const oneKeyWallet = (): Wallet => {
+export const oneKeyWallet = () => {
   return {
-    id: 'onekey',
+    id: 'onekey' as const,
     name: 'OneKey',
     rdns: 'so.onekey.app.wallet',
     iconAccent: '#00B812',
@@ -54,5 +54,5 @@ export const oneKeyWallet = (): Wallet => {
     createConnector: getInjectedConnector({
       namespace: '$onekey.ethereum',
     }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/paraSwapWallet/paraswapWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/paraSwapWallet/paraswapWallet.ts
@@ -7,46 +7,47 @@ export type ParaSwapWalletOptions = DefaultWalletOptions;
 export const paraSwapWallet = ({
   projectId,
   walletConnectParameters,
-}: ParaSwapWalletOptions): Wallet => ({
-  id: 'paraswap',
-  name: 'ParaSwap Wallet',
-  iconUrl: async () => (await import('./paraSwapWallet.svg')).default,
-  iconBackground: '#578CFC',
-  downloadUrls: {
-    ios: 'https://apps.apple.com/us/app/paraswap-multichain-wallet/id1584610690',
-    mobile: 'https://paraswap.io',
-    qrCode: 'https://paraswap.io',
-  },
-  mobile: {
-    getUri: (uri: string) => {
-      return `paraswap://wc?uri=${encodeURIComponent(uri)}`;
+}: ParaSwapWalletOptions) =>
+  ({
+    id: 'paraswap' as const,
+    name: 'ParaSwap Wallet',
+    iconUrl: async () => (await import('./paraSwapWallet.svg')).default,
+    iconBackground: '#578CFC',
+    downloadUrls: {
+      ios: 'https://apps.apple.com/us/app/paraswap-multichain-wallet/id1584610690',
+      mobile: 'https://paraswap.io',
+      qrCode: 'https://paraswap.io',
     },
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl: 'https://paraswap.io',
-      steps: [
-        {
-          description: 'wallet_connectors.paraswap.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.paraswap.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.paraswap.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.paraswap.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.paraswap.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.paraswap.qr_code.step3.title',
-        },
-      ],
+    mobile: {
+      getUri: (uri: string) => {
+        return `paraswap://wc?uri=${encodeURIComponent(uri)}`;
+      },
     },
-  },
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    qrCode: {
+      getUri: (uri: string) => uri,
+      instructions: {
+        learnMoreUrl: 'https://paraswap.io',
+        steps: [
+          {
+            description: 'wallet_connectors.paraswap.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.paraswap.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.paraswap.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.paraswap.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.paraswap.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.paraswap.qr_code.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/phantomWallet/phantomWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/phantomWallet/phantomWallet.ts
@@ -4,9 +4,9 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const phantomWallet = (): Wallet => {
+export const phantomWallet = () => {
   return {
-    id: 'phantom',
+    id: 'phantom' as const,
     name: 'Phantom',
     rdns: 'app.phantom',
     iconUrl: async () => (await import('./phantomWallet.svg')).default,
@@ -50,5 +50,5 @@ export const phantomWallet = (): Wallet => {
     createConnector: getInjectedConnector({
       namespace: 'phantom.ethereum',
     }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/portoWallet/portoWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/portoWallet/portoWallet.ts
@@ -1,10 +1,12 @@
 import { porto, type PortoParameters } from 'wagmi/connectors';
-import type { Wallet, WalletDetailsParams } from '../../Wallet';
+import type { Wallet, WalletDetailsParams, WalletFactory } from '../../Wallet';
 import { createConnector } from 'wagmi';
 
-export const portoWallet = (parameters: PortoParameters): Wallet => {
+export const portoWallet: WalletFactory<PortoParameters, 'porto'> = (
+  parameters,
+) => {
   return {
-    id: 'porto',
+    id: 'porto' as const,
     name: 'Porto',
     shortName: 'Porto',
     rdns: 'xyz.ithaca.porto',
@@ -17,5 +19,5 @@ export const portoWallet = (parameters: PortoParameters): Wallet => {
         ...porto(parameters)(config),
         ...walletDetails,
       })),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/rabbyWallet/rabbyWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rabbyWallet/rabbyWallet.ts
@@ -4,39 +4,40 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const rabbyWallet = (): Wallet => ({
-  id: 'rabby',
-  name: 'Rabby Wallet',
-  iconUrl: async () => (await import('./rabbyWallet.svg')).default,
-  rdns: 'io.rabby',
-  iconBackground: '#8697FF',
-  installed: hasInjectedProvider({ flag: 'isRabby' }),
-  downloadUrls: {
-    chrome:
-      'https://chrome.google.com/webstore/detail/rabby-wallet/acmacodkjbdgmoleebolmdjonilkdbch',
-    browserExtension: 'https://rabby.io',
-  },
-  extension: {
-    instructions: {
-      learnMoreUrl: 'https://rabby.io/',
-      steps: [
-        {
-          description: 'wallet_connectors.rabby.extension.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.rabby.extension.step1.title',
-        },
-        {
-          description: 'wallet_connectors.rabby.extension.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.rabby.extension.step2.title',
-        },
-        {
-          description: 'wallet_connectors.rabby.extension.step3.description',
-          step: 'refresh',
-          title: 'wallet_connectors.rabby.extension.step3.title',
-        },
-      ],
+export const rabbyWallet = () =>
+  ({
+    id: 'rabby' as const,
+    name: 'Rabby Wallet',
+    iconUrl: async () => (await import('./rabbyWallet.svg')).default,
+    rdns: 'io.rabby',
+    iconBackground: '#8697FF',
+    installed: hasInjectedProvider({ flag: 'isRabby' }),
+    downloadUrls: {
+      chrome:
+        'https://chrome.google.com/webstore/detail/rabby-wallet/acmacodkjbdgmoleebolmdjonilkdbch',
+      browserExtension: 'https://rabby.io',
     },
-  },
-  createConnector: getInjectedConnector({ flag: 'isRabby' }),
-});
+    extension: {
+      instructions: {
+        learnMoreUrl: 'https://rabby.io/',
+        steps: [
+          {
+            description: 'wallet_connectors.rabby.extension.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.rabby.extension.step1.title',
+          },
+          {
+            description: 'wallet_connectors.rabby.extension.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.rabby.extension.step2.title',
+          },
+          {
+            description: 'wallet_connectors.rabby.extension.step3.description',
+            step: 'refresh',
+            title: 'wallet_connectors.rabby.extension.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getInjectedConnector({ flag: 'isRabby' }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
@@ -11,7 +11,7 @@ export type RainbowWalletOptions = DefaultWalletOptions;
 export const rainbowWallet = ({
   projectId,
   walletConnectParameters,
-}: RainbowWalletOptions): Wallet => {
+}: RainbowWalletOptions) => {
   const isRainbowInjected = hasInjectedProvider({ flag: 'isRainbow' });
   const shouldUseWalletConnect = !isRainbowInjected;
 
@@ -26,7 +26,7 @@ export const rainbowWallet = ({
   };
 
   return {
-    id: 'rainbow',
+    id: 'rainbow' as const,
     name: 'Rainbow',
     rdns: 'me.rainbow',
     iconUrl: async () => (await import('./rainbowWallet.svg')).default,
@@ -78,5 +78,5 @@ export const rainbowWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({ flag: 'isRainbow' }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/ramperWallet/ramperWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ramperWallet/ramperWallet.ts
@@ -4,13 +4,13 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const ramperWallet = (): Wallet => {
+export const ramperWallet = () => {
   const isRamperWalletInjected = hasInjectedProvider({
     namespace: 'ramper2.provider',
   });
 
   return {
-    id: 'ramper',
+    id: 'ramper' as const,
     name: 'Ramper Wallet',
     iconUrl: async () => (await import('./ramperWallet.svg')).default,
     installed: isRamperWalletInjected,
@@ -46,5 +46,5 @@ export const ramperWallet = (): Wallet => {
     createConnector: getInjectedConnector({
       namespace: 'ramper2.provider',
     }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/readyWallet/readyWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/readyWallet/readyWallet.ts
@@ -7,50 +7,51 @@ export type ReadyWalletOptions = DefaultWalletOptions;
 export const readyWallet = ({
   projectId,
   walletConnectParameters,
-}: ReadyWalletOptions): Wallet => ({
-  id: 'ready',
-  name: 'Ready',
-  iconUrl: async () => (await import('./readyWallet.svg')).default,
-  iconBackground: '#fff',
-  downloadUrls: {
-    android:
-      'https://play.google.com/store/apps/details?id=im.argent.contractwalletclient',
-    ios: 'https://apps.apple.com/us/app/argent/id1358741926',
-    mobile: 'https://www.ready.co/app',
-    qrCode: 'https://www.ready.co/app',
-  },
-  mobile: {
-    getUri: (uri: string) => {
-      return isAndroid()
-        ? uri
-        : `argent://app/wc?uri=${encodeURIComponent(uri)}`;
+}: ReadyWalletOptions) =>
+  ({
+    id: 'ready' as const,
+    name: 'Ready',
+    iconUrl: async () => (await import('./readyWallet.svg')).default,
+    iconBackground: '#fff',
+    downloadUrls: {
+      android:
+        'https://play.google.com/store/apps/details?id=im.argent.contractwalletclient',
+      ios: 'https://apps.apple.com/us/app/argent/id1358741926',
+      mobile: 'https://www.ready.co/app',
+      qrCode: 'https://www.ready.co/app',
     },
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl: 'https://www.ready.co/',
-      steps: [
-        {
-          description: 'wallet_connectors.ready.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.ready.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.ready.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.ready.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.ready.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.ready.qr_code.step3.title',
-        },
-      ],
+    mobile: {
+      getUri: (uri: string) => {
+        return isAndroid()
+          ? uri
+          : `argent://app/wc?uri=${encodeURIComponent(uri)}`;
+      },
     },
-  },
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    qrCode: {
+      getUri: (uri: string) => uri,
+      instructions: {
+        learnMoreUrl: 'https://www.ready.co/',
+        steps: [
+          {
+            description: 'wallet_connectors.ready.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.ready.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.ready.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.ready.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.ready.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.ready.qr_code.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/roninWallet/roninWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/roninWallet/roninWallet.ts
@@ -10,7 +10,7 @@ export type RoninWalletOptions = DefaultWalletOptions;
 export const roninWallet = ({
   projectId,
   walletConnectParameters,
-}: RoninWalletOptions): Wallet => {
+}: RoninWalletOptions) => {
   const isRoninInjected = hasInjectedProvider({
     namespace: 'ronin.provider',
   });
@@ -22,7 +22,7 @@ export const roninWallet = ({
   };
 
   return {
-    id: 'ronin',
+    id: 'ronin' as const,
     name: 'Ronin Wallet',
     iconUrl: async () => (await import('./roninWallet.svg')).default,
     iconBackground: '#ffffff',
@@ -99,5 +99,5 @@ export const roninWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({ namespace: 'ronin.provider' }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
@@ -1,26 +1,27 @@
 import { createConnector } from 'wagmi';
 import { safe } from 'wagmi/connectors';
-import type { Wallet, WalletDetailsParams } from '../../Wallet';
+import type { Wallet, WalletDetailsParams, WalletFactory } from '../../Wallet';
 
-export const safeWallet = (): Wallet => ({
-  id: 'safe',
-  name: 'Safe',
-  iconAccent: '#12ff80',
-  iconBackground: '#fff',
-  iconUrl: async () => (await import('./safeWallet.svg')).default,
-  installed:
-    // Only allowed in iframe context
-    // borrowed from wagmi safe connector
-    !(typeof window === 'undefined') && window?.parent !== window,
-  downloadUrls: {
-    // We're opting not to provide a download prompt if the application is not
-    // already running as a Safe App within the context of the Safe browser,
-    // since it's unlikely to be a desired behavior for users.
-  },
-  createConnector: (walletDetails: WalletDetailsParams) => {
-    return createConnector((config) => ({
-      ...safe()(config),
-      ...walletDetails,
-    }));
-  },
-});
+export const safeWallet: WalletFactory<void, 'safe'> = () =>
+  ({
+    id: 'safe' as const,
+    name: 'Safe',
+    iconAccent: '#12ff80',
+    iconBackground: '#fff',
+    iconUrl: async () => (await import('./safeWallet.svg')).default,
+    installed:
+      // Only allowed in iframe context
+      // borrowed from wagmi safe connector
+      !(typeof window === 'undefined') && window?.parent !== window,
+    downloadUrls: {
+      // We're opting not to provide a download prompt if the application is not
+      // already running as a Safe App within the context of the Safe browser,
+      // since it's unlikely to be a desired behavior for users.
+    },
+    createConnector: (walletDetails: WalletDetailsParams) => {
+      return createConnector((config) => ({
+        ...safe()(config),
+        ...walletDetails,
+      }));
+    },
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/safeheronWallet/safeheronWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safeheronWallet/safeheronWallet.ts
@@ -4,47 +4,48 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const safeheronWallet = (): Wallet => ({
-  id: 'safeheron',
-  name: 'Safeheron',
-  installed: hasInjectedProvider({
-    namespace: 'safeheron',
-    flag: 'isSafeheron',
-  }),
-  iconUrl: async () => (await import('./safeheronWallet.svg')).default,
-  iconBackground: '#fff',
-  downloadUrls: {
-    chrome:
-      'https://chrome.google.com/webstore/detail/safeheron/aiaghdjafpiofpainifbgfgjfpclngoh',
-    browserExtension: 'https://www.safeheron.com/',
-  },
-  extension: {
-    instructions: {
-      learnMoreUrl: 'https://www.safeheron.com/',
-      steps: [
-        {
-          description:
-            'wallet_connectors.safeheron.extension.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.safeheron.extension.step1.title',
-        },
-        {
-          description:
-            'wallet_connectors.safeheron.extension.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.safeheron.extension.step2.title',
-        },
-        {
-          description:
-            'wallet_connectors.safeheron.extension.step3.description',
-          step: 'refresh',
-          title: 'wallet_connectors.safeheron.extension.step3.title',
-        },
-      ],
+export const safeheronWallet = () =>
+  ({
+    id: 'safeheron' as const,
+    name: 'Safeheron',
+    installed: hasInjectedProvider({
+      namespace: 'safeheron',
+      flag: 'isSafeheron',
+    }),
+    iconUrl: async () => (await import('./safeheronWallet.svg')).default,
+    iconBackground: '#fff',
+    downloadUrls: {
+      chrome:
+        'https://chrome.google.com/webstore/detail/safeheron/aiaghdjafpiofpainifbgfgjfpclngoh',
+      browserExtension: 'https://www.safeheron.com/',
     },
-  },
-  createConnector: getInjectedConnector({
-    namespace: 'safeheron',
-    flag: 'isSafeheron',
-  }),
-});
+    extension: {
+      instructions: {
+        learnMoreUrl: 'https://www.safeheron.com/',
+        steps: [
+          {
+            description:
+              'wallet_connectors.safeheron.extension.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.safeheron.extension.step1.title',
+          },
+          {
+            description:
+              'wallet_connectors.safeheron.extension.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.safeheron.extension.step2.title',
+          },
+          {
+            description:
+              'wallet_connectors.safeheron.extension.step3.description',
+            step: 'refresh',
+            title: 'wallet_connectors.safeheron.extension.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getInjectedConnector({
+      namespace: 'safeheron',
+      flag: 'isSafeheron',
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/safepalWallet/safepalWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safepalWallet/safepalWallet.ts
@@ -14,7 +14,7 @@ export type SafepalWalletOptions = DefaultWalletOptions;
 export const safepalWallet = ({
   projectId,
   walletConnectParameters,
-}: SafepalWalletOptions): Wallet => {
+}: SafepalWalletOptions) => {
   const isSafePalWalletInjected = hasInjectedProvider({
     namespace: 'safepalProvider',
     flag: 'isSafePal',
@@ -85,7 +85,7 @@ export const safepalWallet = ({
   };
 
   return {
-    id: 'safepal',
+    id: 'safepal' as const,
     name: 'SafePal Wallet',
     iconUrl: async () => (await import('./safepalWallet.svg')).default,
     // Note that we never resolve `installed` to `false` because the
@@ -116,5 +116,5 @@ export const safepalWallet = ({
           namespace: 'safepalProvider',
           flag: 'isSafePal',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/seifWallet/seifWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/seifWallet/seifWallet.ts
@@ -4,12 +4,12 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export function seifWallet(): Wallet {
+export function seifWallet() {
   const injectedProvider = hasInjectedProvider({
     namespace: '__seif',
   });
   return {
-    id: 'seif',
+    id: 'seif' as const,
     name: 'Seif',
     installed: !!injectedProvider,
     iconUrl: async () => (await import('./seifWallet.svg')).default,
@@ -22,5 +22,5 @@ export function seifWallet(): Wallet {
       namespace: '__seif',
     }),
     rdns: 'com.passkeywallet.seif',
-  };
+  } satisfies Wallet;
 }

--- a/packages/rainbowkit/src/wallets/walletConnectors/subWallet/subWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/subWallet/subWallet.ts
@@ -14,7 +14,7 @@ export type SubWalletOptions = DefaultWalletOptions;
 export const subWallet = ({
   projectId,
   walletConnectParameters,
-}: SubWalletOptions): Wallet => {
+}: SubWalletOptions) => {
   const isSubWalletInjected = hasInjectedProvider({ namespace: 'SubWallet' });
   const shouldUseWalletConnect = !isSubWalletInjected;
 
@@ -88,7 +88,7 @@ export const subWallet = ({
   };
 
   return {
-    id: 'subwallet',
+    id: 'subwallet' as const,
     name: 'SubWallet',
     rdns: 'app.subwallet',
     iconUrl: async () => (await import('./subWallet.svg')).default,
@@ -115,5 +115,5 @@ export const subWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({ namespace: 'SubWallet' }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/tahoWallet/tahoWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tahoWallet/tahoWallet.ts
@@ -4,9 +4,9 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const tahoWallet = (): Wallet => {
+export const tahoWallet = () => {
   return {
-    id: 'taho',
+    id: 'taho' as const,
     name: 'Taho',
     iconBackground: '#d08d57',
     iconUrl: async () => (await import('./tahoWallet.svg')).default,
@@ -43,5 +43,5 @@ export const tahoWallet = (): Wallet => {
       namespace: 'tally',
       flag: 'isTally',
     }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/talismanWallet/talismanWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/talismanWallet/talismanWallet.ts
@@ -4,47 +4,51 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const talismanWallet = (): Wallet => ({
-  id: 'talisman',
-  name: 'Talisman',
-  rdns: 'xyz.talisman',
-  iconUrl: async () => (await import('./talismanWallet.svg')).default,
-  iconBackground: '#fff',
-  installed: hasInjectedProvider({
-    namespace: 'talismanEth',
-    flag: 'isTalisman',
-  }),
-  downloadUrls: {
-    chrome:
-      'https://chrome.google.com/webstore/detail/talisman-polkadot-wallet/fijngjgcjhjmmpcmkeiomlglpeiijkld',
-    firefox:
-      'https://addons.mozilla.org/en-US/firefox/addon/talisman-wallet-extension/',
-    browserExtension: 'https://talisman.xyz/download',
-  },
-  extension: {
-    instructions: {
-      learnMoreUrl: 'https://talisman.xyz/',
-      steps: [
-        {
-          description: 'wallet_connectors.talisman.extension.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.talisman.extension.step1.title',
-        },
-        {
-          description: 'wallet_connectors.talisman.extension.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.talisman.extension.step2.title',
-        },
-        {
-          description: 'wallet_connectors.talisman.extension.step3.description',
-          step: 'refresh',
-          title: 'wallet_connectors.talisman.extension.step3.title',
-        },
-      ],
+export const talismanWallet = () =>
+  ({
+    id: 'talisman' as const,
+    name: 'Talisman',
+    rdns: 'xyz.talisman',
+    iconUrl: async () => (await import('./talismanWallet.svg')).default,
+    iconBackground: '#fff',
+    installed: hasInjectedProvider({
+      namespace: 'talismanEth',
+      flag: 'isTalisman',
+    }),
+    downloadUrls: {
+      chrome:
+        'https://chrome.google.com/webstore/detail/talisman-polkadot-wallet/fijngjgcjhjmmpcmkeiomlglpeiijkld',
+      firefox:
+        'https://addons.mozilla.org/en-US/firefox/addon/talisman-wallet-extension/',
+      browserExtension: 'https://talisman.xyz/download',
     },
-  },
-  createConnector: getInjectedConnector({
-    namespace: 'talismanEth',
-    flag: 'isTalisman',
-  }),
-});
+    extension: {
+      instructions: {
+        learnMoreUrl: 'https://talisman.xyz/',
+        steps: [
+          {
+            description:
+              'wallet_connectors.talisman.extension.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.talisman.extension.step1.title',
+          },
+          {
+            description:
+              'wallet_connectors.talisman.extension.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.talisman.extension.step2.title',
+          },
+          {
+            description:
+              'wallet_connectors.talisman.extension.step3.description',
+            step: 'refresh',
+            title: 'wallet_connectors.talisman.extension.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getInjectedConnector({
+      namespace: 'talismanEth',
+      flag: 'isTalisman',
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/tokenPocketWallet/tokenPocketWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tokenPocketWallet/tokenPocketWallet.ts
@@ -11,7 +11,7 @@ export type TokenPocketWalletOptions = DefaultWalletOptions;
 export const tokenPocketWallet = ({
   projectId,
   walletConnectParameters,
-}: TokenPocketWalletOptions): Wallet => {
+}: TokenPocketWalletOptions) => {
   const isTokenPocketInjected = hasInjectedProvider({ flag: 'isTokenPocket' });
   const shouldUseWalletConnect = !isTokenPocketInjected;
 
@@ -20,7 +20,7 @@ export const tokenPocketWallet = ({
   };
 
   return {
-    id: 'tokenPocket',
+    id: 'tokenPocket' as const,
     name: 'TokenPocket',
     rdns: 'pro.tokenpocket',
     iconUrl: async () => (await import('./tokenPocketWallet.svg')).default,
@@ -99,5 +99,5 @@ export const tokenPocketWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({ flag: 'isTokenPocket' }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/tokenaryWallet/tokenaryWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tokenaryWallet/tokenaryWallet.ts
@@ -5,19 +5,20 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const tokenaryWallet = (): Wallet => ({
-  id: 'tokenary',
-  name: 'Tokenary',
-  iconUrl: async () => (await import('./tokenaryWallet.svg')).default,
-  iconBackground: '#ffffff',
-  installed: hasInjectedProvider({ flag: 'isTokenary' }),
-  hidden: () => !isSafari(),
-  downloadUrls: {
-    ios: 'https://tokenary.io/get',
-    mobile: 'https://tokenary.io',
-    qrCode: 'https://tokenary.io/get',
-    safari: 'https://tokenary.io/get',
-    browserExtension: 'https://tokenary.io/get',
-  },
-  createConnector: getInjectedConnector({ flag: 'isTokenary' }),
-});
+export const tokenaryWallet = () =>
+  ({
+    id: 'tokenary' as const,
+    name: 'Tokenary',
+    iconUrl: async () => (await import('./tokenaryWallet.svg')).default,
+    iconBackground: '#ffffff',
+    installed: hasInjectedProvider({ flag: 'isTokenary' }),
+    hidden: () => !isSafari(),
+    downloadUrls: {
+      ios: 'https://tokenary.io/get',
+      mobile: 'https://tokenary.io',
+      qrCode: 'https://tokenary.io/get',
+      safari: 'https://tokenary.io/get',
+      browserExtension: 'https://tokenary.io/get',
+    },
+    createConnector: getInjectedConnector({ flag: 'isTokenary' }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -15,7 +15,7 @@ export type TrustWalletOptions = DefaultWalletOptions;
 export const trustWallet = ({
   projectId,
   walletConnectParameters,
-}: TrustWalletOptions): Wallet => {
+}: TrustWalletOptions) => {
   const isTrustWalletInjected = isMobile()
     ? hasInjectedProvider({ flag: 'isTrust' })
     : hasInjectedProvider({ flag: 'isTrustWallet' });
@@ -85,7 +85,7 @@ export const trustWallet = ({
   };
 
   return {
-    id: 'trust',
+    id: 'trust' as const,
     name: 'Trust Wallet',
     rdns: 'com.trustwallet.app',
     iconUrl: async () => (await import('./trustWallet.svg')).default,
@@ -116,5 +116,5 @@ export const trustWallet = ({
       : isMobile()
         ? getInjectedConnector({ flag: 'isTrust' })
         : getInjectedConnector({ flag: 'isTrustWallet' }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/uniswapWallet/uniswapWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/uniswapWallet/uniswapWallet.ts
@@ -7,48 +7,49 @@ export type UniswapWalletOptions = DefaultWalletOptions;
 export const uniswapWallet = ({
   projectId,
   walletConnectParameters,
-}: UniswapWalletOptions): Wallet => ({
-  id: 'uniswap',
-  name: 'Uniswap Wallet',
-  iconUrl: async () => (await import('./uniswapWallet.svg')).default,
-  iconBackground: '#FFD8EA',
-  downloadUrls: {
-    ios: 'https://apps.apple.com/app/apple-store/id6443944476',
-    mobile: 'https://wallet.uniswap.org/',
-    qrCode: 'https://wallet.uniswap.org/',
-  },
-
-  mobile: {
-    getUri: (uri: string) => {
-      return `uniswap://wc?uri=${encodeURIComponent(uri)}`;
+}: UniswapWalletOptions) =>
+  ({
+    id: 'uniswap' as const,
+    name: 'Uniswap Wallet',
+    iconUrl: async () => (await import('./uniswapWallet.svg')).default,
+    iconBackground: '#FFD8EA',
+    downloadUrls: {
+      ios: 'https://apps.apple.com/app/apple-store/id6443944476',
+      mobile: 'https://wallet.uniswap.org/',
+      qrCode: 'https://wallet.uniswap.org/',
     },
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl: 'https://wallet.uniswap.org/',
-      steps: [
-        {
-          description: 'wallet_connectors.uniswap.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.uniswap.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.uniswap.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.uniswap.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.uniswap.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.uniswap.qr_code.step3.title',
-        },
-      ],
-    },
-  },
 
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    mobile: {
+      getUri: (uri: string) => {
+        return `uniswap://wc?uri=${encodeURIComponent(uri)}`;
+      },
+    },
+    qrCode: {
+      getUri: (uri: string) => uri,
+      instructions: {
+        learnMoreUrl: 'https://wallet.uniswap.org/',
+        steps: [
+          {
+            description: 'wallet_connectors.uniswap.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.uniswap.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.uniswap.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.uniswap.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.uniswap.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.uniswap.qr_code.step3.title',
+          },
+        ],
+      },
+    },
+
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/universalProfilesWallet/universalProfilesWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/universalProfilesWallet/universalProfilesWallet.ts
@@ -11,13 +11,13 @@ export type UniversalProfilesWalletOptions = DefaultWalletOptions;
 export const universalProfilesWallet = ({
   projectId,
   walletConnectParameters,
-}: UniversalProfilesWalletOptions): Wallet => {
+}: UniversalProfilesWalletOptions) => {
   const isInjected = hasInjectedProvider({ namespace: 'lukso' });
   // const isInjected = typeof window !== "undefined" && !!(window as any).lukso;
   const shouldUseWalletConnect = !isInjected;
 
   return {
-    id: 'universal-profiles',
+    id: 'universal-profiles' as const,
     name: 'Universal Profiles',
     rdns: 'io.universaleverything.universalprofiles',
     iconUrl: async () =>
@@ -96,5 +96,5 @@ export const universalProfilesWallet = ({
       : getInjectedConnector({
           namespace: 'lukso',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/valoraWallet/valoraWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/valoraWallet/valoraWallet.ts
@@ -7,46 +7,47 @@ export type ValoraWalletOptions = DefaultWalletOptions;
 export const valoraWallet = ({
   projectId,
   walletConnectParameters,
-}: ValoraWalletOptions): Wallet => ({
-  id: 'valora',
-  name: 'Valora',
-  iconUrl: async () => (await import('./valoraWallet.svg')).default,
-  iconBackground: '#FFFFFF',
-  downloadUrls: {
-    ios: 'https://apps.apple.com/app/id1520414263?mt=8',
-    android: 'https://play.google.com/store/apps/details?id=co.clabs.valora',
-    mobile: 'https://valora.xyz',
-    qrCode: 'https://valora.xyz',
-  },
-  mobile: {
-    getUri: (uri: string) =>
-      isAndroid() ? uri : `celo://wallet/wc?uri=${encodeURIComponent(uri)}`,
-  },
-  qrCode: {
-    getUri: (uri: string) => uri,
-    instructions: {
-      learnMoreUrl: 'https://valora.xyz/',
-      steps: [
-        {
-          description: 'wallet_connectors.valora.qr_code.step1.description',
-          step: 'install',
-          title: 'wallet_connectors.valora.qr_code.step1.title',
-        },
-        {
-          description: 'wallet_connectors.valora.qr_code.step2.description',
-          step: 'create',
-          title: 'wallet_connectors.valora.qr_code.step2.title',
-        },
-        {
-          description: 'wallet_connectors.valora.qr_code.step3.description',
-          step: 'scan',
-          title: 'wallet_connectors.valora.qr_code.step3.title',
-        },
-      ],
+}: ValoraWalletOptions) =>
+  ({
+    id: 'valora' as const,
+    name: 'Valora',
+    iconUrl: async () => (await import('./valoraWallet.svg')).default,
+    iconBackground: '#FFFFFF',
+    downloadUrls: {
+      ios: 'https://apps.apple.com/app/id1520414263?mt=8',
+      android: 'https://play.google.com/store/apps/details?id=co.clabs.valora',
+      mobile: 'https://valora.xyz',
+      qrCode: 'https://valora.xyz',
     },
-  },
-  createConnector: getWalletConnectConnector({
-    projectId,
-    walletConnectParameters,
-  }),
-});
+    mobile: {
+      getUri: (uri: string) =>
+        isAndroid() ? uri : `celo://wallet/wc?uri=${encodeURIComponent(uri)}`,
+    },
+    qrCode: {
+      getUri: (uri: string) => uri,
+      instructions: {
+        learnMoreUrl: 'https://valora.xyz/',
+        steps: [
+          {
+            description: 'wallet_connectors.valora.qr_code.step1.description',
+            step: 'install',
+            title: 'wallet_connectors.valora.qr_code.step1.title',
+          },
+          {
+            description: 'wallet_connectors.valora.qr_code.step2.description',
+            step: 'create',
+            title: 'wallet_connectors.valora.qr_code.step2.title',
+          },
+          {
+            description: 'wallet_connectors.valora.qr_code.step3.description',
+            step: 'scan',
+            title: 'wallet_connectors.valora.qr_code.step3.title',
+          },
+        ],
+      },
+    },
+    createConnector: getWalletConnectConnector({
+      projectId,
+      walletConnectParameters,
+    }),
+  }) satisfies Wallet;

--- a/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.ts
@@ -9,11 +9,11 @@ export interface WalletConnectWalletOptions {
 export const walletConnectWallet = ({
   projectId,
   options,
-}: WalletConnectWalletOptions): Wallet => {
+}: WalletConnectWalletOptions) => {
   const getUri = (uri: string) => uri;
 
   return {
-    id: 'walletConnect',
+    id: 'walletConnect' as const,
     name: 'WalletConnect',
     installed: undefined,
     iconUrl: async () => (await import('./walletConnectWallet.svg')).default,
@@ -23,5 +23,5 @@ export const walletConnectWallet = ({
       projectId,
       walletConnectParameters: options,
     }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/wigwamWallet/wigwamWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/wigwamWallet/wigwamWallet.ts
@@ -4,9 +4,9 @@ import {
   hasInjectedProvider,
 } from '../../getInjectedConnector';
 
-export const wigwamWallet = (): Wallet => {
+export const wigwamWallet = () => {
   return {
-    id: 'wigwam',
+    id: 'wigwam' as const,
     name: 'Wigwam',
     rdns: 'com.wigwam.wallet',
     iconBackground: '#80EF6E',
@@ -46,5 +46,5 @@ export const wigwamWallet = (): Wallet => {
       namespace: 'wigwamEthereum',
       flag: 'isWigwam',
     }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/xPortalWallet/xPortalWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/xPortalWallet/xPortalWallet.ts
@@ -12,7 +12,7 @@ export type XPortalWalletOptions = DefaultWalletOptions;
 export const xPortalWallet = ({
   projectId,
   walletConnectParameters,
-}: XPortalWalletOptions): Wallet => {
+}: XPortalWalletOptions) => {
   const isXPortalInjected = hasInjectedProvider({
     flag: 'isxPortal',
   });
@@ -23,7 +23,7 @@ export const xPortalWallet = ({
   };
 
   return {
-    id: 'xportal',
+    id: 'xportal' as const,
     name: 'xPortal',
     rdns: 'com.elrond.maiar.wallet',
     iconUrl: async () => (await import('./xPortalWallet.svg')).default,
@@ -76,5 +76,5 @@ export const xPortalWallet = ({
       : getInjectedConnector({
           flag: 'isxPortal',
         }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/zealWallet/zealWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/zealWallet/zealWallet.ts
@@ -10,13 +10,13 @@ export type ZealWalletOptions = DefaultWalletOptions;
 export const zealWallet = ({
   projectId,
   walletConnectParameters,
-}: ZealWalletOptions): Wallet => {
+}: ZealWalletOptions) => {
   const isZealWalletInjected = hasInjectedProvider({ flag: 'isZeal' });
 
   const shouldUseWalletConnect = !isZealWalletInjected;
 
   return {
-    id: 'zeal',
+    id: 'zeal' as const,
     name: 'Zeal',
     rdns: 'app.zeal',
     iconUrl: async () => (await import('./zealWallet.svg')).default,
@@ -91,5 +91,5 @@ export const zealWallet = ({
           walletConnectParameters,
         })
       : getInjectedConnector({ flag: 'isZeal' }),
-  };
+  } satisfies Wallet;
 };

--- a/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
@@ -12,7 +12,7 @@ export type ZerionWalletOptions = DefaultWalletOptions;
 export const zerionWallet = ({
   projectId,
   walletConnectParameters,
-}: ZerionWalletOptions): Wallet => {
+}: ZerionWalletOptions) => {
   const isZerionInjected = hasInjectedProvider({
     namespace: 'zerionWallet',
     flag: 'isZerion',
@@ -24,7 +24,7 @@ export const zerionWallet = ({
   };
 
   return {
-    id: 'zerion',
+    id: 'zerion' as const,
     name: 'Zerion',
     rdns: 'io.zerion.wallet',
     iconUrl: async () => (await import('./zerionWallet.svg')).default,
@@ -104,5 +104,5 @@ export const zerionWallet = ({
           namespace: 'zerionWallet',
           flag: 'isZerion',
         }),
-  };
+  } satisfies Wallet;
 };


### PR DESCRIPTION
# Refactors wallet connectors to use the new WalletFactory helper type,
which preserves literal ID types through 'as const' assertions. This
provides better type safety and enables stricter type checking for
wallet identifiers throughout the codebase.

Changes:
- Add WalletFactory helper type to Wallet.ts
- Add appName and appIcon to CreateWalletFn type for wallets that require them
  (baseAccount, coinbaseWallet, geminiWallet)
- Convert all wallet connectors to use WalletFactory pattern
- Flatten type definitions in baseAccount and coinbaseWallet
- Update WalletButton components to work with new types
- All wallet IDs now use 'as const' for literal type preservation

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the TypeScript typings and structure of various wallet connector implementations in the `rainbowkit` package. It enhances type safety and consistency by utilizing the `satisfies` operator and updating the wallet connector functions.

### Detailed summary
- Updated wallet connector functions to use `satisfies Wallet` for type safety.
- Changed return types from `(): Wallet` to `() =>` for consistency.
- Replaced `id` definitions with `as const` for literal type preservation.
- Modified the `WalletButton` and related props to use `WalletId`.
- Refactored `argentWallet`, `wigwamWallet`, `tahoWallet`, and others to align with new type definitions.
- Enhanced the mapping of wallet connectors to ensure consistent typing across the board.

> The following files were skipped due to too many changes: `packages/rainbowkit/src/wallets/walletConnectors/oktoWallet/oktoWallet.ts`, `packages/rainbowkit/src/wallets/walletConnectors/omniWallet/omniWallet.ts`, `packages/rainbowkit/src/wallets/walletConnectors/oneInchWallet/oneInchWallet.ts`, `packages/rainbowkit/src/wallets/walletConnectors/kresusWallet/kresusWallet.ts`, `packages/rainbowkit/src/wallets/walletConnectors/bestWallet/bestWallet.ts`, `packages/rainbowkit/src/wallets/walletConnectors/readyWallet/readyWallet.ts`, `packages/rainbowkit/src/wallets/walletConnectors/bitverseWallet/bitverseWallet.ts`, `packages/rainbowkit/src/wallets/walletConnectors/talismanWallet/talismanWallet.ts`, `packages/rainbowkit/src/wallets/walletConnectors/iopayWallet/iopayWallet.ts`, `packages/rainbowkit/src/wallets/walletConnectors/imTokenWallet/imTokenWallet.ts`, `packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->