### PR TITLE
fix: example build warnings

### DIFF
--- a/examples/with-create-react-app/package.json
+++ b/examples/with-create-react-app/package.json
@@ -38,15 +38,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "pnpm": {
-    "overrides": {
-      "@react-native-async-storage/async-storage": "npm:empty-module@0.0.2"
-    },
-    "peerDependencyRules": {
-      "ignoreMissing": [
-        "@react-native-async-storage/async-storage"
-      ]
-    }
   }
 }

--- a/examples/with-next-app-i18n/src/proxy.ts
+++ b/examples/with-next-app-i18n/src/proxy.ts
@@ -1,4 +1,5 @@
 import createMiddleware from 'next-intl/middleware';
+import type { NextRequest } from 'next/server';
 import { routing } from './i18n/routing';
 
 export const config = {
@@ -6,4 +7,8 @@ export const config = {
   matcher: ['/', '/(de|en)/:path*'],
 };
 
-export default createMiddleware(routing);
+const handleI18nRouting = createMiddleware(routing);
+
+export function proxy(request: NextRequest) {
+  return handleI18nRouting(request);
+}

--- a/examples/with-remix/package.json
+++ b/examples/with-remix/package.json
@@ -28,15 +28,5 @@
   },
   "engines": {
     "node": ">=22"
-  },
-  "pnpm": {
-    "overrides": {
-      "@react-native-async-storage/async-storage": "npm:empty-module@0.0.2"
-    },
-    "peerDependencyRules": {
-      "ignoreMissing": [
-        "@react-native-async-storage/async-storage"
-      ]
-    }
   }
 }

