### PR TITLE
fix: isolate recent transaction receipt waits

### DIFF
--- a/.changeset/fix-recent-transaction-wait.md
+++ b/.changeset/fix-recent-transaction-wait.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fix recent transaction tracking so failed transactions no longer prevent an app's own transaction receipt wait from settling.

--- a/packages/rainbowkit/src/transactions/getTransactionProvider.test.ts
+++ b/packages/rainbowkit/src/transactions/getTransactionProvider.test.ts
@@ -1,0 +1,85 @@
+import type { PublicClient } from 'viem';
+import { waitForTransactionReceipt } from 'viem/actions';
+import { describe, expect, it, vi } from 'vitest';
+import { getTransactionProvider } from './getTransactionProvider';
+
+const hash =
+  '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d';
+
+function createDeferred<value>() {
+  let resolve: (value: value) => void = () => {};
+  const promise = new Promise<value>((resolve_) => {
+    resolve = resolve_;
+  });
+
+  return { promise, resolve };
+}
+
+function createReceipt() {
+  return { status: 'success' } as Awaited<
+    ReturnType<typeof waitForTransactionReceipt>
+  >;
+}
+
+function createProvider(uid: string) {
+  const receipts: ReturnType<
+    typeof createDeferred<ReturnType<typeof createReceipt>>
+  >[] = [];
+  const getTransactionReceipt = vi.fn(() => {
+    const receipt = createDeferred<ReturnType<typeof createReceipt>>();
+    receipts.push(receipt);
+    return receipt.promise;
+  });
+
+  const provider = {
+    getTransactionReceipt,
+    pollingInterval: 1,
+    uid,
+  } as unknown as PublicClient & {
+    getTransactionReceipt: ReturnType<typeof vi.fn>;
+  };
+
+  return { provider, receipts };
+}
+
+describe('getTransactionProvider', () => {
+  it('uses a RainbowKit transaction watcher uid', () => {
+    const { provider } = createProvider('app-client');
+
+    expect(getTransactionProvider(provider)).toEqual(
+      expect.objectContaining({
+        uid: `${provider.uid}.rk-transactions`,
+      }),
+    );
+  });
+
+  it('documents viem watcher sharing for the same provider uid and hash', async () => {
+    const { provider, receipts } = createProvider('app-client-shared');
+
+    const wait = [
+      waitForTransactionReceipt(provider, { hash, timeout: 0 }),
+      waitForTransactionReceipt(provider, { hash, timeout: 0 }),
+    ];
+
+    expect(provider.getTransactionReceipt).toHaveBeenCalledTimes(1);
+
+    receipts[0]?.resolve(createReceipt());
+    await Promise.all(wait);
+  });
+
+  it('uses a separate viem watcher from the app provider for the same hash', async () => {
+    const { provider, receipts } = createProvider('app-client-isolated');
+    const transactionProvider = getTransactionProvider(provider);
+
+    const wait = [
+      waitForTransactionReceipt(provider, { hash, timeout: 0 }),
+      waitForTransactionReceipt(transactionProvider, { hash, timeout: 0 }),
+    ];
+
+    expect(provider.getTransactionReceipt).toHaveBeenCalledTimes(2);
+
+    receipts[0]?.resolve(createReceipt());
+    receipts[1]?.resolve(createReceipt());
+    await Promise.all(wait);
+  });
+});

--- a/packages/rainbowkit/src/transactions/getTransactionProvider.ts
+++ b/packages/rainbowkit/src/transactions/getTransactionProvider.ts
@@ -1,0 +1,15 @@
+import type { PublicClient } from 'viem';
+
+const transactionWatcherKey = 'rk-transactions';
+
+export function getTransactionProvider(provider: PublicClient): PublicClient {
+  const uid = `${provider.uid}.${transactionWatcherKey}`;
+
+  // viem dedupes receipt watchers by client UID and hash. RainbowKit uses a
+  // stable app-wide UID suffix so its internal watchers don't share observer
+  // state with app-level transaction waits for the same hash.
+  return {
+    ...provider,
+    uid,
+  } as PublicClient;
+}

