### PR TITLE
fix: ssr and type safety

### DIFF
--- a/.changeset/ssr-safety-improvements.md
+++ b/.changeset/ssr-safety-improvements.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Improved SSR safety to prevent WalletConnect initialization warnings.

--- a/packages/rainbowkit/src/wallets/connectorsForWallets.test.ts
+++ b/packages/rainbowkit/src/wallets/connectorsForWallets.test.ts
@@ -20,7 +20,7 @@ describe('connectorsForWallets', () => {
   describe('injected fallback', () => {
     it('should return wallet connect and injected wallet connectors', () => {
       const customWallet: CreateWalletFn = (params) => ({
-        createConnector: () => walletConnect({ projectId: params?.projectId! }),
+        createConnector: () => walletConnect({ projectId: params.projectId }),
         iconBackground: '#fff',
         iconUrl: '/test.png',
         id: 'test-walletconnect-wallet',
@@ -50,7 +50,7 @@ describe('connectorsForWallets', () => {
 
     it("should not return connector if 'hidden' returns true", () => {
       const customWallet: CreateWalletFn = (params) => ({
-        createConnector: () => walletConnect({ projectId: params?.projectId! }),
+        createConnector: () => walletConnect({ projectId: params.projectId }),
         hidden: () => true,
         iconBackground: '#fff',
         iconUrl: '/test.png',

--- a/packages/rainbowkit/src/wallets/useWalletConnectors.ts
+++ b/packages/rainbowkit/src/wallets/useWalletConnectors.ts
@@ -210,7 +210,7 @@ export function useWalletConnectors(
         ? () => getWalletConnectUri(wallet, wallet.desktop!.getUri!)
         : undefined,
       getMobileUri: wallet.mobile?.getUri
-        ? () => getWalletConnectUri(wallet, wallet.mobile?.getUri!)
+        ? () => getWalletConnectUri(wallet, wallet.mobile!.getUri!)
         : undefined,
       recent,
       showWalletConnectModal: wallet.walletConnectModalConnector


### PR DESCRIPTION
fix: mock connector in ssr

fix: directly pass params.projectId to connectorsForWallets

fix: getMobileUri type safety

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving server-side rendering (SSR) safety in the `rainbowkit` package to prevent warnings during WalletConnect initialization.

### Detailed summary
- Updated `getMobileUri` to use non-null assertion on `wallet.mobile!.getUri!`.
- Removed optional chaining in `createConnector` to ensure `projectId` is always accessed.
- Introduced a server-side check to return a mock connector during SSR to prevent errors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->