### PR TITLE
fix: replace innerHTML with DOM property assignment in useCoolMode

### DIFF
--- a/.changeset/fix-coolmode-innerhtml-xss.md
+++ b/.changeset/fix-coolmode-innerhtml-xss.md
@@ -1,0 +1,13 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+fix: harden useCoolMode against malicious wallet icon URLs
+
+The cool mode particle animation built image elements via `innerHTML`, which
+parses its input as HTML. A malicious EIP-6963 wallet could supply a crafted
+icon URL containing injected attributes (e.g. `onerror`) that would execute
+in the dApp's origin when a user interacts with the wallet button.
+
+Switched to `document.createElement('img')` with property assignment so the
+icon value is always treated as a plain URL rather than markup.

--- a/packages/rainbowkit/src/components/RainbowKitProvider/useCoolMode.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/useCoolMode.ts
@@ -84,7 +84,12 @@ function makeElementCool(element: HTMLElement, imageUrl: string): () => void {
     const direction = Math.random() <= 0.5 ? -1 : 1;
 
     const particle = document.createElement('div');
-    particle.innerHTML = `<img src="${imageUrl}" width="${size}" height="${size}" style="border-radius: 25%">`;
+    const img = document.createElement('img');
+    img.src = imageUrl;
+    img.width = size;
+    img.height = size;
+    img.style.borderRadius = '25%';
+    particle.appendChild(img);
     particle.setAttribute(
       'style',
       [


### PR DESCRIPTION
## Summary

Replaces `innerHTML` string interpolation with explicit DOM element construction in the `useCoolMode` particle animation hook.

```diff
- particle.innerHTML = `<img src="${imageUrl}" width="${size}" height="${size}" style="border-radius: 25%">`;
+ const img = document.createElement('img');
+ img.src = imageUrl;
+ img.width = size;
+ img.height = size;
+ img.style.borderRadius = '25%';
+ particle.appendChild(img);
```

## Background

The wallet icon URL passed to `useCoolMode` originates from the EIP-6963 connector pipeline: the `eip6963:announceProvider` browser event is consumed by [mipd](https://github.com/wevm/mipd), which stores the provider detail and emits it to listeners. mipd defines `icon` as the TypeScript type `` `data:image/${string}` `` per RFC-2397, but performs **no runtime validation** — the type annotation is erased at compile time and the raw event value is stored and forwarded as-is. wagmi's `providerDetailToConnector` then spreads the `info` object directly (`{ ...info, id: info.rdns, provider }`) and exposes the icon via `connector.icon`, again without validation.

The result is that `imageUrl` in `useCoolMode` can be any string a wallet extension chooses to announce. The previous `innerHTML` call treated that string as HTML markup, meaning a crafted value such as:

```
x" onerror="<payload>" data-x="
```

would cause the browser to parse and execute the injected attribute.

## Risk level: Low

Exploitation requires a **malicious browser extension** already installed by the user. A browser extension that targets a specific dApp can manipulate its DOM directly through its content script — this XSS primitive does not meaningfully expand what such an extension could already do on the page.

The fix is applied regardless because:
- `innerHTML` with any external value is incorrect regardless of the threat model
- DOM property assignment (`img.src = value`) is the right API for placing a URL into an image element
- The rest of RainbowKit's icon rendering pipeline (modal, ConnectDetails, MobileOptions) already uses safe React JSX `<img src>` — this brings `useCoolMode` in line with that pattern