--- a/packages/rainbowkit/src/transactions/transactionStore.test.ts
+++ b/packages/rainbowkit/src/transactions/transactionStore.test.ts
@@ -1,0 +1,55 @@
+import type { PublicClient } from 'viem';
+import { waitForTransactionReceipt } from 'viem/actions';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTransactionStore } from './transactionStore';
+
+vi.mock('viem/actions', () => ({
+  waitForTransactionReceipt: vi.fn(),
+}));
+
+const account = '0x8ba1f109551bd432803012645ac136ddd64dba72';
+const hash =
+  '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d';
+
+describe('transactionStore', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.mocked(waitForTransactionReceipt).mockReset();
+  });
+
+  it('marks reverted recent transactions as failed', async () => {
+    vi.mocked(waitForTransactionReceipt).mockResolvedValue({
+      status: 'reverted',
+    } as Awaited<ReturnType<typeof waitForTransactionReceipt>>);
+
+    const store = createTransactionStore({
+      provider: { uid: 'app-client' } as PublicClient,
+    });
+
+    store.addTransaction(account, 1, {
+      description: 'Mint NFT',
+      hash,
+    });
+    await vi.waitFor(() => {
+      expect(store.getTransactions(account, 1)[0]?.status).toBe('failed');
+    });
+  });
+
+  it('marks rejected recent transaction waits as failed', async () => {
+    vi.mocked(waitForTransactionReceipt).mockRejectedValue(
+      new Error('Transaction not found'),
+    );
+
+    const store = createTransactionStore({
+      provider: { uid: 'app-client' } as PublicClient,
+    });
+
+    store.addTransaction(account, 1, {
+      description: 'Mint NFT',
+      hash,
+    });
+    await vi.waitFor(() => {
+      expect(store.getTransactions(account, 1)[0]?.status).toBe('failed');
+    });
+  });
+});

--- a/packages/rainbowkit/src/transactions/transactionStore.ts
+++ b/packages/rainbowkit/src/transactions/transactionStore.ts
@@ -1,4 +1,6 @@
 import type { Address, PublicClient, TransactionReceipt } from 'viem';
+import { waitForTransactionReceipt } from 'viem/actions';
+import { getTransactionProvider } from './getTransactionProvider';
 
 const storageKey = 'rk-transactions';
 
@@ -65,7 +67,7 @@ export function createTransactionStore({
 }) {
   let data: Data = loadData();
 
-  let provider = initialProvider;
+  let transactionProvider: PublicClient;
   const listeners: Set<() => void> = new Set();
   const transactionListeners: Set<
     (txStatus: TransactionReceipt['status']) => void
@@ -73,8 +75,10 @@ export function createTransactionStore({
   const transactionRequestCache: Map<string, Promise<void>> = new Map();
 
   function setProvider(newProvider: PublicClient): void {
-    provider = newProvider;
+    transactionProvider = getTransactionProvider(newProvider);
   }
+
+  setProvider(initialProvider);
 
   function getTransactions(account: string, chainId: number): Transaction[] {
     return data[account]?.[chainId] ?? [];
@@ -136,12 +140,14 @@ export function createTransactionStore({
             return await existingRequest;
           }
 
-          const requestPromise = provider
-            .waitForTransactionReceipt({
+          const requestPromise = waitForTransactionReceipt(
+            transactionProvider,
+            {
               confirmations,
               hash: hash as Address,
               timeout: 300_000, // 5 minutes
-            })
+            },
+          )
             .then(({ status }) => {
               transactionRequestCache.delete(hash);
 
@@ -160,6 +166,7 @@ export function createTransactionStore({
               notifyTransactionListeners(status);
             })
             .catch(() => {
+              transactionRequestCache.delete(hash);
               // If a transaction is not found or cancelled
               // viem will throw a 'TransactionNotFoundError'.
               // In this case it should mark the transaction as 'failed'


### PR DESCRIPTION
## Summary
- isolate RainbowKit recent-transaction receipt tracking from app-level receipt waits for the same hash
- add regression coverage for the dedicated viem watcher and reverted transaction status
- add a patch changeset

## Root Cause
viem dedupes receipt watchers by client UID and transaction hash. RainbowKit was using the app public client directly for its internal recent-transaction watcher, so adding a recent transaction with the same hash as an app `useWaitForTransactionReceipt` call could attach both waits to the same viem observer. For reverted receipts, wagmi performs extra handling that can throw, while RainbowKit only needs to mark the recent transaction as failed. Sharing that observer could leave the app hook stuck waiting.

## Fix
RainbowKit now forks the public client UID only for its internal recent-transaction watcher. It keeps the same transport/actions, but viem sees a separate observer key, so app-level waits and RainbowKit UI tracking settle independently.

Fixes #2624

## Validation
- `pnpm test:unit run packages/rainbowkit/src/transactions/transactionStore.test.ts`
- `pnpm test:unit run`
- `pnpm --filter @rainbow-me/rainbowkit typecheck`
- `pnpm format:check`
- `pnpm --filter @rainbow-me/rainbowkit build`

Note: `pnpm lint` still fails in `site/pages/_document.tsx` on existing Next `Head`/`NextScript` JSX type errors, after the RainbowKit package typecheck passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction receipt waiting and status handling; a mistake could cause recent-transaction UI to misreport status or miss updates, though the change is scoped and covered by new unit tests.
> 
> **Overview**
> Fixes recent-transaction tracking so RainbowKit’s internal `waitForTransactionReceipt` calls don’t share viem watcher state with app-level waits for the same hash.
> 
> Introduces `getTransactionProvider` to clone the app `PublicClient` with a stable `uid` suffix, updates `transactionStore` to use this dedicated client, and ensures failed/rejected waits clear the per-hash cache. Adds unit tests covering watcher isolation and marking reverted/rejected receipts as `failed`, plus a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e58de90ceddb24ca0bcec77ca69d4190b95c660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->