### PR TITLE
fix: guard localStorage access during SSR

### DIFF
--- a/.changeset/ssr-safety-improvements.md
+++ b/.changeset/ssr-safety-improvements.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Improved SSR safety to prevent WalletConnect initialization warnings and avoid localStorage crashes in newer Node.js versions.
+Improved SSR safety to prevent WalletConnect initialization warnings and mitigate localStorage API availability changes in Node.js v25 and above.

--- a/.changeset/ssr-safety-improvements.md
+++ b/.changeset/ssr-safety-improvements.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Improved SSR safety to prevent WalletConnect initialization warnings.
+Improved SSR safety to prevent WalletConnect initialization warnings and avoid localStorage crashes in newer Node.js versions.

--- a/packages/rainbowkit/src/components/RainbowKitProvider/useFingerprint.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/useFingerprint.ts
@@ -3,7 +3,9 @@ import { useCallback, useEffect } from 'react';
 const storageKey = 'rk-version';
 
 function setRainbowKitVersion({ version }: { version: string }) {
-  localStorage.setItem(storageKey, version);
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(storageKey, version);
+  }
 }
 
 export function useFingerprint() {

--- a/packages/rainbowkit/src/components/RainbowKitProvider/walletConnectDeepLink.ts
+++ b/packages/rainbowkit/src/components/RainbowKitProvider/walletConnectDeepLink.ts
@@ -7,7 +7,9 @@ export function setWalletConnectDeepLink({
   mobileUri: string;
   name: string;
 }) {
-  localStorage.setItem(
+  if (typeof window === 'undefined') return;
+
+  window.localStorage.setItem(
     storageKey,
     JSON.stringify({
       href: mobileUri.split('?')[0],
@@ -17,5 +19,7 @@ export function setWalletConnectDeepLink({
 }
 
 export function clearWalletConnectDeepLink() {
-  localStorage.removeItem(storageKey);
+  if (typeof window !== 'undefined') {
+    window.localStorage.removeItem(storageKey);
+  }
 }

--- a/packages/rainbowkit/src/transactions/transactionStore.ts
+++ b/packages/rainbowkit/src/transactions/transactionStore.ts
@@ -26,8 +26,8 @@ function safeParseJsonData(string: string | null): Data {
 
 function loadData(): Data {
   return safeParseJsonData(
-    typeof localStorage !== 'undefined'
-      ? localStorage.getItem(storageKey)
+    typeof window !== 'undefined'
+      ? window.localStorage.getItem(storageKey)
       : null,
   );
 }
@@ -203,7 +203,9 @@ export function createTransactionStore({
   }
 
   function persistData(): void {
-    localStorage.setItem(storageKey, JSON.stringify(data));
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(storageKey, JSON.stringify(data));
+    }
   }
 
   function notifyListeners(): void {

--- a/packages/rainbowkit/src/utils/ens.ts
+++ b/packages/rainbowkit/src/utils/ens.ts
@@ -19,13 +19,13 @@ function safeParseJsonData(string: string | null): EnsData | null {
 }
 
 export function addEnsName(address: Address, ensName: string) {
-  if (!isAddress(address)) return;
+  if (!isAddress(address) || typeof window === 'undefined') return;
 
   const now = new Date();
 
   const expiry = new Date(now.getTime() + 180 * 60_000); // Set expiry to 3 hours from now
 
-  localStorage.setItem(
+  window.localStorage.setItem(
     getStorageEnsNameKey(address),
     JSON.stringify({
       ensName,
@@ -35,8 +35,10 @@ export function addEnsName(address: Address, ensName: string) {
 }
 
 export function getEnsName(address: Address): string | null {
+  if (typeof window === 'undefined') return null;
+
   const data = safeParseJsonData(
-    localStorage.getItem(getStorageEnsNameKey(address)),
+    window.localStorage.getItem(getStorageEnsNameKey(address)),
   );
 
   if (!data) return null;
@@ -44,14 +46,14 @@ export function getEnsName(address: Address): string | null {
   const { ensName, expires } = data;
 
   if (typeof ensName !== 'string' || Number.isNaN(Number(expires))) {
-    localStorage.removeItem(getStorageEnsNameKey(address));
+    window.localStorage.removeItem(getStorageEnsNameKey(address));
     return null;
   }
 
   const now = new Date();
 
   if (now.getTime() > Number(expires)) {
-    localStorage.removeItem(getStorageEnsNameKey(address));
+    window.localStorage.removeItem(getStorageEnsNameKey(address));
     return null;
   }
 

--- a/packages/rainbowkit/src/wallets/latestWalletId.ts
+++ b/packages/rainbowkit/src/wallets/latestWalletId.ts
@@ -1,15 +1,19 @@
 const storageKey = 'rk-latest-id';
 
 export function getLatestWalletId(): string {
-  return typeof localStorage !== 'undefined'
-    ? localStorage.getItem(storageKey) || ''
+  return typeof window !== 'undefined'
+    ? window.localStorage.getItem(storageKey) || ''
     : '';
 }
 
 export function addLatestWalletId(walletId: string): void {
-  localStorage.setItem(storageKey, walletId);
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(storageKey, walletId);
+  }
 }
 
 export function clearLatestWalletId(): void {
-  localStorage.removeItem(storageKey);
+  if (typeof window !== 'undefined') {
+    window.localStorage.removeItem(storageKey);
+  }
 }

--- a/packages/rainbowkit/src/wallets/recentWalletIds.ts
+++ b/packages/rainbowkit/src/wallets/recentWalletIds.ts
@@ -10,8 +10,8 @@ function safeParseJsonArray<T>(string: string | null): T[] {
 }
 
 export function getRecentWalletIds(): string[] {
-  return typeof localStorage !== 'undefined'
-    ? safeParseJsonArray(localStorage.getItem(storageKey))
+  return typeof window !== 'undefined'
+    ? safeParseJsonArray(window.localStorage.getItem(storageKey))
     : [];
 }
 
@@ -22,5 +22,7 @@ function dedupe<T>(array: T[]): T[] {
 export function addRecentWalletId(walletId: string): void {
   const newValue = dedupe([walletId, ...getRecentWalletIds()]);
 
-  localStorage.setItem(storageKey, JSON.stringify(newValue));
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(storageKey, JSON.stringify(newValue));
+  }
 }


### PR DESCRIPTION
## Summary
- guard RainbowKit's browser storage calls with `typeof window !== 'undefined'`
- use `window.localStorage` instead of the bare Node/global `localStorage`
- update the existing SSR safety changeset

## Why
Node 25 exposes a global `localStorage`, and without `--localstorage-file` it can be an empty object rather than browser `Storage`. That made SSR code paths pass `typeof localStorage !== 'undefined'` and then crash on `localStorage.getItem`.

Using `window.localStorage` keeps browser behavior unchanged while ensuring server-side React/Next execution does not treat Node globals as browser storage.

Fixes #2639.

## Validation
- `pnpm test:unit run packages/rainbowkit/src/utils/ens.test.ts`
- `pnpm format:check`
- `git diff --check`

Note: the full pre-commit `pnpm lint` hook still fails on existing QRCode TypeScript errors in `packages/rainbowkit/src/components/QRCode/QRCode.tsx`, unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding `window` guards around `localStorage` reads/writes to avoid SSR/Node v25 runtime errors; behavior only differs in non-browser environments where storage is now skipped.
> 
> **Overview**
> Tightens SSR safety by replacing bare `localStorage` usage with `window.localStorage` and explicit `typeof window !== 'undefined'` guards across fingerprinting, WalletConnect deep link persistence, transaction persistence, ENS cache, and recent/latest wallet ID storage.
> 
> Also updates the changeset note to call out mitigation for Node.js v25+ where a global `localStorage` may exist but not behave like browser `Storage`, preventing crashes/warnings during server-side rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 281a46f71952dc49c4e4eb44f4b2cfeb8864f3d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->