### PR TITLE
fix: fix browser freeze with multiple wallet extensions installed

### DIFF
--- a/packages/rainbowkit/src/wallets/getInjectedConnector.test.ts
+++ b/packages/rainbowkit/src/wallets/getInjectedConnector.test.ts
@@ -1,10 +1,26 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { mainnet } from 'wagmi/chains';
 import {
   getInjectedConnector,
   hasInjectedProvider,
 } from './getInjectedConnector';
 
+const mockConfig = {
+  chains: [mainnet],
+  emitter: {
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+    listenerCount: vi.fn(() => 0),
+  },
+  storage: undefined,
+} as any;
+
 describe('getInjectedConnector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('only rainbow provider', () => {
     window.ethereum = { isMetaMask: true, isRainbow: true };
     const connector = getInjectedConnector({
@@ -19,6 +35,75 @@ describe('getInjectedConnector', () => {
       flag: 'isMetaMask',
     });
     expect(!!connector).toEqual(true);
+  });
+
+  it('deduplicates concurrent getAccounts calls on the same connector instance', async () => {
+    const mockAccounts = [
+      '0x1234567890123456789012345678901234567890' as const,
+    ];
+    const mockRequest = vi.fn().mockResolvedValue(mockAccounts);
+    window.ethereum = {
+      isMetaMask: true,
+      request: mockRequest,
+    };
+
+    const connector = getInjectedConnector({
+      flag: 'isMetaMask',
+    });
+
+    const connectorInstance = connector({
+      rkDetails: {
+        id: 'metaMask',
+        name: 'MetaMask',
+        isRainbowKitConnector: true,
+      },
+    } as any)(mockConfig);
+
+    const call1 = connectorInstance.getAccounts();
+    const call2 = connectorInstance.getAccounts();
+    const call3 = connectorInstance.getAccounts();
+
+    const [result1, result2, result3] = await Promise.all([
+      call1,
+      call2,
+      call3,
+    ]);
+    expect(result1).toEqual(mockAccounts);
+    expect(result2).toEqual(mockAccounts);
+    expect(result3).toEqual(mockAccounts);
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles getAccounts errors and clears promise', async () => {
+    const mockError = new Error('RPC Error');
+    const mockRequest = vi
+      .fn()
+      .mockRejectedValueOnce(mockError)
+      .mockResolvedValueOnce(['0x1234567890123456789012345678901234567890']);
+
+    window.ethereum = {
+      isMetaMask: true,
+      request: mockRequest,
+    };
+
+    const connector = getInjectedConnector({
+      flag: 'isMetaMask',
+    });
+
+    const connectorInstance = connector({
+      rkDetails: {
+        id: 'metaMask',
+        name: 'MetaMask',
+        isRainbowKitConnector: true,
+      },
+    } as any)(mockConfig);
+
+    await expect(connectorInstance.getAccounts()).rejects.toThrow('RPC Error');
+
+    const result = await connectorInstance.getAccounts();
+    expect(result).toEqual(['0x1234567890123456789012345678901234567890']);
+    expect(mockRequest).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/rainbowkit/src/wallets/getInjectedConnector.ts
+++ b/packages/rainbowkit/src/wallets/getInjectedConnector.ts
@@ -92,11 +92,27 @@ function createInjectedConnector(provider?: any): CreateConnector {
         }
       : {};
 
-    return createConnector((config) => ({
-      // Spread the injectedConfig object, which may be empty or contain the target function
-      ...injected(injectedConfig)(config),
-      ...walletDetails,
-    }));
+    return createConnector((config) => {
+      const baseConnector = injected(injectedConfig)(config);
+      let getAccountsPromise: Promise<readonly `0x${string}`[]> | null = null;
+
+      return {
+        // Spread the injectedConfig object, which may be empty or contain the target function
+        ...baseConnector,
+        ...walletDetails,
+        getAccounts: async () => {
+          // Prevent duplicate getAccounts calls when onConnect event fires multiple times
+          if (getAccountsPromise) return getAccountsPromise;
+          try {
+            getAccountsPromise = baseConnector.getAccounts();
+            const accounts = await getAccountsPromise;
+            return accounts;
+          } finally {
+            getAccountsPromise = null;
+          }
+        },
+      };
+    });
   };
 }
 


### PR DESCRIPTION
Fixes #2534

## Summary

There is an issue that the browser freezes when multiple wallet extensions (e.g., MetaMask, Phantom, Coinbase Wallet) are installed simultaneously. 

I looked into the browser call stack during the freeze and identified an infinite recursion loop between `getAccounts` and the `onConnect` event.

<img width="432" height="1332" alt="evnetloop" src="https://github.com/user-attachments/assets/b731744e-c781-46c4-a9ad-0de42ce64948" />

It looks like having multiple extensions installed causes them to fight for the provider injection.
I noticed in the call stack that registerProviders (from the injected script) gets triggered repeatedly. Since this emits a connection event every time, RainbowKit responds by calling getAccounts again, creating an infinite loop that freezes the app.

## The Fix

I modified the `getAccounts` implementation in `getInjectedConnector` to prevent concurrent calls.
- AS-IS> Every `onConnect` event triggered a new async call to `baseConnector.getAccounts()`.
- TO-BE> If a request is already in flight, the connector now returns the existing promise instead of starting a new one in order to prevent the event loop while ensuring the app still receives the account data.

## Demo
* Before change (freeze on initial load):
![before](https://github.com/user-attachments/assets/2eac86e6-61b2-4719-ab43-3c0267a04006)

* After change:
![after](https://github.com/user-attachments/assets/ef0c7cf0-c74f-4bcc-a9c1-e4ea524fb52e)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `getInjectedConnector` functionality by implementing a deduplication mechanism for `getAccounts` calls, ensuring that multiple requests do not lead to redundant operations. It also includes tests to verify this behavior and error handling.

### Detailed summary
- Refactored `getInjectedConnector` to use a base connector for `getAccounts`.
- Introduced a promise (`getAccountsPromise`) to prevent duplicate `getAccounts` calls.
- Added tests for:
  - Deduplication of concurrent `getAccounts` calls.
  - Error handling for `getAccounts` and promise clearing.
- Updated test cases to mock Ethereum provider behavior.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->