### PR TITLE
fix: enable scrolling for wallet list in mobile landscape mode

### DIFF
--- a/packages/rainbowkit/src/components/Dialog/Dialog.css.ts
+++ b/packages/rainbowkit/src/components/Dialog/Dialog.css.ts
@@ -45,6 +45,8 @@ export const content = style([
   }),
   {
     animation: `${slideUp} 350ms cubic-bezier(.15,1.15,0.6,1.00), ${fadeIn} 150ms ease`,
+    maxHeight: '100dvh',
     maxWidth: '100vw',
+    overflowY: 'auto',
   },
 ]);


### PR DESCRIPTION
When the connect modal is taller than the viewport — common in mobile landscape or with browser zoom — the wallet icons at the bottom get clipped with no way to reach them. This adds `max-height: 100dvh` and `overflow-y: auto` to the dialog content wrapper so the modal scrolls within the viewport bounds.

Fixes #2167