### PR TITLE
fix: give account modal an accessible name

### DIFF
--- a/.changeset/account-modal-accessible-name.md
+++ b/.changeset/account-modal-accessible-name.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fixed the account modal dialog having no accessible name. `aria-labelledby` now points at the profile heading that actually renders, and the heading id is no longer duplicated on the balance line.

--- a/packages/rainbowkit/src/components/AccountModal/AccountModal.tsx
+++ b/packages/rainbowkit/src/components/AccountModal/AccountModal.tsx
@@ -36,6 +36,7 @@ export function AccountModal({ onClose, open }: AccountModalProps) {
               balance={balance}
               onClose={onClose}
               onDisconnect={disconnect}
+              titleId={titleId}
             />
           </DialogContent>
         </Dialog>

--- a/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
+++ b/packages/rainbowkit/src/components/ProfileDetails/ProfileDetails.tsx
@@ -26,6 +26,7 @@ interface ProfileDetailsProps {
   balance: ReturnType<typeof useProfile>['balance'];
   onClose: () => void;
   onDisconnect: () => void;
+  titleId: string;
 }
 
 export function ProfileDetails({
@@ -35,6 +36,7 @@ export function ProfileDetails({
   balance,
   onClose,
   onDisconnect,
+  titleId,
 }: ProfileDetailsProps) {
   const showRecentTransactions = useContext(ShowRecentTransactionsContext);
   const { i18n } = useContext(I18nContext);
@@ -65,7 +67,6 @@ export function ProfileDetails({
   const displayBalance = ethBalance
     ? abbreviateETHBalance(Number.parseFloat(ethBalance))
     : undefined;
-  const titleId = 'rk_profile_title';
   const mobile = isMobile();
 
   return (
@@ -120,7 +121,6 @@ export function ProfileDetails({
                   <Text
                     as="h1"
                     color="modalTextSecondary"
-                    id={titleId}
                     size={mobile ? '16' : '14'}
                     weight="semibold"
                   >


### PR DESCRIPTION
## Summary

Fixes #2700.

The account modal dialog sets `aria-labelledby="rk_account_modal_title"`, but `ProfileDetails` hardcoded `id="rk_profile_title"` on its headings. The labelled-by id never resolved, so the dialog had no accessible name.

## Changes

- Pass `titleId` from `AccountModal` into `ProfileDetails` so the heading id matches the dialog, same pattern as `ChainModal` / the connect modal.
- Keep the id on the account-name heading only. The balance line was sharing the same id, which is invalid HTML and breaks `aria-labelledby` when a balance is shown.

## Test plan

- [ ] Open the example app, connect a wallet, click the connected account button.
- [ ] `document.getElementById('rk_account_modal_title')` returns the account-name heading while the modal is open.
- [ ] Dialog announces a name (account / ENS), not a nameless "dialog".
- [ ] Balance line still renders; it no longer duplicates the heading id.