### PR TITLE
fix: transpile rainbowkit + wagmi in example app for Next 16 SSG

### DIFF
--- a/packages/example/next.config.js
+++ b/packages/example/next.config.js
@@ -1,3 +1,5 @@
+const path = require('node:path');
+
 /** @type {import('next').NextConfig} */
 module.exports = {
   transpilePackages: [
@@ -9,6 +11,20 @@ module.exports = {
     '@wagmi/connectors',
   ],
   reactStrictMode: true,
+  // Force a single resolution for wagmi packages so rainbowkit's bundled
+  // `'use client'` chunks and the page's direct wagmi imports share one
+  // `WagmiContext` identity across SSG worker bundles.
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      wagmi: path.dirname(require.resolve('wagmi/package.json')),
+      '@wagmi/core': path.dirname(require.resolve('@wagmi/core/package.json')),
+      '@wagmi/connectors': path.dirname(
+        require.resolve('@wagmi/connectors/package.json'),
+      ),
+    };
+    return config;
+  },
   i18n: {
     defaultLocale: 'en-US',
     locales: [

--- a/packages/example/next.config.js
+++ b/packages/example/next.config.js
@@ -1,6 +1,13 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
-  transpilePackages: ['next-auth'],
+  transpilePackages: [
+    'next-auth',
+    '@rainbow-me/rainbowkit',
+    '@rainbow-me/rainbow-button',
+    'wagmi',
+    '@wagmi/core',
+    '@wagmi/connectors',
+  ],
   reactStrictMode: true,
   i18n: {
     defaultLocale: 'en-US',

--- a/packages/example/src/pages/index.tsx
+++ b/packages/example/src/pages/index.tsx
@@ -7,7 +7,6 @@ import {
   useConnectModal,
   WalletButton,
 } from '@rainbow-me/rainbowkit';
-import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import { useSession } from 'next-auth/react';
 import { type ComponentProps, useEffect, useState } from 'react';
@@ -568,7 +567,4 @@ function ManageTransactions() {
   );
 }
 
-// Skip SSG for the demo page. It exercises the full wagmi hook surface and
-// hits `WagmiProviderNotFoundError` under Next 16 parallel SSG; this is a
-// dev demo, not user-facing routing, so prerendering offers no benefit.
-export default dynamic(() => Promise.resolve(Example), { ssr: false });
+export default Example;

--- a/packages/example/src/pages/index.tsx
+++ b/packages/example/src/pages/index.tsx
@@ -7,6 +7,7 @@ import {
   useConnectModal,
   WalletButton,
 } from '@rainbow-me/rainbowkit';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import { useSession } from 'next-auth/react';
 import { type ComponentProps, useEffect, useState } from 'react';
@@ -567,4 +568,7 @@ function ManageTransactions() {
   );
 }
 
-export default Example;
+// Skip SSG for the demo page. It exercises the full wagmi hook surface and
+// hits `WagmiProviderNotFoundError` under Next 16 parallel SSG; this is a
+// dev demo, not user-facing routing, so prerendering offers no benefit.
+export default dynamic(() => Promise.resolve(Example), { ssr: false });


### PR DESCRIPTION
## Summary

Fixes the `WagmiProviderNotFoundError` thrown during Vercel SSG of `packages/example` after the Next 16 / wagmi 2.19.3 upgrade in #2669.

## Root cause

Bundler-level duplication of wagmi's `'use client'` context module under Next 16's parallel SSG (3 workers, Node 24).

- rainbowkit's `build.js` stamps every emitted chunk with `'use client'` and externalizes wagmi, so `packages/rainbowkit/dist/index.js` is a client module that imports from `wagmi`.
- `_app.tsx` imports `WagmiProvider` from `wagmi`, and `pages/index.tsx` independently imports `useAccount`, `useSendTransaction`, etc. directly from `wagmi`.
- The page bundle and rainbowkit's externalized dist resolve wagmi through different bundling contexts, so Next compiles `wagmi/dist/.../context.js` twice in the same SSG worker. Two `createContext()` calls produce two distinct `WagmiContext` identities. `<WagmiProvider>` writes identity A; rainbowkit's internal `useConfig` reads identity B.

The bug is concurrency-sensitive — latent on local single-worker Node 22 builds, surfaces on Vercel's parallel Node 24 SSG. Same class as wevm/wagmi#2707, #4583, #1466.

## Why `transpilePackages` alone isn't enough

#2669 fixed the same error in the docs site by adding `transpilePackages` for `@rainbow-me/rainbowkit`, `wagmi`, `@wagmi/core`, `@wagmi/connectors`. Mirroring that in `packages/example` fixed `/hi-IN/404` but not `/`, because the index page imports the full wagmi hook surface alongside rainbowkit's components — that dual import pattern reintroduces a second wagmi resolution path `transpilePackages` doesn't dedupe across SSG workers.

`pnpm why wagmi` confirms only one installed instance (`wagmi@2.19.3`, `@wagmi/core@2.22.1`). The duplication is at the bundler chunk-graph layer, not the package-resolution layer.

## Fix

1. Add `transpilePackages` for rainbowkit, rainbow-button, wagmi, @wagmi/core, @wagmi/connectors.
2. Add a webpack `resolve.alias` pinning wagmi / @wagmi/core / @wagmi/connectors to a single absolute path, so every Next bundling pass — server and client, page and externalized dist — resolves wagmi through one module instance and `createContext` evaluates exactly once per SSG worker.

Also adds Node 24 + corepack local-setup notes to `CLAUDE.md` so the husky `pnpm lint` pre-commit hook works on a fresh checkout.