### PR TITLE
docs: add setup tip for Node.js and pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ RainbowKit is a [React](https://reactjs.org/) library that makes it easy to add 
 - 🦄 Built on top of [wagmi](https://wagmi.sh) and [viem](https://viem.sh)
 
 ## Quick start
+> Tip: For best results, use Node.js v18+ and install `pnpm` before running the setup commands.
 
 You can scaffold a new RainbowKit + [wagmi](https://wagmi.sh) + [Next.js](https://nextjs.org) app with one of the following commands, using your package manager of choice:
 


### PR DESCRIPTION
Added a short tip to clarify recommended Node.js version and pnpm usage for local development.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a tip to the `README.md` file recommending the use of Node.js v18+ and `pnpm` for optimal results when running setup commands.

### Detailed summary
- Added a tip in the `README.md` under "Quick start" suggesting the use of Node.js v18+ and `pnpm` for better results.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->