### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,3 +161,14 @@ pnpm link:cli  # Makes `create-rainbowkit` available system-wide
 - React 19 and Next.js 15 compatible
 - Built on wagmi v2 and viem 2.x
 - Node.js >= 22 required
+
+## Cursor Cloud specific instructions
+
+- **Node.js**: Installed via nvm (v22). Source nvm before running any commands: `export NVM_DIR="$HOME/.nvm" && source "$NVM_DIR/nvm.sh"`.
+- **pnpm**: Enabled via `corepack enable pnpm`. The lockfile pins pnpm 10.24.0.
+- **`pnpm install`** runs `prepare` scripts that build the three library packages (`rainbowkit`, `rainbow-button`, `rainbowkit-siwe-next-auth`). A separate `pnpm build` is needed only for the `site`, `example`, and other example apps.
+- **Dev servers**: `pnpm dev:example` starts library watch-mode + the example Next.js app on port 3000. `pnpm dev:site` starts library watch-mode + the docs site on port 3001. `pnpm dev` runs both.
+- **Environment variables**: `RAINBOW_PROVIDER_API_KEY` and `WALLETCONNECT_PROJECT_ID` are optional; the example app and tests work without them (enhanced provider is disabled and WalletConnect falls back to a placeholder).
+- **No external services**: No databases, Docker, or external APIs are required. This is a pure frontend/library monorepo.
+- **Lint/test/build commands**: See the "Development Commands" section above. All commands are run from the repo root.
+- **Pre-commit hooks**: Husky runs `pnpm lint` on pre-commit and commitlint on commit-msg. Commit messages must follow conventional commit format (see `commitlint.config.js`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with durable, non-obvious context for future Cloud Agent sessions:

- nvm sourcing requirement for Node.js 22
- pnpm enablement via corepack
- Clarification that `pnpm install` runs prepare/build for library packages
- Dev server port assignments (3000 for example, 3001 for docs)
- Environment variables are optional (app/tests work without them)
- No external services required
- Pre-commit hook behavior (Husky + commitlint)

**Verification**

All commands were verified in the Cloud Agent environment:

| Check | Result |
|---|---|
| `pnpm install --frozen-lockfile` | All 2503 packages installed, prepare scripts built library packages |
| `pnpm build` | All packages built successfully (libs, examples, site) |
| `pnpm lint` | Biome lint + format check + typecheck all passed |
| `pnpm test run` | 21 test files, 93 tests passed |
| `pnpm dev:example` | Example app running on localhost:3000, HTTP 200 |

[rainbowkit_connect_wallet_demo.mp4](https://cursor.com/agents/bc-d3a2cf4e-9c53-4b4c-acd7-ce561d428432/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frainbowkit_connect_wallet_demo.mp4)

Demo showing the RainbowKit example app's Connect Wallet flow working at localhost:3000.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3a2cf4e-9c53-4b4c-acd7-ce561d428432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3a2cf4e-9c53-4b4c-acd7-ce561d428432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

