### PR TITLE
fix: show mobile download link when wallet app may be missing

### DIFF
--- a/.changeset/mobile-missing-app-download.md
+++ b/.changeset/mobile-missing-app-download.md
@@ -1,0 +1,5 @@
+---
+"@rainbow-me/rainbowkit": patch
+---
+
+Fix mobile connecting status missing a download link when the wallet app may not be installed.

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileStatus.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileStatus.tsx
@@ -1,15 +1,18 @@
 import React, { useContext } from 'react';
 import { Box } from '../Box/Box';
+import { ActionButton } from '../Button/ActionButton';
 import { CloseButton } from '../CloseButton/CloseButton';
 import { I18nContext } from '../RainbowKitProvider/I18nContext';
 import { WalletButtonContext } from '../RainbowKitProvider/WalletButtonContext';
 import { Text } from '../Text/Text';
+import { getMobileDownloadUrl } from '../../wallets/downloadUrls';
 import { WalletButton } from './MobileOptions';
 
 export const MobileStatus = ({ onClose }: { onClose: () => void }) => {
   const { connector } = useContext(WalletButtonContext);
   const { i18n } = useContext(I18nContext);
   const connectorName = connector?.name || '';
+  const mobileDownloadUrl = getMobileDownloadUrl(connector ?? undefined);
 
   return (
     <Box>
@@ -46,13 +49,40 @@ export const MobileStatus = ({ onClose }: { onClose: () => void }) => {
           </Text>
         </Box>
 
-        <Box maxWidth="full" marginTop="8">
+        <Box maxWidth="full" marginTop="8" paddingX="24">
           <Text textAlign="center" color="modalText" size="16" weight="medium">
             {i18n.t('connect.status.confirm_mobile', {
               wallet: connectorName,
             })}
           </Text>
         </Box>
+
+        {mobileDownloadUrl ? (
+          <Box
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+            gap="12"
+            marginTop="24"
+            paddingX="24"
+          >
+            <Text
+              textAlign="center"
+              color="modalTextSecondary"
+              size="14"
+              weight="medium"
+            >
+              {i18n.t('connect.secondary_action.get.description', {
+                wallet: connectorName,
+              })}
+            </Text>
+            <ActionButton
+              href={mobileDownloadUrl}
+              label={i18n.t('connect.secondary_action.get.label')}
+              type="secondary"
+            />
+          </Box>
+        ) : null}
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary

On mobile, picking a wallet deep-links into the app (`rainbow://...`, etc.). If the app is not installed, the browser blocks or no-ops the custom scheme and the connecting screen only said "Continue in {wallet}" / "Accept connection request", with no install path. That is #2574.

Desktop already has install / GET secondary actions. This mirrors that on the mobile connecting status screen.

## Changes

- In `MobileStatus`, when the selected wallet has a mobile download URL, show the existing "Don't have {wallet}?" copy plus a GET button that opens the App Store / Play Store / mobile download link via `getMobileDownloadUrl`.

## Test plan

- [ ] Open Connect on a phone (or mobile UA) without the wallet installed, select Rainbow / MetaMask, confirm the GET link appears under the connecting copy
- [ ] Tap GET and land on the store / download URL
- [ ] Wallet with no `downloadUrls` still shows the previous connecting UI only

Fixes #2574