### PR TITLE
chore: disable Dependabot version updates, keep security-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: weekly
     versioning-strategy: lockfile-only
+    open-pull-requests-limit: 0
     groups:
       security:
         applies-to: security-updates


### PR DESCRIPTION
## Summary
- Adds `open-pull-requests-limit: 0` to disable version update PRs
- Security updates remain active and grouped into a single PR (hardcoded limit of 10, unaffected by this setting)
- The 5 currently open Dependabot PRs (#2645–#2649) are all version updates, not security — this change prevents future noise

## Test plan
- [ ] Verify no new version update PRs are opened after merge
- [ ] Verify security update PRs still work when advisories are published