### PR TITLE
chore: next js route types

### DIFF
--- a/examples/with-next-app-i18n/next-env.d.ts
+++ b/examples/with-next-app-i18n/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/with-next-app/next-env.d.ts
+++ b/examples/with-next-app/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/with-next-custom-button/next-env.d.ts
+++ b/examples/with-next-custom-button/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/examples/with-next-mint-nft/next-env.d.ts
+++ b/examples/with-next-mint-nft/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/examples/with-next-rainbow-button/next-env.d.ts
+++ b/examples/with-next-rainbow-button/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/examples/with-next-siwe-iron-session/next-env.d.ts
+++ b/examples/with-next-siwe-iron-session/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/examples/with-next-siwe-next-auth/next-env.d.ts
+++ b/examples/with-next-siwe-next-auth/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/examples/with-next-wallet-button/next-env.d.ts
+++ b/examples/with-next-wallet-button/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/examples/with-next/next-env.d.ts
+++ b/examples/with-next/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/create-rainbowkit/generated-test-app/next-env.d.ts
+++ b/packages/create-rainbowkit/generated-test-app/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/site/next-env.d.ts
+++ b/site/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
### TL;DR

Added TypeScript route type definitions to all Next.js projects.

### What changed?

Added a reference path to `./.next/types/routes.d.ts` in the `next-env.d.ts` file across all Next.js examples and packages. This change enables TypeScript to recognize and provide type checking for Next.js route definitions.

### How to test?

1. Run `npm run dev` or `yarn dev` in any of the affected Next.js projects
2. Verify that TypeScript correctly recognizes route paths in the codebase
3. Check that route-related autocompletion works in your IDE

### Why make this change?

This change improves the developer experience by providing better TypeScript support for Next.js routes. With these type definitions, developers will get autocompletion and type checking for route paths, reducing errors and improving code quality. This is a recommended practice for Next.js projects using TypeScript.