### PR TITLE
fix: pin transitive qr to 0.5.5 to avoid border=0 crash

### DIFF
--- a/.changeset/fix-qr-border-2677.md
+++ b/.changeset/fix-qr-border-2677.md
@@ -2,4 +2,4 @@
 "@rainbow-me/rainbowkit": patch
 ---
 
-Pin transitive `qr` to `0.5.5` to avoid the `border=0` crash introduced in [qr@0.6.0](https://github.com/paulmillr/qr/releases/tag/0.6.0). Temporary workaround until [cuer#11](https://github.com/wevm/cuer/pull/11) is merged and released. Fixes #2677.
+Pin transitive `qr` to `0.4.2` to avoid the `border=0` crash introduced in [qr@0.6.0](https://github.com/paulmillr/qr/releases/tag/0.6.0). `0.4.2` is the version cuer was originally tested against and declares no `engines.node` constraint, preserving RainbowKit's existing Node support. Temporary workaround until [cuer#11](https://github.com/wevm/cuer/pull/11) is merged and released. Fixes #2677.

--- a/.changeset/fix-qr-border-2677.md
+++ b/.changeset/fix-qr-border-2677.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Pin transitive `qr` to `0.5.5` to avoid the `border=0` crash introduced in [qr@0.6.0](https://github.com/paulmillr/qr/releases/tag/0.6.0). Temporary workaround until [cuer#11](https://github.com/wevm/cuer/pull/11) is merged and released. Fixes #2677.

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
       "esbuild"
     ],
     "overrides": {
-      "@remix-run/dev>esbuild": "0.25.5"
+      "@remix-run/dev>esbuild": "0.25.5",
+      "qr": "0.5.5"
     }
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     ],
     "overrides": {
       "@remix-run/dev>esbuild": "0.25.5",
-      "qr": "0.5.5"
+      "qr": "0.4.2"
     }
   },
   "engines": {

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -72,6 +72,7 @@
     "@vanilla-extract/sprinkles": "1.6.5",
     "clsx": "2.1.1",
     "cuer": "0.0.3",
+    "qr": "0.5.5",
     "react-remove-scroll": "2.7.2",
     "ua-parser-js": "^2.0.9"
   },

--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -72,7 +72,7 @@
     "@vanilla-extract/sprinkles": "1.6.5",
     "clsx": "2.1.1",
     "cuer": "0.0.3",
-    "qr": "0.5.5",
+    "qr": "0.4.2",
     "react-remove-scroll": "2.7.2",
     "ua-parser-js": "^2.0.9"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   react-dom: ^19.2.5
   elliptic: 6.6.1
   '@remix-run/dev>esbuild': 0.25.5
-  qr: 0.5.5
+  qr: 0.4.2
 
 pnpmfileChecksum: sha256-ROa84Qg+MkpzIsPst6Z16qq0lhN6UZ8989JrwPM2pZU=
 
@@ -471,8 +471,8 @@ importers:
         specifier: 0.0.3
         version: 0.0.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       qr:
-        specifier: 0.5.5
-        version: 0.5.5
+        specifier: 0.4.2
+        version: 0.4.2
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
@@ -11115,9 +11115,8 @@ packages:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
 
-  qr@0.5.5:
-    resolution: {integrity: sha512-iQBvKj7MRKO+co+MY0IZpyLO+ezvttxsmV86WywrgPuAmgBkv0pytyi03wourniSoPgzffeBW6cBgIkpqcvjTg==}
-    engines: {node: '>= 20.19.0'}
+  qr@0.4.2:
+    resolution: {integrity: sha512-wCv4rt7IcPNGT0J8JiTBHx7YrZzYuzpof38y/MFYd5Sp7OTyAFYL1e110In8PrAG/ffIOVl1ha3joJ2zpYxKMQ==}
 
   qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
@@ -21061,7 +21060,7 @@ snapshots:
 
   cuer@0.0.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
     dependencies:
-      qr: 0.5.5
+      qr: 0.4.2
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -26386,7 +26385,7 @@ snapshots:
 
   q@1.5.1: {}
 
-  qr@0.5.5: {}
+  qr@0.4.2: {}
 
   qrcode@1.5.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   react-dom: ^19.2.5
   elliptic: 6.6.1
   '@remix-run/dev>esbuild': 0.25.5
+  qr: 0.5.5
 
 pnpmfileChecksum: sha256-ROa84Qg+MkpzIsPst6Z16qq0lhN6UZ8989JrwPM2pZU=
 
@@ -469,6 +470,9 @@ importers:
       cuer:
         specifier: 0.0.3
         version: 0.0.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+      qr:
+        specifier: 0.5.5
+        version: 0.5.5
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
@@ -11111,8 +11115,9 @@ packages:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
 
-  qr@0.4.2:
-    resolution: {integrity: sha512-wCv4rt7IcPNGT0J8JiTBHx7YrZzYuzpof38y/MFYd5Sp7OTyAFYL1e110In8PrAG/ffIOVl1ha3joJ2zpYxKMQ==}
+  qr@0.5.5:
+    resolution: {integrity: sha512-iQBvKj7MRKO+co+MY0IZpyLO+ezvttxsmV86WywrgPuAmgBkv0pytyi03wourniSoPgzffeBW6cBgIkpqcvjTg==}
+    engines: {node: '>= 20.19.0'}
 
   qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
@@ -21056,7 +21061,7 @@ snapshots:
 
   cuer@0.0.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
     dependencies:
-      qr: 0.4.2
+      qr: 0.5.5
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -26381,7 +26386,7 @@ snapshots:
 
   q@1.5.1: {}
 
-  qr@0.4.2: {}
+  qr@0.5.5: {}
 
   qrcode@1.5.3:
     dependencies:


### PR DESCRIPTION
Fixes #2677.

`qr@0.6.0` rejects `border=0`, which crashes cuer's QR renderer. Pins `qr` to `0.4.2` via direct dep + pnpm override.

Temporary workaround until [cuer#11](https://github.com/wevm/cuer/pull/11) is merged and released.