### PR TITLE
feat: support async createMessage in AuthenticationAdapter

### DIFF
--- a/.changeset/async-create-message.md
+++ b/.changeset/async-create-message.md
@@ -2,4 +2,6 @@
 '@rainbow-me/rainbowkit': patch
 ---
 
-feat: support async createMessage in AuthenticationAdapter
+Allow `AuthenticationAdapter.createMessage` to return a promise, so apps can fetch or construct the message to sign asynchronously. This enables server-side SIWE message creation before prompting the wallet, while preserving existing synchronous adapters.
+
+See the [server-side message creation docs](/docs/custom-authentication#server-side-message-creation) for guidance on deriving or validating security-sensitive fields on the server.

--- a/.changeset/async-create-message.md
+++ b/.changeset/async-create-message.md
@@ -1,5 +1,5 @@
 ---
-'@rainbow-me/rainbowkit': minor
+'@rainbow-me/rainbowkit': patch
 ---
 
 feat: support async createMessage in AuthenticationAdapter

--- a/.changeset/async-create-message.md
+++ b/.changeset/async-create-message.md
@@ -2,6 +2,6 @@
 '@rainbow-me/rainbowkit': patch
 ---
 
-Allow `AuthenticationAdapter.createMessage` to return a promise, so apps can fetch or construct the message to sign asynchronously. This enables server-side SIWE message creation before prompting the wallet, while preserving existing synchronous adapters.
+The `AuthenticationAdapter.createMessage` API can now return a promise, so dApps can fetch or construct a custom SIWE message asynchronously. This enables server-side SIWE message creation before prompting the wallet, while preserving existing synchronous behavior.
 
-See the [server-side message creation docs](/docs/custom-authentication#server-side-message-creation) for guidance on deriving or validating security-sensitive fields on the server.
+See the [server-side message creation docs](/docs/custom-authentication#server-side-message-creation) for guidance.

--- a/.changeset/async-create-message.md
+++ b/.changeset/async-create-message.md
@@ -1,0 +1,5 @@
+---
+'@rainbow-me/rainbowkit': minor
+---
+
+feat: support async createMessage in AuthenticationAdapter

--- a/packages/rainbowkit/src/components/RainbowKitProvider/AuthenticationContext.tsx
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/AuthenticationContext.tsx
@@ -20,7 +20,7 @@ export interface AuthenticationAdapter<Message> {
     nonce: string;
     address: Address;
     chainId: number;
-  }) => Message;
+  }) => Promise<Message> | Message;
   verify: (args: { message: Message; signature: string }) => Promise<boolean>;
   signOut: () => Promise<void>;
 }

