### PR TITLE
chore: use active Alchemy mainnet transports

### DIFF
--- a/.changeset/example-alchemy-mainnet-transport.md
+++ b/.changeset/example-alchemy-mainnet-transport.md
@@ -1,0 +1,5 @@
+---
+"example": patch
+---
+
+Use the configured Alchemy API key for active example app mainnet RPC transports.

--- a/packages/example/src/transports.ts
+++ b/packages/example/src/transports.ts
@@ -1,0 +1,58 @@
+import type { Chain, Transport } from 'viem';
+import { http } from 'wagmi';
+import {
+  arbitrum,
+  avalanche,
+  base,
+  blast,
+  bsc,
+  gnosis,
+  linea,
+  mainnet,
+  optimism,
+  polygon,
+  scroll,
+  zksync,
+  zora,
+} from 'wagmi/chains';
+
+const alchemy = (): Transport => {
+  const alchemyNetworks = {
+    [mainnet.id]: 'eth-mainnet',
+    [base.id]: 'base-mainnet',
+    [optimism.id]: 'opt-mainnet',
+    [arbitrum.id]: 'arb-mainnet',
+    [polygon.id]: 'polygon-mainnet',
+    [avalanche.id]: 'avax-mainnet',
+    [blast.id]: 'blast-mainnet',
+    [bsc.id]: 'bnb-mainnet',
+    [zora.id]: 'zora-mainnet',
+    [linea.id]: 'linea-mainnet',
+    [gnosis.id]: 'gnosis-mainnet',
+    [scroll.id]: 'scroll-mainnet',
+    [zksync.id]: 'zksync-mainnet',
+  } as const;
+
+  return (parameters) => {
+    const network = parameters.chain
+      ? alchemyNetworks[parameters.chain.id as keyof typeof alchemyNetworks]
+      : undefined;
+
+    return http(
+      network && process.env.NEXT_PUBLIC_ALCHEMY_ID
+        ? `https://${network}.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_ID}`
+        : undefined,
+    )(parameters);
+  };
+};
+
+export const createTransports = <chains extends readonly [Chain, ...Chain[]]>(
+  chains: chains,
+) => {
+  const transport = alchemy();
+
+  return Object.fromEntries(chains.map(({ id }) => [id, transport])) as Record<
+    chains[number]['id'],
+    Transport
+  >;
+};

--- a/packages/example/src/wagmi.ts
+++ b/packages/example/src/wagmi.ts
@@ -109,6 +109,7 @@ import {
   zora,
   zoraSepolia,
 } from 'wagmi/chains';
+import { createTransports } from './transports';
 
 const projectId =
   process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID ?? 'YOUR_PROJECT_ID';
@@ -147,57 +148,60 @@ const avalanche = {
   },
 } as const satisfies Chain;
 