--- a/examples/with-remix/remix.config.js
+++ b/examples/with-remix/remix.config.js
@@ -9,7 +9,7 @@ export default {
     v3_throwAbortReason: true,
     v3_relativeSplatPath: true,
     v3_lazyRouteDiscovery: true,
-    //v3_singleFetch: true,
+    v3_singleFetch: true,
     v3_fetcherPersist: true,
   },
   browserNodeBuiltinsPolyfill: {

--- a/packages/example/src/pages/icons.tsx
+++ b/packages/example/src/pages/icons.tsx
@@ -1,94 +1,150 @@
-import type { GetStaticProps } from 'next';
-import fs from 'node:fs';
-import path from 'node:path';
+import { useState, useEffect } from 'react';
 import { Cuer } from 'cuer';
+import * as wallets from '@rainbow-me/rainbowkit/wallets';
 
-interface Wallet {
-  name: string;
-  svgDataUrl: string;
-}
+const names = Object.keys(wallets)
+  .filter((k) => typeof (wallets as Record<string, unknown>)[k] === 'function')
+  .sort();
 
-interface IconsProps {
-  wallets: Wallet[];
-}
-
-export const getStaticProps: GetStaticProps<IconsProps> = async () => {
-  const wallets: Wallet[] = [];
-
-  try {
-    const walletConnectorsPath = path.join(
-      process.cwd(),
-      'node_modules/@rainbow-me/rainbowkit/dist/wallets/walletConnectors',
-    );
-
-    const files = fs.readdirSync(walletConnectorsPath);
-
-    // Find hashed JS files (e.g., backpackWallet-QESORHY7.js)
-    const hashedJsFiles = files.filter((file) =>
-      /^[a-zA-Z0-9]+(Wallet|Account)-[A-Z0-9]+\.js$/.test(file),
-    );
-
-    const seenWallets = new Set<string>();
-
-    for (const jsFile of hashedJsFiles) {
-      try {
-        const walletName = jsFile.split('-')[0];
-        const jsFilePath = path.join(walletConnectorsPath, jsFile);
-        const jsContent = fs.readFileSync(jsFilePath, 'utf-8');
-
-        const svgDataUrlMatch = jsContent.match(
-          /var \w+_default = "(data:image\/svg\+xml,[^"]+)";/,
-        );
-
-        if (svgDataUrlMatch?.[1] && !seenWallets.has(walletName)) {
-          seenWallets.add(walletName);
-          wallets.push({
-            name: walletName,
-            svgDataUrl: svgDataUrlMatch[1],
-          });
-        }
-      } catch (error) {
-        console.error(`Error processing ${jsFile}:`, error);
+async function loadIcon(fn: unknown): Promise<string | null> {
+  for (const p of [
+    {},
+    { projectId: '_' },
+    { appName: '_' },
+    { projectId: '_', appName: '_' },
+  ]) {
+    try {
+      const w = Object.keys(p).length
+        ? (fn as Function)(p)
+        : (fn as Function)();
+      if (w?.iconUrl) {
+        const icon =
+          typeof w.iconUrl === 'function' ? await w.iconUrl() : w.iconUrl;
+        if (icon) return icon;
       }
-    }
-
-    wallets.sort((a, b) => a.name.localeCompare(b.name));
-  } catch (error) {
-    console.error('Error reading wallet connectors:', error);
+    } catch {}
   }
+  return null;
+}
 
-  return {
-    props: {
-      wallets,
-    },
-  };
-};
+export default function Icons() {
+  const [icons, setIcons] = useState<Record<string, string>>({});
 
-export default function Icons({ wallets }: IconsProps) {
+  useEffect(() => {
+    for (const name of names) {
+      loadIcon((wallets as Record<string, unknown>)[name]).then((icon) => {
+        if (icon) setIcons((prev) => ({ ...prev, [name]: icon }));
+      });
+    }
+  }, []);
+
   return (
-    <>
-      <div className="page-wrapper">
-        <div className="container">
-          <div className="grid">
-            {wallets.map((wallet) => (
-              <div className="card" key={wallet.name}>
-                <div className="wallet-name">{wallet.name}</div>
-                <div className="svg-container">
-                  <div className="svg-box">
-                    <div className="size-label">28×28</div>
-                    <div className="svg-display small">
-                      <img src={wallet.svgDataUrl} alt={wallet.name} />
+    <div
+      style={{
+        minHeight: '100vh',
+        background: '#f5f5f5',
+        padding: '40px 20px',
+        fontFamily: 'system-ui',
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 1400,
+          margin: '0 auto',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill,minmax(550px,1fr))',
+          gap: 24,
+        }}
+      >
+        {names.map((name) => {
+          const icon = icons[name];
+          return (
+            <div
+              key={name}
+              style={{
+                background: 'white',
+                borderRadius: 12,
+                padding: 24,
+                boxShadow: '0 2px 8px rgba(0,0,0,.1)',
+              }}
+            >
+              <div style={{ fontSize: 20, fontWeight: 600, marginBottom: 16 }}>
+                {name}
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  gap: 24,
+                  marginBottom: 16,
+                  flexWrap: 'wrap',
+                }}
+              >
+                {[28, 120].map((s) => (
+                  <div
+                    key={s}
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: 8,
+                    }}
+                  >
+                    <div
+                      style={{ fontSize: 12, fontWeight: 600, color: '#666' }}
+                    >
+                      {s}×{s}
+                    </div>
+                    <div
+                      style={{
+                        width: s + 16,
+                        height: s + 16,
+                        background: '#f0f0f0',
+                        border: '2px solid #e0e0e0',
+                        borderRadius: 8,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      {icon && (
+                        <img
+                          src={icon}
+                          alt={name}
+                          style={{
+                            width: s,
+                            height: s,
+                            borderRadius: s === 28 ? 6 : 25.71,
+                            background: 'white',
+                          }}
+                        />
+                      )}
                     </div>
                   </div>
-                  <div className="svg-box">
-                    <div className="size-label">120×120</div>
-                    <div className="svg-display large">
-                      <img src={wallet.svgDataUrl} alt={wallet.name} />
-                    </div>
+                ))}
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ fontSize: 12, fontWeight: 600, color: '#666' }}>
+                    QR
                   </div>
-                  <div className="svg-box">
-                    <div className="size-label">QR</div>
-                    <div className="svg-display large">
+                  <div
+                    style={{
+                      width: 136,
+                      height: 136,
+                      background: 'white',
+                      border: '2px solid #e0e0e0',
+                      borderRadius: 8,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    {icon && (
                       <Cuer.Root
                         errorCorrection="medium"
                         size={120}
@@ -98,219 +154,47 @@ export default function Icons({ wallets }: IconsProps) {
                         <Cuer.Finder radius={0.25} />
                         <Cuer.Arena>
                           <img
-                            alt={wallet.name}
-                            src={wallet.svgDataUrl}
+                            src={icon}
+                            alt={name}
                             style={{
                               objectFit: 'cover',
                               height: '88%',
                               width: '88%',
                               borderRadius: '22.5%',
+                              background: 'white',
                             }}
                           />
                         </Cuer.Arena>
                       </Cuer.Root>
-                    </div>
+                    )}
                   </div>
                 </div>
-                <button
-                  className="file-path"
-                  onClick={() => {
-                    navigator.clipboard.writeText(
-                      `packages/rainbowkit/src/wallets/walletConnectors/${wallet.name}/${wallet.name}.svg`,
-                    );
-                  }}
-                  aria-label="Copy file path"
-                  title="Copy full path to clipboard"
-                >
-                  <span>
-                    src/wallets/walletConnectors/{wallet.name}/{wallet.name}
-                    .svg
-                  </span>
-                  <svg
-                    className="copy-icon"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 14 14"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    role="img"
-                    aria-label="Copy to clipboard"
-                  >
-                    <title>Copy to clipboard</title>
-                    <path
-                      d="M9.5 1H2.5C1.94772 1 1.5 1.44772 1.5 2V9C1.5 9.55228 1.94772 10 2.5 10H9.5C10.0523 10 10.5 9.55228 10.5 9V2C10.5 1.44772 10.0523 1 9.5 1Z"
-                      stroke="currentColor"
-                      strokeWidth="1.2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M3.5 10V11.5C3.5 12.0523 3.94772 12.5 4.5 12.5H11.5C12.0523 12.5 12.5 12.0523 12.5 11.5V4.5C12.5 3.94772 12.0523 3.5 11.5 3.5H10"
-                      stroke="currentColor"
-                      strokeWidth="1.2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </button>
               </div>
-            ))}
-          </div>
-        </div>
+              <button
+                onClick={() =>
+                  navigator.clipboard.writeText(
+                    `packages/rainbowkit/src/wallets/walletConnectors/${name}/${name}.svg`,
+                  )
+                }
+                style={{
+                  width: '100%',
+                  fontSize: 11,
+                  color: '#999',
+                  fontFamily: 'monospace',
+                  padding: '8px 32px 8px 8px',
+                  background: '#f9f9f9',
+                  borderRadius: 4,
+                  border: '1px solid #e0e0e0',
+                  cursor: 'pointer',
+                  textAlign: 'left',
+                }}
+              >
+                src/wallets/walletConnectors/{name}/{name}.svg
+              </button>
+            </div>
+          );
+        })}
       </div>
-
-      <style jsx>{`
-        .page-wrapper {
-            min-height: 100vh;
-            background: #f5f5f5;
-            padding: 40px 20px;
-            font-family: -apple-system, BlinkMacSystemFont,
-              'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
-              sans-serif;
-        }
-
-        .container {
-            max-width: 1400px;
-            margin: 0 auto;
-        }
-
-        .grid {
-            display: grid;
-            grid-template-columns: repeat(
-              auto-fill,
-              minmax(550px, 1fr)
-            );
-            gap: 24px;
-        }
-
-        .card {
-            background: white;
-            border-radius: 12px;
-            padding: 24px;
-            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-            transition: transform 0.2s, box-shadow 0.2s;
-        }
-
-        .card:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-        }
-
-        .wallet-name {
-            font-size: 20px;
-            font-weight: 600;
-            color: #333;
-            margin-bottom: 16px;
-        }
-
-        .svg-container {
-            display: flex;
-            gap: 24px;
-            align-items: center;
-            margin-bottom: 16px;
-            flex-wrap: wrap;
-        }
-
-        .svg-box {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 8px;
-        }
-
-        .size-label {
-            font-size: 12px;
-            font-weight: 600;
-            color: #666;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-
-        .svg-display {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background: #f0f0f0;
-            border: 2px solid #e0e0e0;
-            border-radius: 8px;
-            padding: 8px;
-        }
-
-        .svg-display.small {
-            width: 44px;
-            height: 44px;
-        }
-
-        .svg-display.large {
-            width: 136px;
-            height: 136px;
-        }
-
-        .svg-box:last-child .svg-display {
-            background: white;
-        }
-
-        .svg-display.small img {
-            width: 28px;
-            height: 28px;
-            border-radius: 6px;
-        }
-
-        .svg-display.large img {
-            width: 120px;
-            height: 120px;
-            border-radius: 25.71px;
-        }
-
-        .file-path {
-            position: relative;
-            width: 100%;
-            font-size: 11px;
-            color: #999;
-            font-family: 'Monaco', 'Menlo', monospace;
-            word-break: break-all;
-            padding: 8px 32px 8px 8px;
-            background: #f9f9f9;
-            border-radius: 4px;
-            border: 1px solid #e0e0e0;
-            display: flex;
-            align-items: center;
-            cursor: pointer;
-            transition: all 0.2s;
-            text-align: left;
-        }
-
-        .file-path:hover {
-            background: #f0f0f0;
-            border-color: #ccc;
-        }
-
-        .file-path:active {
-            background: #e8e8e8;
-        }
-
-        .file-path span {
-            flex: 1;
-        }
-
-        .copy-icon {
-            position: absolute;
-            right: 8px;
-            top: 50%;
-            transform: translateY(-50%);
-        }
-
-        @media (max-width: 768px) {
-            .grid {
-                grid-template-columns: 1fr;
-            }
-
-            .svg-container {
-                flex-direction: column;
-                gap: 16px;
-            }
-        }
-      `}</style>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
fix(examples): resolve indexedDB SSR errors in App Router examples

Use dynamic imports with ssr: false to defer WalletConnect provider
initialization to client-side only. This prevents indexedDB access
during server-side rendering which was causing ReferenceErrors.

Affected examples:
- with-next-app
- with-next-app-i18n

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

Revert "fix(examples): resolve indexedDB SSR errors in App Router examples"

This reverts commit aebfb9ed9cc3100b7dacf57d8b28b7c823a610ed.

refactor(with-next-app-i18n): migrate middleware to proxy convention

Migrate from deprecated middleware.ts to the new proxy.ts file
convention introduced in Next.js 16. The middleware file convention
is deprecated in favor of proxy to clarify the network boundary
and routing focus.

Changes:
- Renamed middleware.ts to proxy.ts
- Changed export from default to named proxy function
- Wrapped next-intl createMiddleware in proxy function

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

fix(example): optimize /icons page to reduce page data size

Convert /icons page from static generation (getStaticProps) to
client-side data fetching. This eliminates the 713 KB page data
warning by moving wallet icon data to an API route that loads
on demand.

Changes:
- Created /api/icons API route to serve wallet data
- Converted icons.tsx to use client-side fetch with loading state
- Removed getStaticProps that embedded all SVG data URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fix: icons
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

chore(with-remix): enable React Router v7 singleFetch future flag

Enable v3_singleFetch future flag in remix.config.js to opt-in
to the new data fetching behavior that will be default in React
Router v7. This silences the deprecation warning during build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

chore(examples): remove redundant pnpm configs from example packages

Remove pnpm.overrides and pnpm.peerDependencyRules from example
package.json files. These configurations only take effect when
defined at the workspace root, so having them in example packages
causes warnings without any actual effect.

Affected examples:
- with-create-react-app
- with-remix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces several updates across multiple files, primarily enhancing wallet icon handling in the `Icons` component and adjusting configurations in `remix.config.js`. It removes deprecated code and improves the overall structure and functionality.

### Detailed summary
- In `remix.config.js`, enabled `v3_singleFetch`.
- Removed unused `pnpm` configurations in `package.json` files for multiple examples.
- Added `NextRequest` type import in `proxy.ts` and refactored middleware logic.
- Replaced file system operations with dynamic loading of wallet icons in `icons.tsx`.
- Simplified wallet icon display and added clipboard functionality for SVG paths.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->