--- a/packages/rainbowkit/src/components/SignIn/SignIn.test.tsx
+++ b/packages/rainbowkit/src/components/SignIn/SignIn.test.tsx
@@ -1,0 +1,145 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import React from 'react';
+import type { Address } from 'viem';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  RainbowKitAuthenticationProvider,
+  createAuthenticationAdapter,
+} from '../RainbowKitProvider/AuthenticationContext';
+import { SignIn } from './SignIn';
+
+const wagmiMocks = vi.hoisted(() => ({
+  signMessageAsync: vi.fn(),
+  useAccount: vi.fn(),
+  useAccountEffect: vi.fn(),
+}));
+
+vi.mock('wagmi', () => ({
+  useAccount: wagmiMocks.useAccount,
+  useAccountEffect: wagmiMocks.useAccountEffect,
+  useSignMessage: () => ({
+    signMessageAsync: wagmiMocks.signMessageAsync,
+  }),
+}));
+
+const address = '0x0000000000000000000000000000000000000001' as Address;
+
+function renderSignIn({
+  createMessage,
+}: {
+  createMessage: (args: {
+    nonce: string;
+    address: Address;
+    chainId: number;
+  }) => string | Promise<string>;
+}) {
+  const adapter = createAuthenticationAdapter<string>({
+    createMessage,
+    getNonce: async () => 'nonce',
+    signOut: async () => {},
+    verify: async () => true,
+  });
+
+  return render(
+    <RainbowKitAuthenticationProvider
+      adapter={adapter}
+      status="unauthenticated"
+    >
+      <SignIn onClose={() => {}} onCloseModal={() => {}} />
+    </RainbowKitAuthenticationProvider>,
+  );
+}
+
+describe('SignIn', () => {
+  beforeEach(() => {
+    wagmiMocks.signMessageAsync.mockReset();
+    wagmiMocks.useAccount.mockReturnValue({
+      address,
+      chain: { id: 1 },
+    });
+    wagmiMocks.useAccountEffect.mockReset();
+  });
+
+  it('skips message preparation state when message creation is synchronous', async () => {
+    const createMessage = vi.fn(() => 'message');
+    wagmiMocks.signMessageAsync.mockReturnValue(new Promise(() => {}));
+
+    renderSignIn({ createMessage });
+
+    const button = await screen.findByTestId('rk-auth-message-button');
+    await waitFor(() => expect(button).toHaveTextContent('Sign message'));
+
+    fireEvent.click(button);
+
+    expect(createMessage).toHaveBeenCalledOnce();
+    await waitFor(() =>
+      expect(wagmiMocks.signMessageAsync).toHaveBeenCalledWith({
+        message: 'message',
+      }),
+    );
+    expect(button).toHaveTextContent('Waiting for signature...');
+  });
+
+  it('shows message preparation state while async message creation is pending', async () => {
+    let resolveMessage: (message: string) => void = () => {};
+    const messagePromise = new Promise<string>((resolve) => {
+      resolveMessage = resolve;
+    });
+    const createMessage = vi.fn(() => messagePromise);
+    wagmiMocks.signMessageAsync.mockReturnValue(new Promise(() => {}));
+
+    renderSignIn({ createMessage });
+
+    const button = await screen.findByTestId('rk-auth-message-button');
+    await waitFor(() => expect(button).toHaveTextContent('Sign message'));
+
+    fireEvent.click(button);
+
+    expect(createMessage).toHaveBeenCalledOnce();
+    expect(wagmiMocks.signMessageAsync).not.toHaveBeenCalled();
+    expect(button).toHaveTextContent('Preparing message...');
+
+    await act(async () => {
+      resolveMessage('message');
+      await messagePromise;
+    });
+
+    await waitFor(() =>
+      expect(wagmiMocks.signMessageAsync).toHaveBeenCalledWith({
+        message: 'message',
+      }),
+    );
+    expect(button).toHaveTextContent('Waiting for signature...');
+  });
+
+  it('preserves the nonce so users can retry after message creation fails', async () => {
+    const createMessage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockReturnValue(new Promise(() => {}));
+
+    renderSignIn({ createMessage });
+
+    const button = await screen.findByTestId('rk-auth-message-button');
+    await waitFor(() => expect(button).toHaveTextContent('Sign message'));
+
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Error preparing message, please retry!'),
+      ).toBeInTheDocument(),
+    );
+    expect(button).toHaveTextContent('Sign message');
+
+    fireEvent.click(button);
+
+    expect(createMessage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/rainbowkit/src/components/SignIn/SignIn.tsx
+++ b/packages/rainbowkit/src/components/SignIn/SignIn.tsx
@@ -72,7 +72,11 @@ export function SignIn({
         status: 'signing',
       }));
 
-      const message = authAdapter.createMessage({ address, chainId, nonce });
+      const message = await authAdapter.createMessage({
+        address,
+        chainId,
+        nonce,
+      });
       let signature: string;
 
       try {

--- a/packages/rainbowkit/src/components/SignIn/SignIn.tsx
+++ b/packages/rainbowkit/src/components/SignIn/SignIn.tsx
@@ -22,7 +22,7 @@ export function SignIn({
 }) {
   const { i18n } = useContext(I18nContext);
   const [{ status, ...state }, setState] = React.useState<{
-    status: 'idle' | 'signing' | 'verifying';
+    status: 'idle' | 'creatingMessage' | 'signing' | 'verifying';
     errorMessage?: string;
     nonce?: string;
   }>({ status: 'idle' });
@@ -69,17 +69,34 @@ export function SignIn({
       setState((x) => ({
         ...x,
         errorMessage: undefined,
-        status: 'signing',
       }));
 
-      const message = await authAdapter.createMessage({
-        address,
-        chainId,
-        nonce,
-      });
+      let message: Awaited<ReturnType<typeof authAdapter.createMessage>>;
+      try {
+        const messageResult = authAdapter.createMessage({
+          address,
+          chainId,
+          nonce,
+        });
+
+        if (messageResult instanceof Promise) {
+          setState((x) => ({ ...x, status: 'creatingMessage' }));
+        }
+
+        message = await messageResult;
+      } catch {
+        return setState((x) => ({
+          ...x,
+          errorMessage: i18n.t('sign_in.message.preparing_error'),
+          status: 'idle',
+        }));
+      }
+
       let signature: string;
 
       try {
+        setState((x) => ({ ...x, status: 'signing' }));
+
         signature = await signMessageAsync({
           message,
         });
@@ -120,10 +137,11 @@ export function SignIn({
         }));
       }
     } catch {
-      setState({
+      setState((x) => ({
+        ...x,
         errorMessage: i18n.t('sign_in.signature.oops_error'),
         status: 'idle',
-      });
+      }));
     }
   };
 
@@ -205,10 +223,13 @@ export function SignIn({
         >
           <ActionButton
             disabled={
-              !state.nonce || status === 'signing' || status === 'verifying'
+              !state.nonce ||
+              status === 'creatingMessage' ||
+              status === 'signing' ||
+              status === 'verifying'
             }
             label={
-              !state.nonce
+              !state.nonce || status === 'creatingMessage'
                 ? i18n.t('sign_in.message.preparing')
                 : status === 'signing'
                   ? i18n.t('sign_in.signature.waiting')

--- a/site/data/en-US/docs/custom-authentication.mdx
+++ b/site/data/en-US/docs/custom-authentication.mdx
@@ -55,15 +55,19 @@ const authenticationAdapter = createAuthenticationAdapter({
 
 #### Server-side message creation
 
-For stricter security, `createMessage` also supports returning a `Promise`, allowing you to construct [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) messages on the server where security-critical fields like `domain`, `nonce`, and `issued-at` timestamps can't be manipulated by clients. See [SIWE documentation](https://docs.siwe.xyz/quickstart/creating-messages#server-side-message-creation) for more details.
+`createMessage` also supports returning a `Promise`, allowing you to construct [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) messages on the server. For stricter security, the server endpoint should derive or validate security-critical fields like `domain`, `nonce`, and `issued-at` timestamps instead of trusting client-provided values. See [SIWE documentation](https://docs.siwe.xyz/quickstart/creating-messages#server-side-message-creation) for more details.
 
 ```tsx
-  createMessage: async ({ nonce, address, chainId }) => {
+  createMessage: async ({ address, chainId }) => {
     const response = await fetch('/api/siwe/message', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ nonce, address, chainId }),
+      body: JSON.stringify({ address, chainId }),
     });
+
+    if (!response.ok) {
+      throw new Error('Failed to create message');
+    }
 
     return await response.text();
   },

--- a/site/data/en-US/docs/custom-authentication.mdx
+++ b/site/data/en-US/docs/custom-authentication.mdx
@@ -53,6 +53,22 @@ const authenticationAdapter = createAuthenticationAdapter({
 });
 ```
 
+#### Server-side message creation
+
+For stricter security, `createMessage` also supports returning a `Promise`, allowing you to construct [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) messages on the server where security-critical fields like `domain`, `nonce`, and `issued-at` timestamps can't be manipulated by clients. See [SIWE documentation](https://docs.siwe.xyz/quickstart/creating-messages#server-side-message-creation) for more details.
+
+```tsx
+  createMessage: async ({ nonce, address, chainId }) => {
+    const response = await fetch('/api/siwe/message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nonce, address, chainId }),
+    });
+
+    return await response.text();
+  },
+```
+
 #### Providing the authentication state
 
 Assuming your application is already managing the authentication lifecycle in some way, you can pass the current authentication status along with your custom adapter to `RainbowKitAuthenticationProvider`, wrapping your existing `RainbowKitProvider`.


### PR DESCRIPTION
## Description

`createMessage` return type widened from `Message` to `Promise<Message> | Message`, enabling server-side SIWE message creation.

## Background

[EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) and [SIWE docs](https://docs.siwe.xyz/quickstart/creating-messages#server-side-message-creation) recommend constructing messages on the server to prevent client manipulation of `domain`, `nonce`, `issued-at`. This was impossible with a sync-only `createMessage`.

From the docs, it's more desirable to generate nonce and create message in a single call. In this case, we don't need `getNonce` separately - I'd like to make this optional if this PR accepted as a follow up.

<!-- start pr-codex -->

## PR-Codex overview
This PR introduces support for asynchronous message creation in the `AuthenticationAdapter`, enhancing security by allowing server-side message generation.

### Detailed summary
- Updated `createMessage` in `AuthenticationAdapter` to return a `Promise<Message>` instead of `Message`.
- Updated `SignIn.tsx` to use `await` with `createMessage`.
- Added documentation on server-side message creation in `custom-authentication.mdx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widens a public authentication adapter API and changes the Sign-In flow state machine; async handling and error paths could affect downstream integrations and UI behavior during SIWE signing.
> 
> **Overview**
> Enables `AuthenticationAdapter.createMessage` to return `Promise<Message> | Message`, allowing dApps to fetch/construct SIWE messages asynchronously (e.g., server-side) while keeping sync adapters working.
> 
> Updates the `SignIn` flow to await message creation, introduce a new *creating message* UI state (disables the button and shows “Preparing message…”), and handle message-creation failures without losing the existing nonce so users can retry. Adds targeted `SignIn` tests for sync vs async behavior and retry-on-failure, plus documentation and a patch changeset describing server-side message creation guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 481196174d50cfb1558a7e538bc328370e35c9c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->