### PR TITLE
fix: for broken SIWE docs link

### DIFF
--- a/site/data/en-US/docs/custom-authentication.mdx
+++ b/site/data/en-US/docs/custom-authentication.mdx
@@ -55,7 +55,7 @@ const authenticationAdapter = createAuthenticationAdapter({
 
 #### Server-side message creation
 
-`createMessage` also supports returning a `Promise`, allowing you to construct [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) messages on the server. For stricter security, the server endpoint should derive or validate security-critical fields like `domain`, `nonce`, and `issued-at` timestamps instead of trusting client-provided values. See [SIWE documentation](https://docs.siwe.xyz/quickstart/creating-messages#server-side-message-creation) for more details.
+`createMessage` also supports returning a `Promise`, allowing you to construct [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) messages on the server. For stricter security, the server endpoint should derive or validate security-critical fields like `domain`, `nonce`, and `issued-at` timestamps instead of trusting client-provided values. See [SIWE documentation](https://docs.siwe.xyz/security-considerations#server-side-message-generation) for more details.
 
 ```tsx
   createMessage: async ({ address, chainId }) => {


### PR DESCRIPTION
While reviewing #2633, there was an update on SIWE docs, introducing broken reference in our side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates an external SIWE reference URL; no runtime behavior is affected.
> 
> **Overview**
> Fixes a broken SIWE docs reference in `custom-authentication.mdx` by updating the server-side message creation link to the current *security considerations* section URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac35f7db0fd9dd8e004ffd2e64790ab0f1ffd6dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->