### PR TITLE
Fix NaN ETH balance when using wagmi v3

### DIFF
--- a/.changeset/old-pillows-rhyme.md
+++ b/.changeset/old-pillows-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fix ConnectButton balance display for wagmi v3 (prevents NaN ETH).

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ dist
 # Others
 .DS_Store
 node-compile-cache/
+/.idea/

--- a/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
+++ b/packages/rainbowkit/src/components/ConnectButton/ConnectButtonRenderer.tsx
@@ -1,5 +1,6 @@
 import React, { type ReactNode, useContext } from 'react';
 import { useAccount, useConfig } from 'wagmi';
+import { formatUnits } from 'viem';
 import { normalizeResponsiveValue } from '../../css/sprinkles.css';
 import { useIsMounted } from '../../hooks/useIsMounted';
 import { useProfile } from '../../hooks/useProfile';
@@ -105,9 +106,19 @@ export function ConnectButtonRenderer({
     includeBalance: shouldShowBalance,
   });
 
-  const displayBalance = balance
-    ? `${abbreviateETHBalance(Number.parseFloat(balance.formatted))} ${balance.symbol}`
-    : undefined;
+  const formatted =
+      balance && 'formatted' in (balance as any)
+          ? (balance as any).formatted
+          : balance
+              ? formatUnits((balance as any).value, (balance as any).decimals)
+              : undefined;
+
+  const symbol = (balance as any)?.symbol;
+
+  const displayBalance =
+      formatted != null && symbol
+          ? `${abbreviateETHBalance(Number.parseFloat(formatted))} ${symbol}`
+          : undefined;
 
   const { openConnectModal } = useConnectModal();
   const { openChainModal } = useChainModal();
@@ -122,7 +133,7 @@ export function ConnectButtonRenderer({
           ? {
               address,
               balanceDecimals: balance?.decimals,
-              balanceFormatted: balance?.formatted,
+              balanceFormatted: formatted,
               balanceSymbol: balance?.symbol,
               displayBalance,
               displayName: ensName


### PR DESCRIPTION
Fixes an issue where the ConnectButton displays "NaN ETH" when used with wagmi v3.

wagmi v3 removed `balance.formatted`, but RainbowKit was still assuming the v2
balance shape. This change supports both wagmi v2 and v3 by formatting the
balance from `value` + `decimals` when needed.

- Backward compatible with wagmi v2
- Works correctly with wagmi v3
- Prevents NaN balance display

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the display of the balance in the `ConnectButton` component for wagmi v3, preventing the display of NaN ETH values.

### Detailed summary
- Added `/.idea/` to `.gitignore`.
- Updated balance display logic in `ConnectButtonRenderer`:
  - Introduced `formatted` variable to handle balance formatting.
  - Revised `displayBalance` to ensure it shows a valid value.
  - Changed `balanceFormatted` prop to use `formatted` instead of `balance?.formatted`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->