+const chains = [
+  mainnet,
+  base,
+  optimism,
+  arbitrum,
+  polygon,
+  apeChain,
+  avalanche,
+  berachain,
+  blast,
+  bsc,
+  degen,
+  gravity,
+  ink,
+  sanko,
+  superposition,
+  unichain,
+  zora,
+  linea,
+  gnosis,
+  scroll,
+  zksync,
+  lukso,
+  ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true'
+    ? [
+        sepolia,
+        holesky,
+        arbitrumSepolia,
+        avalancheFuji,
+        baseSepolia,
+        berachainTestnetbArtio,
+        blastSepolia,
+        bscTestnet,
+        curtis,
+        inkSepolia,
+        lineaSepolia,
+        monadTestnet,
+        optimismSepolia,
+        polygonMumbai,
+        scrollSepolia,
+        unichainSepolia,
+        zoraSepolia,
+      ]
+    : []),
+] as const satisfies readonly [Chain, ...Chain[]];
+
 export const config = getDefaultConfig({
   appName: 'RainbowKit Demo',
   projectId,
   walletConnectParameters: {
     telemetryEnabled: false,
   },
-  chains: [
-    mainnet,
-    base,
-    optimism,
-    arbitrum,
-    polygon,
-    apeChain,
-    avalanche,
-    berachain,
-    blast,
-    bsc,
-    degen,
-    gravity,
-    ink,
-    sanko,
-    superposition,
-    unichain,
-    zora,
-    linea,
-    gnosis,
-    scroll,
-    zksync,
-    lukso,
-    ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true'
-      ? [
-          sepolia,
-          holesky,
-          arbitrumSepolia,
-          avalancheFuji,
-          baseSepolia,
-          berachainTestnetbArtio,
-          blastSepolia,
-          bscTestnet,
-          curtis,
-          inkSepolia,
-          lineaSepolia,
-          monadTestnet,
-          optimismSepolia,
-          polygonMumbai,
-          scrollSepolia,
-          unichainSepolia,
-          zoraSepolia,
-        ]
-      : []),
-  ],
+  chains,
+  transports: createTransports(chains),
   wallets: [
     {
       groupName: 'Popular',


### PR DESCRIPTION
## Summary

- Keep the example app chain list as a shared `chains` array.
- Generate a complete transport map with `createTransports(chains)`.
- Move the chain-aware Alchemy transport helper into `packages/example/src/transports.ts`.
- Use `NEXT_PUBLIC_ALCHEMY_ID` only for active Alchemy mainnets; missing env, inactive mainnets, unsupported chains, and testnets fall back to viem's default `http()` behavior.

## Root cause

`getDefaultConfig` creates default `http()` transports when no transport map is supplied. Bare `http()` lets viem resolve each chain to its first built-in default RPC URL. For Ethereum mainnet that currently resolves to `https://eth.merkle.io`, which caused the failed/429 requests observed in the Vercel example app HAR.

## Implementation note

The custom `alchemy()` transport is chain-aware because wagmi/viem call transport factories with `{ chain }` when creating a client. It looks up active Alchemy mainnet slugs internally and delegates to `http(url)` when both a slug and `NEXT_PUBLIC_ALCHEMY_ID` exist; otherwise it delegates to `http(undefined)`, preserving viem's default chain RPC fallback.

## Alchemy endpoint testing

Tested with the provided example Alchemy key using `eth_chainId` against each Alchemy-supported mainnet URL in the example chain list.

Active for this key and included with Alchemy URLs:

- Ethereum mainnet
- Base
- OP Mainnet
- Arbitrum One
- Polygon
- Avalanche
- Blast
- BNB Smart Chain
- Zora
- Linea
- Gnosis
- Scroll
- ZKsync Era

Documented by Alchemy but inactive for this key, so they fall back to default `http()`:

- ApeChain: 403 network not enabled
- Berachain: 403 network not enabled
- Degen: 403 network not enabled
- Ink: 403 network not enabled
- Unichain: 403 network not enabled

Not listed in Alchemy Node supported-chain docs, so they fall back to default `http()`:

- Gravity
- Sanko
- Superposition
- LUKSO

## Validation

- `pnpm exec biome check packages/example/src/wagmi.ts packages/example/src/transports.ts .changeset/example-alchemy-mainnet-transport.md`
- `git diff --check`
- `pnpm --filter example typecheck` still fails only on the existing `cuer@0.0.3` QRCode prop typing errors in `packages/example/src/pages/icons.tsx`; no `wagmi.ts` or `transports.ts` errors remain. PR #2663 addresses that separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the example app’s RPC transport selection, which can impact connectivity/rate limits across multiple chains if the Alchemy mapping or env var is misconfigured. Scope is limited to the example package and falls back to default `http()` when unavailable.
> 
> **Overview**
> The example app now supplies an explicit `transports` map to `getDefaultConfig`, routing supported mainnets through Alchemy when `NEXT_PUBLIC_ALCHEMY_ID` is present and otherwise falling back to default `http()` behavior.
> 
> This factors the chain list into a shared `chains` constant and introduces `packages/example/src/transports.ts` with a chain-aware Alchemy transport factory plus `createTransports(chains)` to generate the per-chain transport mapping. A changeset bumps `example` with a patch note describing the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84f754037f34dd5045b0eab38659e9ee76248e6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->